### PR TITLE
feat: Add Check 11 - CHANGELOG validation (shift-left from CI)

### DIFF
--- a/packages/dev-tools/src/pre-publish-check.ts
+++ b/packages/dev-tools/src/pre-publish-check.ts
@@ -12,6 +12,7 @@
  * 8. Workspace dependencies are correct
  * 9. All packages have proper "files" field
  * 10. All packages have required metadata (repository, author, license)
+ * 11. CHANGELOG.md has entry for current version (publish mode only)
  *
  * Usage:
  *   tsx tools/pre-publish-check.ts [--allow-branch BRANCH] [--skip-git-checks]
@@ -511,6 +512,63 @@ try {
   const message = error instanceof Error ? error.message : String(error);
   console.error(message);
   process.exit(1);
+}
+
+// Check 11: CHANGELOG.md has entry for current version (skip in development mode)
+if (skipGitChecks) {
+  log('⊘ CHANGELOG check skipped (development mode)', 'yellow');
+} else {
+  console.log('');
+  console.log('Checking CHANGELOG.md...');
+
+  try {
+    // Read version from umbrella package (monorepo canonical version)
+    const umbrellaPkgJsonPath = join(packagesDir, 'vibe-agent-toolkit', 'package.json');
+    if (!existsSync(umbrellaPkgJsonPath)) {
+      throw new Error('Umbrella package (vibe-agent-toolkit) package.json not found');
+    }
+
+    const umbrellaPkgJson = JSON.parse(readFileSync(umbrellaPkgJsonPath, 'utf8')) as Record<string, unknown>;
+    const version = umbrellaPkgJson['version'];
+    if (typeof version !== 'string') {
+      throw new TypeError('Version not found in umbrella package (vibe-agent-toolkit) package.json');
+    }
+
+    // Read CHANGELOG.md
+    const changelogPath = join(PROJECT_ROOT, 'CHANGELOG.md');
+    if (!existsSync(changelogPath)) {
+      log('✗ CHANGELOG.md not found', 'red');
+      console.log('  Create CHANGELOG.md to document releases');
+      process.exit(1);
+    }
+
+    const changelogContent = readFileSync(changelogPath, 'utf8');
+
+    // Look for version entry: ## [X.Y.Z] - YYYY-MM-DD or ## [X.Y.Z-rc.N] - YYYY-MM-DD
+    // Escape dots in version string for regex matching
+    const escapedVersion = version.replaceAll('.', String.raw`\.`);
+    // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
+    const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\] - \d{4}-\d{2}-\d{2}`, 'm');
+
+    if (!versionPattern.test(changelogContent)) {
+      log(`✗ CHANGELOG.md missing entry for version ${version}`, 'red');
+      console.log('');
+      console.log('  Recovery instructions:');
+      console.log(`  1. Add version entry to CHANGELOG.md:`);
+      console.log(`     ## [${version}] - ${new Date().toISOString().split('T')[0]}`);
+      console.log('  2. Document changes under the version header');
+      console.log('  3. Run pre-publish-check again');
+      console.log('');
+      process.exit(1);
+    }
+
+    log(`✓ CHANGELOG.md has entry for version ${version}`, 'green');
+  } catch (error) {
+    log('✗ Failed to check CHANGELOG.md', 'red');
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(message);
+    process.exit(1);
+  }
 }
 
 // Success!


### PR DESCRIPTION
# Shift-Left CHANGELOG Validation to vibe-agent-toolkit

Returns the favor! vibe-validate learned this improvement from vibe-agent-toolkit's pre-publish checks, found an issue (CHANGELOG validation only in CI), and now returns the improvement.

## Problem

Same issue vibe-validate hit in v0.18.4:
- ✅ npm publish succeeds
- ❌ GitHub Release creation fails (missing CHANGELOG entry)
- Result: Packages published but undocumented

## Solution

**Added Check 11: CHANGELOG.md Version Validation**
- Validates CHANGELOG has entry for current version
- Prevents npm publish → GitHub Release failure
- Shift-left from CI to local pre-publish check

**Two-Mode Support:**
- Development mode (`--skip-git-checks`): Skips CHANGELOG check ✓
- Publish mode: Enforces CHANGELOG check ✓

**Uses Umbrella Package:**
- Reads version from `packages/vibe-agent-toolkit/package.json`
- Semantically correct: umbrella represents entire monorepo
- Consistent with package-lists.ts marking

## Testing

✅ **Positive Test:** With CHANGELOG entry (v0.1.2)
```
✓ CHANGELOG.md has entry for version 0.1.2
✅ Repository is ready to publish!
```

✅ **Development Mode:** With --skip-git-checks
```
⊘ CHANGELOG check skipped (development mode)
```

✅ **Work Recovery:** Successfully recovered from vibe-validate snapshot after accidental git reset

## Impact

- Prevents partial releases (npm published but no GitHub Release)
- Catches missing CHANGELOG entries before tag creation
- Compatible with existing validation workflow

## Cross-Pollination

- vibe-validate → vibe-agent-toolkit: Pre-publish check pattern ✅
- vibe-agent-toolkit → vibe-validate: Check 11 CHANGELOG validation ✅
- Two-way learning between sibling repos

🤖 Generated with [Claude Code](https://claude.ai/code)