### PR TITLE
feat(rag): add OnnxEmbeddingProvider and make embedding deps optional

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "eslint-plugin-unicorn": "^62.0.0",
         "husky": "^9.1.7",
         "jscpd": "^4.0.5",
+        "onnxruntime-node": "^1.24.1",
         "rimraf": "^6.0.1",
         "secretlint": "^11.2.5",
         "semver": "^7.7.3",
@@ -202,7 +203,6 @@
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
-        "@xenova/transformers": "^2.17.0",
         "gpt-tokenizer": "^2.6.0",
         "zod": "^3.22.0",
         "zod-to-json-schema": "^3.22.0",
@@ -213,6 +213,8 @@
         "vitest": "^3.2.0",
       },
       "optionalDependencies": {
+        "@xenova/transformers": "^2.17.0",
+        "onnxruntime-node": "^1.24.0",
         "openai": "^6.16.0",
       },
     },
@@ -1078,6 +1080,8 @@
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
     "boundary": ["boundary@2.0.0", "", {}, "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -1208,6 +1212,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff-sequences": ["diff-sequences@29.6.3", "", {}, "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q=="],
@@ -1263,6 +1269,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
@@ -1423,6 +1431,8 @@
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
     "global-prefix": ["global-prefix@4.0.0", "", { "dependencies": { "ini": "^4.1.3", "kind-of": "^6.0.3", "which": "^4.0.0" } }, "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA=="],
 
@@ -1626,6 +1636,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
 
     "jsonfile": ["jsonfile@6.2.0", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg=="],
@@ -1685,6 +1697,8 @@
     "markdown-table": ["markdown-table@2.0.0", "", { "dependencies": { "repeat-string": "^1.0.0" } }, "sha512-Ezda85ToJUBhM6WGaG6veasyym+Tbs3cMAw/ZhOPqXiYsr0jgocBV3j3nx+4lk47plLlIqjwuTm/ywVI+zjJ/A=="],
 
     "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -1854,9 +1868,9 @@
 
     "onnx-proto": ["onnx-proto@4.0.4", "", { "dependencies": { "protobufjs": "^6.8.8" } }, "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA=="],
 
-    "onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="],
+    "onnxruntime-common": ["onnxruntime-common@1.24.1", "", {}, "sha512-UnV15u4p4XxoIV+jFP4hXPsW93s3QrwLSpi20HUDYHoTfI4z4sjzex3L4XDOxGGZJ/M/catrwAG2go958UQq0w=="],
 
-    "onnxruntime-node": ["onnxruntime-node@1.14.0", "", { "dependencies": { "onnxruntime-common": "~1.14.0" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w=="],
+    "onnxruntime-node": ["onnxruntime-node@1.24.1", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-Ex/oUXKdhDoxvlNxBT3oYtW0MH88yYpPlXQeVQUXpcJQmN24usd/8RCoPLN5kCHwDsiZ+nqsnjciyFRl423dQw=="],
 
     "onnxruntime-web": ["onnxruntime-web@1.14.0", "", { "dependencies": { "flatbuffers": "^1.12.0", "guid-typescript": "^1.0.9", "long": "^4.0.0", "onnx-proto": "^4.0.4", "onnxruntime-common": "~1.14.0", "platform": "^1.3.6" } }, "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw=="],
 
@@ -2038,6 +2052,8 @@
 
     "rimraf": ["rimraf@6.1.2", "", { "dependencies": { "glob": "^13.0.0", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
@@ -2064,7 +2080,11 @@
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -2124,7 +2144,7 @@
 
     "spdx-license-ids": ["spdx-license-ids@3.0.22", "", {}, "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -2490,6 +2510,8 @@
 
     "@vitest/runner/strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
 
+    "@xenova/transformers/onnxruntime-node": ["onnxruntime-node@1.14.0", "", { "dependencies": { "onnxruntime-common": "~1.14.0" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "apache-arrow/@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
@@ -2580,6 +2602,8 @@
 
     "onnxruntime-web/flatbuffers": ["flatbuffers@1.12.0", "", {}, "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="],
 
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="],
+
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -2599,6 +2623,8 @@
     "readdirp/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "rimraf/glob": ["glob@13.0.1", "", { "dependencies": { "minimatch": "^10.1.2", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-B7U/vJpE3DkJ5WXTgTpTRN63uV42DseiXXKMwG14LQBXmsdeIoHAPbU/MEo6II0k5ED74uc2ZGTC6MwHFQhF6w=="],
+
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2956,6 +2982,8 @@
 
     "@vitest/runner/strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
+    "@xenova/transformers/onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.14.0", "", {}, "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew=="],
+
     "apache-arrow/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "blamer/execa/get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -3081,6 +3109,8 @@
     "@vibe-agent-toolkit/vat-example-cat-agents/vitest/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "blamer/execa/onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "gray-matter/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Welcome to the Vibe Agent Toolkit documentation.
 - **[Collection Validation](./guides/collection-validation.md)** - Per-collection frontmatter validation with JSON Schemas
 - **[Writing Tests](./writing-tests.md)** - Test conventions, helpers, and duplication avoidance
 - **[RAG Usage Guide](./guides/rag-usage-guide.md)** - Using the RAG package for semantic search
+- **[Embedding Providers](./embedding-providers.md)** - How embedding providers work and creating custom providers
 
 ## Configuration
 

--- a/docs/embedding-providers.md
+++ b/docs/embedding-providers.md
@@ -1,0 +1,631 @@
+# Embedding Providers
+
+Embedding providers convert text into vector embeddings for semantic search in RAG (Retrieval-Augmented Generation) systems. They're the critical component that enables your agent to find relevant context based on meaning, not just keyword matching.
+
+## Overview
+
+**What are embeddings?**
+
+Embeddings are numerical vectors that capture the semantic meaning of text. Similar text produces similar vectors, enabling semantic search.
+
+**How they fit into RAG:**
+
+```
+User Query → Embedding Provider → Query Vector
+                                      ↓
+                              Vector Database Search
+                                      ↓
+                              Top-K Similar Chunks → LLM Context
+```
+
+The RAG package provides:
+- `EmbeddingProvider` interface - Standard contract for all providers
+- Built-in providers - Ready-to-use implementations
+- Easy provider swapping - Change providers without changing RAG code
+
+## The EmbeddingProvider Interface
+
+All embedding providers implement this interface:
+
+```typescript
+/**
+ * Embedding Provider
+ *
+ * Converts text to vector embeddings for semantic search.
+ */
+export interface EmbeddingProvider {
+  /** Provider name: "openai", "transformers-js", etc. */
+  name: string;
+
+  /** Model name: "text-embedding-3-small", "all-MiniLM-L6-v2", etc. */
+  model: string;
+
+  /** Embedding vector dimensions */
+  dimensions: number;
+
+  /**
+   * Embed a single text chunk
+   *
+   * @param text - Text to embed
+   * @returns Vector embedding
+   */
+  embed(text: string): Promise<number[]>;
+
+  /**
+   * Embed multiple text chunks efficiently
+   *
+   * @param texts - Array of texts to embed
+   * @returns Array of vector embeddings
+   */
+  embedBatch(texts: string[]): Promise<number[][]>;
+}
+```
+
+**Key methods:**
+
+- `embed(text)` - Convert single text to vector. Use for query embedding.
+- `embedBatch(texts)` - Convert multiple texts efficiently. Use for indexing documents.
+
+## Built-in Providers
+
+### Comparison Table
+
+| Provider | Speed | Quality | Cost | API Key | Dimensions | Hardware Accel | Install |
+|----------|-------|---------|------|---------|------------|----------------|---------|
+| **Transformers** | Fast | Good | Free | No | 384 | CPU/WASM | `npm install @xenova/transformers` |
+| **ONNX** | Very Fast | Good | Free | No | 384 | CoreML/CUDA/DirectML | `npm install onnxruntime-node` |
+| **OpenAI** | Medium | Excellent | $$ | Yes | 1536/3072 | N/A | `npm install openai` |
+
+**When to use each:**
+
+- **Transformers**: Prototyping, quick local development, privacy-sensitive data, no API budget
+- **ONNX**: Production local embeddings, hardware acceleration (GPU/Neural Engine), high throughput
+- **OpenAI**: Highest quality needed, budget available, network access OK
+
+### TransformersEmbeddingProvider
+
+**Local, free, WASM-powered embeddings.**
+
+```typescript
+import { TransformersEmbeddingProvider } from '@vibe-agent-toolkit/rag';
+
+// Install first: npm install @xenova/transformers
+
+const provider = new TransformersEmbeddingProvider({
+  model: 'Xenova/all-MiniLM-L6-v2',  // Default
+  dimensions: 384,                     // Default
+});
+
+// Single text
+const vector = await provider.embed('What is RAG?');
+console.log(vector.length); // 384
+
+// Batch (parallel processing)
+const vectors = await provider.embedBatch([
+  'Chunk 1 text',
+  'Chunk 2 text',
+  'Chunk 3 text',
+]);
+console.log(vectors.length); // 3
+```
+
+**Details:**
+- **Model**: `Xenova/all-MiniLM-L6-v2` (default) - 20MB download on first run
+- **Dimensions**: 384 (default)
+- **No API key required**
+- **Runs in Node.js via WASM** - No Python/GPU needed
+- **Good quality** - Sentence-transformers model, widely used
+- **Fast inference** - Quantized model
+- **Network**: Downloads model once, then fully offline
+
+### OnnxEmbeddingProvider
+
+**Local, hardware-accelerated embeddings via native ONNX Runtime.**
+
+```typescript
+import { OnnxEmbeddingProvider } from '@vibe-agent-toolkit/rag';
+
+// Install first: npm install onnxruntime-node
+
+// Auto-downloads model on first run, uses hardware acceleration
+const provider = new OnnxEmbeddingProvider({
+  model: 'sentence-transformers/all-MiniLM-L6-v2',  // Default
+  dimensions: 384,                                     // Default
+});
+
+// Single text
+const vector = await provider.embed('What is RAG?');
+console.log(vector.length); // 384
+
+// Batch (true batched ONNX inference - single model call)
+const vectors = await provider.embedBatch([
+  'Chunk 1 text',
+  'Chunk 2 text',
+  'Chunk 3 text',
+]);
+```
+
+**Details:**
+- **Model**: `sentence-transformers/all-MiniLM-L6-v2` (default) - ~90MB download on first run
+- **Dimensions**: 384 (default)
+- **No API key required**
+- **Native C++ ONNX Runtime** - Not WASM, significantly faster than Transformers provider
+- **Hardware acceleration**: Auto-detects available hardware:
+  - macOS Apple Silicon: CoreML (GPU + Neural Engine)
+  - Linux with NVIDIA: CUDA
+  - Windows: DirectML (any DirectX 12 GPU)
+  - All platforms: CPU fallback
+- **True batch inference** - Single model call for multiple texts (not Promise.all)
+- **Pure TypeScript tokenizer** - No additional native dependencies beyond onnxruntime-node
+- **Network**: Downloads model + vocab once to `~/.cache/vat-onnx-models/`, then fully offline
+
+**Custom configuration:**
+```typescript
+const provider = new OnnxEmbeddingProvider({
+  modelPath: '/path/to/pre-downloaded/model',  // Skip auto-download
+  executionProviders: ['coreml', 'cpu'],         // Explicit EP selection
+  maxSequenceLength: 512,                         // Override max tokens
+  cacheDir: '/custom/cache/dir',                  // Override cache location
+});
+```
+
+### OpenAIEmbeddingProvider
+
+**Cloud-based, state-of-the-art embeddings.**
+
+```typescript
+import { OpenAIEmbeddingProvider } from '@vibe-agent-toolkit/rag';
+
+// Install first: npm install openai
+
+const provider = new OpenAIEmbeddingProvider({
+  apiKey: process.env.OPENAI_API_KEY!,
+  model: 'text-embedding-3-small',   // Default (1536 dims)
+  // model: 'text-embedding-3-large', // Higher quality (3072 dims)
+  // dimensions: 512,                  // Custom (text-embedding-3-* only)
+});
+
+// Single text
+const vector = await provider.embed('What is RAG?');
+console.log(vector.length); // 1536
+
+// Batch (uses OpenAI batch API)
+const vectors = await provider.embedBatch([
+  'Chunk 1 text',
+  'Chunk 2 text',
+]);
+```
+
+**Available models:**
+- `text-embedding-3-small` - 1536 dims (default, best cost/quality)
+- `text-embedding-3-large` - 3072 dims (highest quality)
+- `text-embedding-ada-002` - 1536 dims (legacy)
+
+**Details:**
+- **API key required** - Get from https://platform.openai.com/api-keys
+- **Cost**: ~$0.0001/1K tokens (text-embedding-3-small)
+- **Network latency** - API call per batch
+- **Rate limits** - 3,000 RPM (tier 1), 5,000 RPM (tier 2+)
+- **Production-ready** - Widely tested, highly reliable
+
+## Installing Provider Dependencies
+
+**All embedding providers are optional dependencies.** Install only what you need:
+
+```bash
+# Transformers (local, WASM, free)
+npm install @xenova/transformers
+
+# ONNX (local, native, hardware-accelerated, free)
+npm install onnxruntime-node
+
+# OpenAI (cloud, API key required)
+npm install openai
+```
+
+**Error if not installed:**
+
+```typescript
+// Without 'openai' installed:
+const provider = new OpenAIEmbeddingProvider({ apiKey: 'sk-...' });
+// Error: OpenAI SDK not installed. Install with: bun add openai
+
+// Without '@xenova/transformers' installed:
+const provider = new TransformersEmbeddingProvider();
+await provider.embed('test');
+// Error: @xenova/transformers is not installed. Install with: npm install @xenova/transformers
+```
+
+## Creating a Custom Provider
+
+Need Ollama? Cohere? Voyage AI? Here's how to plug in any embedding service.
+
+### Step 1: Implement the Interface
+
+```typescript
+import type { EmbeddingProvider } from '@vibe-agent-toolkit/rag';
+
+export interface OllamaEmbeddingConfig {
+  baseUrl?: string;  // Default: http://localhost:11434
+  model?: string;    // Default: nomic-embed-text
+}
+
+export class OllamaEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'ollama';
+  readonly model: string;
+  readonly dimensions: number;
+
+  private readonly baseUrl: string;
+
+  constructor(config: OllamaEmbeddingConfig = {}) {
+    this.baseUrl = config.baseUrl ?? 'http://localhost:11434';
+    this.model = config.model ?? 'nomic-embed-text';
+    this.dimensions = 768; // nomic-embed-text dimensions
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const response = await fetch(`${this.baseUrl}/api/embeddings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        model: this.model,
+        prompt: text,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Ollama API error: ${response.statusText}`);
+    }
+
+    const data = await response.json() as { embedding: number[] };
+    return data.embedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    // Ollama doesn't have batch API, so process sequentially
+    const embeddings: number[][] = [];
+    for (const text of texts) {
+      embeddings.push(await this.embed(text));
+    }
+    return embeddings;
+  }
+}
+```
+
+### Step 2: Use with LanceDBRAGProvider
+
+```typescript
+import { LanceDBRAGProvider } from '@vibe-agent-toolkit/rag-lancedb';
+import { OllamaEmbeddingProvider } from './ollama-embedding-provider.js';
+
+// Create custom provider
+const embeddingProvider = new OllamaEmbeddingProvider({
+  baseUrl: 'http://localhost:11434',
+  model: 'nomic-embed-text',
+});
+
+// Pass to RAG provider
+const ragProvider = new LanceDBRAGProvider({
+  dbPath: './vector-db',
+  tableName: 'docs',
+  embeddingProvider,  // Use your custom provider
+});
+
+// Index documents
+await ragProvider.indexResources(resources);
+
+// Query works seamlessly
+const results = await ragProvider.query({
+  query: 'What is RAG?',
+  topK: 5,
+});
+```
+
+### Step 3: Add Batch Optimization (Optional)
+
+If your API supports batch embedding, optimize `embedBatch`:
+
+```typescript
+async embedBatch(texts: string[]): Promise<number[][]> {
+  if (texts.length === 0) return [];
+
+  // Example: Cohere batch API
+  const response = await fetch(`${this.baseUrl}/embed`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: this.model,
+      texts,  // Send all at once
+    }),
+  });
+
+  const data = await response.json() as { embeddings: number[][] };
+  return data.embeddings;
+}
+```
+
+### Complete Example: Cohere Provider
+
+```typescript
+import type { EmbeddingProvider } from '@vibe-agent-toolkit/rag';
+
+export interface CohereEmbeddingConfig {
+  apiKey: string;
+  model?: string;
+}
+
+export class CohereEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'cohere';
+  readonly model: string;
+  readonly dimensions: number;
+
+  private readonly apiKey: string;
+
+  constructor(config: CohereEmbeddingConfig) {
+    this.apiKey = config.apiKey;
+    this.model = config.model ?? 'embed-english-v3.0';
+    this.dimensions = 1024; // embed-english-v3.0 dimensions
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const response = await fetch('https://api.cohere.ai/v1/embed', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        texts: [text],
+        input_type: 'search_document',
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Cohere API error: ${response.statusText}`);
+    }
+
+    const data = await response.json() as { embeddings: number[][] };
+    const firstEmbedding = data.embeddings[0];
+    if (!firstEmbedding) {
+      throw new Error('Cohere returned no embeddings');
+    }
+    return firstEmbedding;
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const response = await fetch('https://api.cohere.ai/v1/embed', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        texts,
+        input_type: 'search_document',
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Cohere API error: ${response.statusText}`);
+    }
+
+    const data = await response.json() as { embeddings: number[][] };
+    return data.embeddings;
+  }
+}
+```
+
+**Usage:**
+
+```typescript
+import { CohereEmbeddingProvider } from './cohere-embedding-provider.js';
+
+const provider = new CohereEmbeddingProvider({
+  apiKey: process.env.COHERE_API_KEY!,
+  model: 'embed-english-v3.0',
+});
+
+const results = await ragProvider.query({
+  query: 'What is RAG?',
+  topK: 5,
+});
+```
+
+## Provider Selection Guide
+
+### Decision Tree
+
+```
+Need embeddings?
+├─ Quick prototyping / Simplest setup?
+│  └─ Use TransformersEmbeddingProvider (WASM, no native deps)
+│
+├─ Local embeddings / High throughput / Hardware acceleration?
+│  └─ Use OnnxEmbeddingProvider (native C++, GPU/Neural Engine)
+│
+├─ Production cloud / Highest quality?
+│  ├─ Need best accuracy?
+│  │  └─ Use OpenAIEmbeddingProvider with text-embedding-3-large (3072 dims)
+│  └─ Cost-conscious?
+│     └─ Use OpenAIEmbeddingProvider with text-embedding-3-small (1536 dims)
+│
+└─ Need specific provider (Cohere, Voyage, Ollama)?
+   └─ Create custom provider (see examples above)
+```
+
+### Quality vs Cost Trade-offs
+
+**Quality (best to good):**
+1. OpenAI text-embedding-3-large (3072 dims) - Highest quality
+2. OpenAI text-embedding-3-small (1536 dims) - Excellent quality
+3. ONNX / Transformers all-MiniLM-L6-v2 (384 dims) - Good quality (same model, different runtime)
+
+**Speed (fastest to slowest):**
+1. ONNX - Native C++ with hardware acceleration (CoreML/CUDA/DirectML)
+2. Transformers - WASM single-threaded
+3. OpenAI - Network round-trip per batch
+
+**Cost (cheapest to most expensive):**
+1. ONNX / Transformers - Free (compute cost only)
+2. OpenAI text-embedding-3-small - ~$0.0001/1K tokens
+3. OpenAI text-embedding-3-large - ~$0.0003/1K tokens
+
+### Dimension Considerations
+
+**More dimensions = better semantic understanding, but:**
+- Larger storage requirements
+- Slower search (marginal)
+- Higher API costs (for cloud providers)
+
+**Recommendations:**
+- **384 dims** (Transformers) - Sufficient for most use cases
+- **1536 dims** (OpenAI small) - Better for complex domains (legal, medical, technical)
+- **3072 dims** (OpenAI large) - Highest accuracy needed (enterprise search, research)
+
+### Mixing Providers (Don't Do This)
+
+**CRITICAL**: Never mix embedding providers for the same vector database table.
+
+```typescript
+// WRONG - Different providers for indexing vs querying
+const indexProvider = new TransformersEmbeddingProvider(); // 384 dims
+await ragProvider.indexResources(resources);
+
+const queryProvider = new OpenAIEmbeddingProvider({ apiKey }); // 1536 dims
+await ragProvider.query({ query: 'test' }); // Won't work - dimension mismatch
+```
+
+**Why?** Vector databases require consistent dimensions. Once you index with a provider, you must use the same provider (and model) for queries.
+
+**Solution:** Pick one provider and stick with it. To switch providers, re-index all documents.
+
+## Advanced Patterns
+
+### Lazy Initialization
+
+Defer model loading until first use:
+
+```typescript
+export class LazyEmbeddingProvider implements EmbeddingProvider {
+  private pipelinePromise: Promise<Pipeline> | null = null;
+
+  private async getPipeline(): Promise<Pipeline> {
+    // Load only once, cache for future calls
+    this.pipelinePromise ??= this.loadPipeline();
+    return this.pipelinePromise;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const pipeline = await this.getPipeline();
+    return pipeline.embed(text);
+  }
+}
+```
+
+### Error Handling
+
+Handle API failures gracefully:
+
+```typescript
+async embed(text: string): Promise<number[]> {
+  try {
+    const response = await fetch(this.apiUrl, { /* ... */ });
+    if (!response.ok) {
+      throw new Error(`API error: ${response.status} ${response.statusText}`);
+    }
+    return await this.parseResponse(response);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('ECONNREFUSED')) {
+      throw new Error(`Cannot connect to embedding service at ${this.apiUrl}. Is it running?`);
+    }
+    throw error;
+  }
+}
+```
+
+### Rate Limiting
+
+Add rate limiting for cloud APIs:
+
+```typescript
+import pLimit from 'p-limit';
+
+export class RateLimitedProvider implements EmbeddingProvider {
+  private limiter = pLimit(10); // Max 10 concurrent requests
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    const tasks = texts.map(text =>
+      this.limiter(() => this.embed(text))
+    );
+    return Promise.all(tasks);
+  }
+}
+```
+
+## Troubleshooting
+
+### "Module not installed" errors
+
+**Problem:**
+```
+Error: OpenAI SDK not installed. Install with: bun add openai
+```
+
+**Solution:**
+```bash
+npm install openai
+# or
+bun add openai
+```
+
+### Dimension mismatch errors
+
+**Problem:**
+```
+Error: Vector dimension mismatch. Expected 384, got 1536.
+```
+
+**Solution:** You switched providers after indexing. Either:
+1. Re-index with new provider: `await ragProvider.clearAndReindex(resources)`
+2. Switch back to original provider
+
+### API key errors
+
+**Problem:**
+```
+Error: Invalid API key
+```
+
+**Solution:**
+```typescript
+// Check API key is set
+console.log(process.env.OPENAI_API_KEY ? 'Set' : 'Missing');
+
+// Load from .env file
+import 'dotenv/config';
+const provider = new OpenAIEmbeddingProvider({
+  apiKey: process.env.OPENAI_API_KEY!,
+});
+```
+
+### Model download hangs (Transformers)
+
+**Problem:** First run hangs downloading model.
+
+**Solution:**
+- **Check network** - Model downloads from Hugging Face
+- **Wait** - all-MiniLM-L6-v2 is ~20MB, takes 30-60s on slow connections
+- **Use cache** - Models cache to `~/.cache/huggingface/`, subsequent runs are instant
+
+## Related Documentation
+
+- [RAG Usage Guide](./guides/rag-usage-guide.md) - Using RAG providers with embedding providers
+- [Resources Package](../packages/resources/README.md) - Parsing markdown for RAG indexing
+- [LanceDB RAG Provider](../packages/rag-lancedb/README.md) - Vector database implementation

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-unicorn": "^62.0.0",
     "husky": "^9.1.7",
     "jscpd": "^4.0.5",
+    "onnxruntime-node": "^1.24.1",
     "rimraf": "^6.0.1",
     "secretlint": "^11.2.5",
     "semver": "^7.7.3",

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "@vibe-agent-toolkit/resources": "workspace:*",
     "@vibe-agent-toolkit/utils": "workspace:*",
-    "@xenova/transformers": "^2.17.0",
     "gpt-tokenizer": "^2.6.0",
     "zod": "^3.22.0",
     "zod-to-json-schema": "^3.22.0"
@@ -44,7 +43,9 @@
     "vitest": "^3.2.0"
   },
   "optionalDependencies": {
-    "openai": "^6.16.0"
+    "@xenova/transformers": "^2.17.0",
+    "openai": "^6.16.0",
+    "onnxruntime-node": "^1.24.0"
   },
   "repository": {
     "type": "git",

--- a/packages/rag/src/embedding-providers/index.ts
+++ b/packages/rag/src/embedding-providers/index.ts
@@ -13,3 +13,8 @@ export {
   OpenAIEmbeddingProvider,
   type OpenAIEmbeddingConfig,
 } from './openai-embedding-provider.js';
+
+export {
+  OnnxEmbeddingProvider,
+  type OnnxEmbeddingConfig,
+} from './onnx-embedding-provider.js';

--- a/packages/rag/src/embedding-providers/onnx-embedding-provider.ts
+++ b/packages/rag/src/embedding-providers/onnx-embedding-provider.ts
@@ -1,0 +1,289 @@
+/**
+ * ONNX Embedding Provider
+ *
+ * Uses onnxruntime-node for native ONNX inference of embedding models.
+ * No API key required, runs entirely in Node.js with native performance.
+ *
+ * Requires optional dependency: npm install onnxruntime-node
+ *
+ * Features:
+ * - Pure TypeScript WordPiece tokenizer (no native tokenizer dependency)
+ * - Auto-downloads models from HuggingFace CDN
+ * - Batched inference for efficient multi-text embedding
+ * - L2-normalized output for cosine similarity
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { EmbeddingProvider } from '../interfaces/embedding.js';
+
+import {
+  BertTokenizer,
+  ensureModelFiles,
+  l2Normalize,
+  meanPooling,
+} from './onnx-utils.js';
+
+/**
+ * Configuration for OnnxEmbeddingProvider
+ */
+export interface OnnxEmbeddingConfig {
+  /** HuggingFace model ID (default: 'sentence-transformers/all-MiniLM-L6-v2') */
+  model?: string;
+  /** Embedding dimensions (default: 384) */
+  dimensions?: number;
+  /** Path to pre-downloaded model directory containing model.onnx and vocab.txt (optional) */
+  modelPath?: string;
+  /** Cache directory for auto-downloaded models (default: ~/.cache/vat-onnx-models) */
+  cacheDir?: string;
+  /** ONNX Runtime execution providers to try (default: let onnxruntime-node auto-detect) */
+  executionProviders?: string[];
+  /** Max sequence length for tokenization (default: 256) */
+  maxSequenceLength?: number;
+}
+
+/** Shape of the ONNX Runtime Tensor constructor and InferenceSession we need */
+interface OrtModule {
+  Tensor: new (
+    type: string,
+    data: BigInt64Array,
+    dims: readonly number[],
+  ) => OrtTensor;
+  InferenceSession: {
+    create: (
+      path: string,
+      options?: { executionProviders?: string[] },
+    ) => Promise<OrtSession>;
+  };
+}
+
+/** Minimal ONNX tensor interface */
+interface OrtTensor {
+  data: Float32Array | BigInt64Array;
+  dims: readonly number[];
+}
+
+/** Minimal ONNX session interface */
+interface OrtSession {
+  run: (feeds: Record<string, OrtTensor>) => Promise<Record<string, OrtTensor>>;
+}
+
+/** Loaded model resources */
+interface LoadedModel {
+  session: OrtSession;
+  tokenizer: BertTokenizer;
+}
+
+/**
+ * Lazily import onnxruntime-node with a clear error message.
+ */
+async function loadOnnxRuntime(): Promise<OrtModule> {
+  try {
+    const ort = await import('onnxruntime-node');
+    return ort as unknown as OrtModule;
+  } catch {
+    throw new Error(
+      'onnxruntime-node is not installed. Install with: npm install onnxruntime-node',
+    );
+  }
+}
+
+/**
+ * Build batched ONNX tensors from tokenizer output.
+ *
+ * Creates int64 tensors for input_ids and attention_mask with
+ * shape [batchSize, sequenceLength].
+ */
+function createBatchTensors(
+  ort: OrtModule,
+  inputIds: number[][],
+  attentionMask: number[][],
+  batchSize: number,
+  sequenceLength: number,
+): { inputIdsTensor: OrtTensor; attentionMaskTensor: OrtTensor; tokenTypeIdsTensor: OrtTensor } {
+  const flatInputIds = new BigInt64Array(batchSize * sequenceLength);
+  const flatMask = new BigInt64Array(batchSize * sequenceLength);
+
+  for (let batch = 0; batch < batchSize; batch++) {
+    const batchIds = inputIds[batch];
+    const batchMask = attentionMask[batch];
+
+    if (!batchIds || !batchMask) {
+      continue;
+    }
+
+    for (let seq = 0; seq < sequenceLength; seq++) {
+      const index = batch * sequenceLength + seq;
+      flatInputIds[index] = BigInt(batchIds[seq] ?? 0);
+      flatMask[index] = BigInt(batchMask[seq] ?? 0);
+    }
+  }
+
+  const dims = [batchSize, sequenceLength] as const;
+
+  // token_type_ids is all zeros for single-segment inputs (standard for embedding models)
+  const flatTokenTypeIds = new BigInt64Array(batchSize * sequenceLength);
+
+  return {
+    inputIdsTensor: new ort.Tensor('int64', flatInputIds, dims),
+    attentionMaskTensor: new ort.Tensor('int64', flatMask, dims),
+    tokenTypeIdsTensor: new ort.Tensor('int64', flatTokenTypeIds, dims),
+  };
+}
+
+/**
+ * OnnxEmbeddingProvider
+ *
+ * Local embedding generation using ONNX Runtime for native inference.
+ * Default model: sentence-transformers/all-MiniLM-L6-v2 (384 dimensions)
+ *
+ * Benefits:
+ * - No API key required
+ * - Native C++ inference performance via onnxruntime-node
+ * - Pure TypeScript tokenizer (no native tokenizer dependency)
+ * - Auto-downloads models from HuggingFace
+ * - Batched inference support
+ * - Platform-aware execution provider selection
+ *
+ * Note: First run downloads model files (~80MB for all-MiniLM-L6-v2 ONNX)
+ */
+export class OnnxEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'onnx';
+  readonly model: string;
+  readonly dimensions: number;
+
+  private readonly configModelPath: string | undefined;
+  private readonly cacheDir: string;
+  private readonly executionProviders: string[] | undefined;
+  private readonly maxSequenceLength: number;
+
+  private initPromise: Promise<LoadedModel> | null = null;
+
+  /**
+   * Create OnnxEmbeddingProvider
+   *
+   * @param config - Optional configuration
+   */
+  constructor(config: OnnxEmbeddingConfig = {}) {
+    this.model = config.model ?? 'sentence-transformers/all-MiniLM-L6-v2';
+    this.dimensions = config.dimensions ?? 384;
+    this.configModelPath = config.modelPath;
+    this.cacheDir = config.cacheDir ?? join(homedir(), '.cache', 'vat-onnx-models');
+    this.executionProviders = config.executionProviders;
+    this.maxSequenceLength = config.maxSequenceLength ?? 256;
+  }
+
+  /**
+   * Initialize the ONNX session and tokenizer.
+   *
+   * Uses a single promise to avoid race conditions when multiple
+   * embed calls happen concurrently.
+   */
+  private async initialize(): Promise<LoadedModel> {
+    this.initPromise ??= this.loadModel();
+    return this.initPromise;
+  }
+
+  /**
+   * Load the ONNX model and tokenizer.
+   *
+   * If modelPath is provided, uses it directly. Otherwise, ensures
+   * model files are downloaded to the cache directory.
+   */
+  private async loadModel(): Promise<LoadedModel> {
+    const ort = await loadOnnxRuntime();
+
+    let modelPath: string;
+    let vocabPath: string;
+
+    if (this.configModelPath) {
+      modelPath = join(this.configModelPath, 'model.onnx');
+      vocabPath = join(this.configModelPath, 'vocab.txt');
+    } else {
+      const files = await ensureModelFiles(this.model, this.cacheDir);
+      modelPath = files.modelPath;
+      vocabPath = files.vocabPath;
+    }
+
+    const sessionOptions = this.executionProviders
+      ? { executionProviders: this.executionProviders }
+      : undefined;
+
+    const session = await ort.InferenceSession.create(modelPath, sessionOptions);
+    const tokenizer = await BertTokenizer.fromVocabFile(vocabPath);
+
+    return { session, tokenizer };
+  }
+
+  /**
+   * Embed a single text chunk
+   *
+   * @param text - Text to embed
+   * @returns Normalized vector embedding
+   */
+  async embed(text: string): Promise<number[]> {
+    const [result] = await this.embedBatch([text]);
+
+    if (!result) {
+      throw new Error('ONNX inference returned no embeddings');
+    }
+
+    return result;
+  }
+
+  /**
+   * Embed multiple text chunks efficiently using batched inference.
+   *
+   * Tokenizes all texts, creates batched ONNX tensors, runs a single
+   * inference call, then applies mean pooling and L2 normalization.
+   *
+   * @param texts - Array of texts to embed
+   * @returns Array of normalized vector embeddings
+   */
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) {
+      return [];
+    }
+
+    const { session, tokenizer } = await this.initialize();
+    const ort = await loadOnnxRuntime();
+
+    const { inputIds, attentionMask, maxLen } = tokenizer.tokenizeBatch(
+      texts,
+      this.maxSequenceLength,
+    );
+
+    const batchSize = texts.length;
+    const { inputIdsTensor, attentionMaskTensor, tokenTypeIdsTensor } = createBatchTensors(
+      ort,
+      inputIds,
+      attentionMask,
+      batchSize,
+      maxLen,
+    );
+
+    const outputs = await session.run({
+      input_ids: inputIdsTensor,
+      attention_mask: attentionMaskTensor,
+      token_type_ids: tokenTypeIdsTensor,
+    });
+
+    const lastHiddenState = outputs['last_hidden_state'];
+
+    if (!lastHiddenState) {
+      throw new Error('ONNX model did not return last_hidden_state output');
+    }
+
+    const hiddenData = lastHiddenState.data as Float32Array;
+    const pooled = meanPooling(
+      hiddenData,
+      attentionMask,
+      batchSize,
+      maxLen,
+      this.dimensions,
+    );
+
+    return pooled.map((vector) => l2Normalize(vector));
+  }
+}

--- a/packages/rag/src/embedding-providers/onnx-utils.ts
+++ b/packages/rag/src/embedding-providers/onnx-utils.ts
@@ -1,0 +1,447 @@
+/**
+ * ONNX Embedding Utilities
+ *
+ * Pure TypeScript utilities for ONNX-based embedding inference:
+ * - WordPiece tokenizer (no native dependencies)
+ * - Mean pooling and L2 normalization
+ * - HuggingFace model file downloader
+ */
+
+import { readFile, stat, mkdir, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// WordPiece Tokenizer
+// ---------------------------------------------------------------------------
+
+/** Output of a single tokenization call */
+export interface TokenizerOutput {
+  inputIds: number[];
+  attentionMask: number[];
+}
+
+/** Batch tokenization result with padding info */
+export interface BatchTokenizerOutput {
+  inputIds: number[][];
+  attentionMask: number[][];
+  maxLen: number;
+}
+
+/** Special token IDs for BERT-style models */
+const SPECIAL_TOKENS = {
+  CLS: 101,
+  SEP: 102,
+  UNK: 100,
+  PAD: 0,
+} as const;
+
+/**
+ * Strip accents from a string using Unicode NFD normalization.
+ *
+ * Decomposes characters into base + combining marks, then removes the
+ * combining diacritical marks (Unicode category Mn, range U+0300-U+036F).
+ */
+function stripAccents(text: string): string {
+  return text.normalize('NFD').replaceAll(/[\u0300-\u036F]/g, '');
+}
+
+/**
+ * Split text on whitespace and punctuation boundaries.
+ *
+ * Punctuation characters become individual tokens. Whitespace is consumed
+ * as a delimiter. All other characters are grouped into word tokens.
+ */
+function splitOnPunctuation(text: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+
+  for (const char of text) {
+    if (/\s/.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+    } else if (/\p{P}/u.test(char)) {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = '';
+      }
+      tokens.push(char);
+    } else {
+      current += char;
+    }
+  }
+
+  if (current.length > 0) {
+    tokens.push(current);
+  }
+
+  return tokens;
+}
+
+/**
+ * Apply the WordPiece algorithm to a single word.
+ *
+ * Attempts to find the longest prefix in the vocabulary, then iterates
+ * with "##" prefixed subwords. Falls back to [UNK] if no decomposition
+ * is possible.
+ */
+function wordPieceTokenize(
+  word: string,
+  vocab: ReadonlyMap<string, number>,
+): number[] {
+  const ids: number[] = [];
+  let start = 0;
+
+  while (start < word.length) {
+    let end = word.length;
+    let foundId: number | undefined;
+
+    while (start < end) {
+      const substr = start === 0 ? word.slice(0, end) : `##${word.slice(start, end)}`;
+      const vocabId = vocab.get(substr);
+
+      if (vocabId !== undefined) {
+        foundId = vocabId;
+        break;
+      }
+      end--;
+    }
+
+    if (foundId === undefined) {
+      return [SPECIAL_TOKENS.UNK];
+    }
+
+    ids.push(foundId);
+    start = end;
+  }
+
+  return ids;
+}
+
+/**
+ * Pad an array of numbers to a target length with a pad value.
+ */
+function padArray(source: number[], targetLength: number, padValue: number): number[] {
+  if (source.length >= targetLength) {
+    return source;
+  }
+  const padded = new Array<number>(targetLength).fill(padValue);
+  for (const [index, value] of source.entries()) {
+    padded[index] = value;
+  }
+  return padded;
+}
+
+/**
+ * Parse a vocab.txt file into a token-to-id map.
+ *
+ * Each line in the file corresponds to a token, with the line number
+ * (0-indexed) as the token ID. Empty lines are skipped.
+ */
+function parseVocab(content: string): Map<string, number> {
+  const lines = content.split('\n');
+  const vocab = new Map<string, number>();
+
+  for (const [index, token] of lines.entries()) {
+    if (token.length > 0) {
+      vocab.set(token, index);
+    }
+  }
+
+  return vocab;
+}
+
+/**
+ * A pure TypeScript WordPiece tokenizer for BERT-style models.
+ *
+ * Loads vocabulary from a vocab.txt file and performs basic BERT
+ * preprocessing: lowercase, strip accents, split on whitespace
+ * and punctuation, then apply the WordPiece algorithm.
+ */
+export class BertTokenizer {
+  private readonly vocab: ReadonlyMap<string, number>;
+
+  private constructor(vocab: ReadonlyMap<string, number>) {
+    this.vocab = vocab;
+  }
+
+  /**
+   * Create a tokenizer from a vocab.txt file.
+   *
+   * The file should contain one token per line, where the line number
+   * (0-indexed) corresponds to the token ID.
+   *
+   * @param vocabPath - Absolute path to vocab.txt
+   * @returns Initialized BertTokenizer
+   */
+  static async fromVocabFile(vocabPath: string): Promise<BertTokenizer> {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- vocabPath is from model cache, not user input
+    const content = await readFile(vocabPath, 'utf8');
+    const vocab = parseVocab(content);
+    return new BertTokenizer(vocab);
+  }
+
+  /**
+   * Tokenize a single text string.
+   *
+   * Applies BERT preprocessing (lowercase, strip accents, split on
+   * punctuation), then WordPiece tokenization. Adds [CLS] and [SEP]
+   * special tokens. Truncates to maxLength if necessary.
+   *
+   * @param text - Input text
+   * @param maxLength - Maximum sequence length including special tokens (default: 256)
+   * @returns Token IDs and attention mask
+   */
+  tokenize(text: string, maxLength = 256): TokenizerOutput {
+    const processed = stripAccents(text.toLowerCase());
+    const words = splitOnPunctuation(processed);
+
+    const tokenIds: number[] = [SPECIAL_TOKENS.CLS];
+
+    // Reserve 2 slots for [CLS] and [SEP]
+    const maxContentTokens = maxLength - 2;
+
+    for (const word of words) {
+      if (tokenIds.length - 1 >= maxContentTokens) {
+        break;
+      }
+      const wordIds = wordPieceTokenize(word, this.vocab);
+      for (const id of wordIds) {
+        if (tokenIds.length - 1 >= maxContentTokens) {
+          break;
+        }
+        tokenIds.push(id);
+      }
+    }
+
+    tokenIds.push(SPECIAL_TOKENS.SEP);
+
+    const attentionMask = new Array<number>(tokenIds.length).fill(1);
+
+    return { inputIds: tokenIds, attentionMask };
+  }
+
+  /**
+   * Tokenize a batch of texts with padding to the longest sequence.
+   *
+   * All sequences are padded to the same length so they can be
+   * combined into a single batched tensor for ONNX inference.
+   *
+   * @param texts - Array of input texts
+   * @param maxLength - Maximum sequence length including special tokens (default: 256)
+   * @returns Padded token IDs, attention masks, and the padded sequence length
+   */
+  tokenizeBatch(texts: string[], maxLength = 256): BatchTokenizerOutput {
+    const tokenized = texts.map((text) => this.tokenize(text, maxLength));
+
+    let maxLen = 0;
+    for (const item of tokenized) {
+      if (item.inputIds.length > maxLen) {
+        maxLen = item.inputIds.length;
+      }
+    }
+
+    const inputIds = tokenized.map((item) =>
+      padArray(item.inputIds, maxLen, SPECIAL_TOKENS.PAD),
+    );
+    const attentionMask = tokenized.map((item) =>
+      padArray(item.attentionMask, maxLen, 0),
+    );
+
+    return { inputIds, attentionMask, maxLen };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mean Pooling
+// ---------------------------------------------------------------------------
+
+/**
+ * Pool a single batch item from the hidden state using its attention mask.
+ *
+ * Sums token embeddings weighted by the attention mask, then divides by the
+ * number of non-padding tokens to produce a mean-pooled embedding.
+ */
+function poolSingleItem(
+  lastHiddenState: Float32Array,
+  mask: number[],
+  batchIndex: number,
+  sequenceLength: number,
+  embeddingDim: number,
+): number[] {
+  const embedding = new Array<number>(embeddingDim).fill(0);
+  let maskSum = 0;
+
+  for (let seq = 0; seq < sequenceLength; seq++) {
+    const maskValue = mask[seq] ?? 0;
+    maskSum += maskValue;
+
+    if (maskValue === 0) {
+      continue;
+    }
+
+    const offset = (batchIndex * sequenceLength + seq) * embeddingDim;
+    for (let dim = 0; dim < embeddingDim; dim++) {
+      const current = embedding[dim] ?? 0;
+      embedding[dim] = current + (lastHiddenState[offset + dim] ?? 0);
+    }
+  }
+
+  if (maskSum > 0) {
+    for (let dim = 0; dim < embeddingDim; dim++) {
+      const current = embedding[dim] ?? 0;
+      embedding[dim] = current / maskSum;
+    }
+  }
+
+  return embedding;
+}
+
+/**
+ * Apply mean pooling to the last hidden state of a transformer model.
+ *
+ * Weights each token embedding by its attention mask value (0 or 1) so
+ * that padding tokens are excluded from the mean. Returns one embedding
+ * vector per batch item.
+ *
+ * @param lastHiddenState - Raw model output, shape [batch, seq, dim], as Float32Array
+ * @param attentionMasks - Attention masks for each batch item
+ * @param batchSize - Number of items in the batch
+ * @param sequenceLength - Padded sequence length
+ * @param embeddingDim - Embedding dimensionality (e.g. 384)
+ * @returns Array of embedding vectors (one per batch item)
+ */
+export function meanPooling(
+  lastHiddenState: Float32Array,
+  attentionMasks: number[][],
+  batchSize: number,
+  sequenceLength: number,
+  embeddingDim: number,
+): number[][] {
+  const results: number[][] = [];
+
+  for (let batch = 0; batch < batchSize; batch++) {
+    const mask = attentionMasks[batch];
+
+    if (!mask) {
+      results.push(new Array<number>(embeddingDim).fill(0));
+      continue;
+    }
+
+    results.push(
+      poolSingleItem(lastHiddenState, mask, batch, sequenceLength, embeddingDim),
+    );
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// L2 Normalization
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize a vector to unit length using L2 (Euclidean) norm.
+ *
+ * If the vector has zero magnitude, returns the vector unchanged.
+ *
+ * @param vector - Input vector
+ * @returns Unit-length vector
+ */
+export function l2Normalize(vector: number[]): number[] {
+  let sumSquared = 0;
+  for (const value of vector) {
+    sumSquared += value * value;
+  }
+
+  const magnitude = Math.sqrt(sumSquared);
+
+  if (magnitude === 0) {
+    return vector;
+  }
+
+  return vector.map((value) => value / magnitude);
+}
+
+// ---------------------------------------------------------------------------
+// Model File Download
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a file exists at the given path.
+ */
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- filePath is constructed from known cache directory
+    await stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Download a file from a URL to a local path.
+ *
+ * Creates parent directories as needed. Buffers the response body
+ * and writes to disk.
+ */
+async function downloadFile(url: string, destination: string): Promise<void> {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- destination is constructed from known cache directory
+  await mkdir(dirname(destination), { recursive: true });
+
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download ${url}: ${response.status.toString()} ${response.statusText}`,
+    );
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- destination is constructed from known cache directory
+  await writeFile(destination, Buffer.from(arrayBuffer));
+}
+
+/**
+ * Ensure that model.onnx and vocab.txt files are available locally.
+ *
+ * Downloads from HuggingFace CDN if the files are not already cached.
+ * Uses the pattern:
+ *   https://huggingface.co/{modelId}/resolve/main/onnx/model.onnx
+ *   https://huggingface.co/{modelId}/resolve/main/vocab.txt
+ *
+ * @param modelId - HuggingFace model ID (e.g. 'sentence-transformers/all-MiniLM-L6-v2')
+ * @param cacheDir - Local directory for cached model files
+ * @returns Paths to the model and vocab files
+ */
+export async function ensureModelFiles(
+  modelId: string,
+  cacheDir: string,
+): Promise<{ modelPath: string; vocabPath: string }> {
+  const modelDir = join(cacheDir, modelId.replaceAll('/', '_'));
+  const modelPath = join(modelDir, 'model.onnx');
+  const vocabPath = join(modelDir, 'vocab.txt');
+
+  const baseUrl = `https://huggingface.co/${modelId}/resolve/main`;
+
+  const modelExists = await fileExists(modelPath);
+  if (!modelExists) {
+    const modelUrl = `${baseUrl}/onnx/model.onnx`;
+    console.log(`[vat-onnx] Downloading model: ${modelUrl}`);
+    console.log(`[vat-onnx] Destination: ${modelPath}`);
+    await downloadFile(modelUrl, modelPath);
+    console.log('[vat-onnx] Model download complete.');
+  }
+
+  const vocabExists = await fileExists(vocabPath);
+  if (!vocabExists) {
+    const vocabUrl = `${baseUrl}/vocab.txt`;
+    console.log(`[vat-onnx] Downloading vocab: ${vocabUrl}`);
+    await downloadFile(vocabUrl, vocabPath);
+    console.log('[vat-onnx] Vocab download complete.');
+  }
+
+  return { modelPath, vocabPath };
+}

--- a/packages/rag/src/index.ts
+++ b/packages/rag/src/index.ts
@@ -50,8 +50,10 @@ export { ApproximateTokenCounter, FastTokenCounter } from './token-counters/inde
 export {
   OpenAIEmbeddingProvider,
   TransformersEmbeddingProvider,
+  OnnxEmbeddingProvider,
   type OpenAIEmbeddingConfig,
   type TransformersEmbeddingConfig,
+  type OnnxEmbeddingConfig,
 } from './embedding-providers/index.js';
 
 // Chunking

--- a/packages/rag/src/types/onnxruntime-node.d.ts
+++ b/packages/rag/src/types/onnxruntime-node.d.ts
@@ -1,0 +1,24 @@
+/**
+ * Minimal type declarations for onnxruntime-node.
+ *
+ * onnxruntime-node is an optional dependency used by OnnxEmbeddingProvider.
+ * We define our own typed interfaces in onnx-embedding-provider.ts, so we
+ * only need a bare module declaration to satisfy the dynamic import.
+ */
+declare module 'onnxruntime-node' {
+  /** ONNX Runtime Tensor */
+  export class Tensor {
+    constructor(type: string, data: BigInt64Array | Float32Array, dims: readonly number[]);
+    readonly data: Float32Array | BigInt64Array;
+    readonly dims: readonly number[];
+  }
+
+  /** ONNX Runtime Inference Session */
+  export class InferenceSession {
+    static create(
+      path: string,
+      options?: { executionProviders?: string[] },
+    ): Promise<InferenceSession>;
+    run(feeds: Record<string, Tensor>): Promise<Record<string, Tensor>>;
+  }
+}

--- a/packages/rag/test/embedding-providers/onnx-embedding-provider.test.ts
+++ b/packages/rag/test/embedding-providers/onnx-embedding-provider.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit Tests for OnnxEmbeddingProvider
+ *
+ * These tests verify configuration, metadata, and edge cases
+ * without requiring onnxruntime-node or model downloads.
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { OnnxEmbeddingProvider } from '../../src/embedding-providers/onnx-embedding-provider.js';
+
+/** Non-public directory for test paths to satisfy sonarjs/publicly-writable-directories */
+const TEST_PATH_BASE = join(homedir(), '.cache', 'vat-test');
+
+describe('OnnxEmbeddingProvider - Unit Tests', () => {
+  it('should have correct default metadata', () => {
+    const provider = new OnnxEmbeddingProvider();
+
+    expect(provider.name).toBe('onnx');
+    expect(provider.model).toBe('sentence-transformers/all-MiniLM-L6-v2');
+    expect(provider.dimensions).toBe(384);
+  });
+
+  it('should accept custom model configuration', () => {
+    const provider = new OnnxEmbeddingProvider({
+      model: 'sentence-transformers/paraphrase-MiniLM-L3-v2',
+      dimensions: 384,
+    });
+
+    expect(provider.name).toBe('onnx');
+    expect(provider.model).toBe('sentence-transformers/paraphrase-MiniLM-L3-v2');
+    expect(provider.dimensions).toBe(384);
+  });
+
+  it('should accept custom dimensions', () => {
+    const provider = new OnnxEmbeddingProvider({
+      dimensions: 768,
+    });
+
+    expect(provider.dimensions).toBe(768);
+  });
+
+  it('should accept modelPath configuration', () => {
+    const provider = new OnnxEmbeddingProvider({
+      modelPath: join(TEST_PATH_BASE, 'my-model'),
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.name).toBe('onnx');
+  });
+
+  it('should accept cacheDir configuration', () => {
+    const provider = new OnnxEmbeddingProvider({
+      cacheDir: join(TEST_PATH_BASE, 'custom-cache'),
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.name).toBe('onnx');
+  });
+
+  it('should accept executionProviders configuration', () => {
+    const provider = new OnnxEmbeddingProvider({
+      executionProviders: ['cpu'],
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.name).toBe('onnx');
+  });
+
+  it('should accept maxSequenceLength configuration', () => {
+    const provider = new OnnxEmbeddingProvider({
+      maxSequenceLength: 128,
+    });
+
+    expect(provider).toBeDefined();
+    expect(provider.name).toBe('onnx');
+  });
+
+  it('should accept all configuration options together', () => {
+    const provider = new OnnxEmbeddingProvider({
+      model: 'custom/model',
+      dimensions: 512,
+      modelPath: join(TEST_PATH_BASE, 'models'),
+      cacheDir: join(TEST_PATH_BASE, 'cache'),
+      executionProviders: ['cpu'],
+      maxSequenceLength: 512,
+    });
+
+    expect(provider.name).toBe('onnx');
+    expect(provider.model).toBe('custom/model');
+    expect(provider.dimensions).toBe(512);
+  });
+
+  it('should return empty array when embedBatch called with empty array', async () => {
+    const provider = new OnnxEmbeddingProvider();
+    const embeddings = await provider.embedBatch([]);
+
+    expect(embeddings).toEqual([]);
+  });
+});

--- a/packages/rag/test/embedding-providers/onnx-utils.test.ts
+++ b/packages/rag/test/embedding-providers/onnx-utils.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Unit Tests for ONNX Embedding Utilities
+ *
+ * Tests the pure TypeScript utilities (tokenizer, pooling, normalization)
+ * without requiring onnxruntime-node or model downloads.
+ */
+
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { normalizedTmpdir } from '@vibe-agent-toolkit/utils';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  BertTokenizer,
+  l2Normalize,
+  meanPooling,
+} from '../../src/embedding-providers/onnx-utils.js';
+
+// ---------------------------------------------------------------------------
+// Test Vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal BERT vocabulary for testing.
+ *
+ * Line number = token ID. We include the special tokens at their
+ * standard BERT positions (0=[PAD], 100=[UNK], 101=[CLS], 102=[SEP])
+ * plus a handful of real word/subword tokens.
+ */
+function buildTestVocab(): string {
+  // We need tokens at specific indices:
+  //   0   -> [PAD]
+  //   100 -> [UNK]
+  //   101 -> [CLS]
+  //   102 -> [SEP]
+  // Fill gaps with placeholder tokens.
+  const lines: string[] = [];
+
+  // Index 0: [PAD]
+  lines[0] = '[PAD]';
+
+  // Indices 1-99: placeholders
+  for (let index = 1; index < 100; index++) {
+    lines[index] = `placeholder_${index.toString()}`;
+  }
+
+  // Special tokens
+  lines[100] = '[UNK]';
+  lines[101] = '[CLS]';
+  lines[102] = '[SEP]';
+
+  // Real word tokens starting at 103
+  lines[103] = 'hello';
+  lines[104] = 'world';
+  lines[105] = 'the';
+  lines[106] = 'cat';
+  lines[107] = 'sat';
+  lines[108] = 'on';
+  lines[109] = 'mat';
+  lines[110] = 'test';
+  lines[111] = '##ing';
+  lines[112] = '##s';
+  lines[113] = 'a';
+  lines[114] = '.';
+  lines[115] = ',';
+  lines[116] = 'cafe';
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Test Setup
+// ---------------------------------------------------------------------------
+
+let vocabDir: string;
+let vocabPath: string;
+let tokenizer: BertTokenizer;
+
+beforeAll(async () => {
+  vocabDir = join(normalizedTmpdir(), `onnx-utils-test-${Date.now().toString()}`);
+  vocabPath = join(vocabDir, 'vocab.txt');
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test temp directory
+  await mkdir(vocabDir, { recursive: true });
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- test temp file
+  await writeFile(vocabPath, buildTestVocab(), 'utf8');
+
+  tokenizer = await BertTokenizer.fromVocabFile(vocabPath);
+});
+
+afterAll(async () => {
+  await rm(vocabDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Shared Test Helpers
+// ---------------------------------------------------------------------------
+
+/** Safely access an element from an array, returning undefined if out of bounds */
+function safeGet<T>(array: T[], index: number): T | undefined {
+  return array[index];
+}
+
+/** CLS token ID */
+const CLS_TOKEN = 101;
+
+/** SEP token ID */
+const SEP_TOKEN = 102;
+
+/** UNK token ID */
+const UNK_TOKEN = 100;
+
+/** Common test phrases */
+const helloWorld = 'hello world';
+const longPhrase = 'hello world the cat sat on the mat';
+
+// ---------------------------------------------------------------------------
+// BertTokenizer Tests
+// ---------------------------------------------------------------------------
+
+describe('BertTokenizer', () => {
+  describe('fromVocabFile', () => {
+    it('should create a tokenizer from a vocab file', () => {
+      expect(tokenizer).toBeDefined();
+    });
+  });
+
+  describe('tokenize', () => {
+    it('should wrap tokens with [CLS] and [SEP]', () => {
+      const result = tokenizer.tokenize('hello');
+
+      expect(safeGet(result.inputIds, 0)).toBe(CLS_TOKEN);
+      expect(safeGet(result.inputIds, result.inputIds.length - 1)).toBe(SEP_TOKEN);
+    });
+
+    it('should lowercase input text', () => {
+      const result = tokenizer.tokenize('Hello');
+
+      // "Hello" -> "hello" -> token 103
+      expect(result.inputIds).toContain(103);
+    });
+
+    it('should strip accents', () => {
+      // "cafe" with accent -> "cafe" after stripping -> token 116
+      const result = tokenizer.tokenize('caf\u00e9');
+
+      expect(result.inputIds).toContain(116);
+    });
+
+    it('should produce attention mask of all 1s for real tokens', () => {
+      const result = tokenizer.tokenize(helloWorld);
+
+      expect(result.attentionMask.length).toBe(result.inputIds.length);
+      expect(result.attentionMask.every((v) => v === 1)).toBe(true);
+    });
+
+    it('should handle unknown tokens with [UNK]', () => {
+      const result = tokenizer.tokenize('xyzzy');
+
+      // "xyzzy" is not in the vocab -> [UNK]=100
+      expect(result.inputIds).toContain(UNK_TOKEN);
+    });
+
+    it('should split on punctuation', () => {
+      const result = tokenizer.tokenize('hello, world.');
+
+      // Should include comma (115) and period (114) as separate tokens
+      expect(result.inputIds).toContain(115); // comma
+      expect(result.inputIds).toContain(114); // period
+    });
+
+    it('should tokenize subword pieces', () => {
+      const result = tokenizer.tokenize('testing');
+
+      // "testing" -> "test" (110) + "##ing" (111)
+      expect(result.inputIds).toContain(110);
+      expect(result.inputIds).toContain(111);
+    });
+
+    it('should truncate at maxLength', () => {
+      // Use a very small maxLength to force truncation
+      const maxLength = 5;
+      const result = tokenizer.tokenize(longPhrase, maxLength);
+
+      // maxLength=5 means at most 5 tokens total including [CLS] and [SEP]
+      expect(result.inputIds.length).toBeLessThanOrEqual(maxLength);
+      expect(safeGet(result.inputIds, 0)).toBe(CLS_TOKEN);
+      expect(safeGet(result.inputIds, result.inputIds.length - 1)).toBe(SEP_TOKEN);
+    });
+
+    it('should handle empty string', () => {
+      const result = tokenizer.tokenize('');
+
+      // Just [CLS] and [SEP]
+      expect(result.inputIds).toEqual([CLS_TOKEN, SEP_TOKEN]);
+      expect(result.attentionMask).toEqual([1, 1]);
+    });
+  });
+
+  describe('tokenizeBatch', () => {
+    it('should tokenize multiple texts', () => {
+      const result = tokenizer.tokenizeBatch(['hello', 'world']);
+
+      expect(result.inputIds).toHaveLength(2);
+      expect(result.attentionMask).toHaveLength(2);
+    });
+
+    it('should pad all sequences to the longest length', () => {
+      // "hello" = 3 tokens ([CLS], hello, [SEP])
+      // "hello world" = 4 tokens ([CLS], hello, world, [SEP])
+      const result = tokenizer.tokenizeBatch(['hello', helloWorld]);
+
+      const firstIds = safeGet(result.inputIds, 0);
+      const secondIds = safeGet(result.inputIds, 1);
+
+      expect(firstIds).toBeDefined();
+      expect(secondIds).toBeDefined();
+
+      // Both should be padded to the same length (maxLen)
+      expect(firstIds?.length).toBe(result.maxLen);
+      expect(secondIds?.length).toBe(result.maxLen);
+    });
+
+    it('should use 0 for padding in attention mask', () => {
+      const result = tokenizer.tokenizeBatch(['hello', helloWorld]);
+
+      const firstMask = safeGet(result.attentionMask, 0);
+      expect(firstMask).toBeDefined();
+
+      // The shorter sequence should have 0s at the end
+      const lastMaskValue = firstMask ? safeGet(firstMask, firstMask.length - 1) : undefined;
+      // If there is padding (sequences differ in length), the last value should be 0
+      const clsSepHelloLength = 3; // [CLS] + hello + [SEP]
+      if (firstMask && firstMask.length > clsSepHelloLength) {
+        expect(lastMaskValue).toBe(0);
+      }
+    });
+
+    it('should respect maxLength parameter', () => {
+      const maxLength = 5;
+      const result = tokenizer.tokenizeBatch(
+        [longPhrase],
+        maxLength,
+      );
+
+      expect(result.maxLen).toBeLessThanOrEqual(maxLength);
+    });
+
+    it('should report correct maxLen', () => {
+      const result = tokenizer.tokenizeBatch(['hello', helloWorld]);
+
+      // "hello world" = [CLS] + hello + world + [SEP] = 4 tokens
+      const expectedMaxLen = 4;
+      expect(result.maxLen).toBe(expectedMaxLen);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mean Pooling Tests
+// ---------------------------------------------------------------------------
+
+describe('meanPooling', () => {
+  it('should pool a single item with uniform attention', () => {
+    // 1 batch, 2 sequence positions, 3 dimensions
+    // Hidden state: position 0 = [1, 2, 3], position 1 = [4, 5, 6]
+    const hiddenState = new Float32Array([1, 2, 3, 4, 5, 6]);
+    const attentionMasks = [[1, 1]];
+
+    const result = meanPooling(hiddenState, attentionMasks, 1, 2, 3);
+
+    expect(result).toHaveLength(1);
+
+    const embedding = safeGet(result, 0);
+    expect(embedding).toBeDefined();
+    expect(embedding).toHaveLength(3);
+
+    // Mean of [1,4]=2.5, [2,5]=3.5, [3,6]=4.5
+    expect(safeGet(embedding ?? [], 0)).toBeCloseTo(2.5, 5);
+    expect(safeGet(embedding ?? [], 1)).toBeCloseTo(3.5, 5);
+    expect(safeGet(embedding ?? [], 2)).toBeCloseTo(4.5, 5);
+  });
+
+  it('should respect attention mask (ignore padding)', () => {
+    // 1 batch, 3 sequence positions, 2 dimensions
+    // Position 0 = [10, 20], Position 1 = [30, 40], Position 2 = [99, 99] (padding)
+    const hiddenState = new Float32Array([10, 20, 30, 40, 99, 99]);
+    const attentionMasks = [[1, 1, 0]]; // Position 2 is padding
+
+    const result = meanPooling(hiddenState, attentionMasks, 1, 3, 2);
+
+    const embedding = safeGet(result, 0);
+    expect(embedding).toBeDefined();
+
+    // Mean of [10,30]=20, [20,40]=30 (position 2 excluded by mask)
+    expect(safeGet(embedding ?? [], 0)).toBeCloseTo(20, 5);
+    expect(safeGet(embedding ?? [], 1)).toBeCloseTo(30, 5);
+  });
+
+  it('should handle multiple batch items', () => {
+    // 2 batches, 2 sequence positions, 2 dimensions
+    // Batch 0: pos0=[1,2], pos1=[3,4]
+    // Batch 1: pos0=[5,6], pos1=[7,8]
+    const hiddenState = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const attentionMasks = [
+      [1, 1],
+      [1, 1],
+    ];
+
+    const result = meanPooling(hiddenState, attentionMasks, 2, 2, 2);
+
+    expect(result).toHaveLength(2);
+
+    const first = safeGet(result, 0);
+    const second = safeGet(result, 1);
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+
+    // Batch 0: mean([1,3])=2, mean([2,4])=3
+    expect(safeGet(first ?? [], 0)).toBeCloseTo(2, 5);
+    expect(safeGet(first ?? [], 1)).toBeCloseTo(3, 5);
+
+    // Batch 1: mean([5,7])=6, mean([6,8])=7
+    expect(safeGet(second ?? [], 0)).toBeCloseTo(6, 5);
+    expect(safeGet(second ?? [], 1)).toBeCloseTo(7, 5);
+  });
+
+  it('should return zeros when all mask values are zero', () => {
+    const hiddenState = new Float32Array([10, 20, 30, 40]);
+    const attentionMasks = [[0, 0]];
+
+    const result = meanPooling(hiddenState, attentionMasks, 1, 2, 2);
+
+    const embedding = safeGet(result, 0);
+    expect(embedding).toBeDefined();
+    expect(safeGet(embedding ?? [], 0)).toBe(0);
+    expect(safeGet(embedding ?? [], 1)).toBe(0);
+  });
+
+  it('should handle missing mask gracefully', () => {
+    // If attentionMasks array is shorter than batchSize,
+    // the missing batch should get zeros
+    const hiddenState = new Float32Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const attentionMasks = [[1, 1]]; // Only 1 mask but batchSize=2
+
+    const result = meanPooling(hiddenState, attentionMasks, 2, 2, 2);
+
+    expect(result).toHaveLength(2);
+
+    const second = safeGet(result, 1);
+    expect(second).toBeDefined();
+    // Missing mask -> zeros
+    expect(safeGet(second ?? [], 0)).toBe(0);
+    expect(safeGet(second ?? [], 1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// L2 Normalization Tests
+// ---------------------------------------------------------------------------
+
+describe('l2Normalize', () => {
+  it('should normalize a [3, 4] vector to [0.6, 0.8]', () => {
+    const result = l2Normalize([3, 4]);
+
+    expect(result).toHaveLength(2);
+    expect(safeGet(result, 0)).toBeCloseTo(0.6, 10);
+    expect(safeGet(result, 1)).toBeCloseTo(0.8, 10);
+  });
+
+  it('should return zero vector unchanged', () => {
+    const result = l2Normalize([0, 0, 0]);
+
+    expect(result).toEqual([0, 0, 0]);
+  });
+
+  it('should leave an already-unit vector unchanged', () => {
+    // [1, 0, 0] is already a unit vector
+    const result = l2Normalize([1, 0, 0]);
+
+    expect(safeGet(result, 0)).toBeCloseTo(1, 10);
+    expect(safeGet(result, 1)).toBeCloseTo(0, 10);
+    expect(safeGet(result, 2)).toBeCloseTo(0, 10);
+  });
+
+  it('should produce a unit vector (magnitude = 1)', () => {
+    const result = l2Normalize([1, 2, 3, 4, 5]);
+
+    const magnitude = Math.sqrt(
+      result.reduce((sum, val) => sum + val * val, 0),
+    );
+
+    expect(magnitude).toBeCloseTo(1, 10);
+  });
+
+  it('should handle single-element vectors', () => {
+    const result = l2Normalize([5]);
+
+    expect(result).toHaveLength(1);
+    expect(safeGet(result, 0)).toBeCloseTo(1, 10);
+  });
+
+  it('should handle negative values', () => {
+    const result = l2Normalize([-3, 4]);
+
+    expect(safeGet(result, 0)).toBeCloseTo(-0.6, 10);
+    expect(safeGet(result, 1)).toBeCloseTo(0.8, 10);
+  });
+});

--- a/packages/rag/test/integration/embedding-test-helpers.ts
+++ b/packages/rag/test/integration/embedding-test-helpers.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared test helpers for embedding provider integration tests.
+ *
+ * Reduces duplication across provider-specific integration test files.
+ */
+
+import { expect } from 'vitest';
+
+import type { EmbeddingProvider } from '../../src/interfaces/embedding.js';
+
+/**
+ * Assert that embedBatch returns correct structure for a batch of 3 texts.
+ *
+ * Checks that the result has 3 embeddings, each with the expected number of dimensions.
+ */
+export async function assertBatchEmbedding(
+  provider: EmbeddingProvider,
+  expectedDimensions: number,
+): Promise<void> {
+  const texts = ['Hello', 'world', 'test'];
+  const embeddings = await provider.embedBatch(texts);
+
+  expect(embeddings).toHaveLength(3);
+  for (const embedding of embeddings) {
+    expect(embedding).toHaveLength(expectedDimensions);
+  }
+}

--- a/packages/rag/test/integration/onnx-embedding-provider.integration.test.ts
+++ b/packages/rag/test/integration/onnx-embedding-provider.integration.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Integration Tests for OnnxEmbeddingProvider
+ *
+ * These tests use real ONNX Runtime inference with the all-MiniLM-L6-v2 model.
+ * First run downloads model files (~80MB).
+ *
+ * Skipped when:
+ * - onnxruntime-node is not installed
+ * - Running on Windows (avoid downloading native binaries in CI)
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { OnnxEmbeddingProvider } from '../../src/embedding-providers/onnx-embedding-provider.js';
+
+import { assertBatchEmbedding } from './embedding-test-helpers.js';
+
+// Detect runtime availability
+let onnxAvailable = false;
+try {
+  await import('onnxruntime-node');
+  onnxAvailable = true;
+} catch {
+  // onnxruntime-node not installed
+}
+
+const isWindows = process.platform === 'win32';
+const skipOnnx = !onnxAvailable || isWindows;
+
+/**
+ * Cosine similarity between two normalized vectors.
+ * For L2-normalized vectors, dot product equals cosine similarity.
+ */
+function cosineSimilarity(a: number[], b: number[]): number {
+  return a.reduce((sum, value, index) => sum + value * (b[index] ?? 0), 0);
+}
+
+describe.skipIf(skipOnnx)('OnnxEmbeddingProvider - Integration Tests', () => {
+  // Model download can take a while on first run
+  const provider = new OnnxEmbeddingProvider();
+
+  it(
+    'should embed a single text',
+    async () => {
+      const embedding = await provider.embed('Hello world');
+
+      expect(embedding).toBeInstanceOf(Array);
+      expect(embedding).toHaveLength(384);
+      expect(embedding.every((n) => typeof n === 'number')).toBe(true);
+    },
+    120_000,
+  );
+
+  it(
+    'should embed batch of texts',
+    async () => {
+      await assertBatchEmbedding(provider, 384);
+    },
+    120_000,
+  );
+
+  it(
+    'should produce normalized embeddings (magnitude close to 1)',
+    async () => {
+      const embedding = await provider.embed('Test embedding normalization');
+
+      const magnitude = Math.sqrt(
+        embedding.reduce((sum, val) => sum + val * val, 0),
+      );
+
+      expect(magnitude).toBeCloseTo(1, 2);
+    },
+    120_000,
+  );
+
+  it(
+    'should produce different embeddings for different texts',
+    async () => {
+      const embedding1 = await provider.embed('cat');
+      const embedding2 = await provider.embed('quantum mechanics');
+
+      expect(embedding1).not.toEqual(embedding2);
+    },
+    120_000,
+  );
+
+  it(
+    'should produce similar embeddings for similar texts',
+    async () => {
+      const embeddingCat = await provider.embed('cat');
+      const embeddingKitten = await provider.embed('kitten');
+      const embeddingSpaceship = await provider.embed('spaceship');
+
+      const similarityCatKitten = cosineSimilarity(embeddingCat, embeddingKitten);
+      const similarityCatSpaceship = cosineSimilarity(embeddingCat, embeddingSpaceship);
+
+      // cat-kitten should be more similar than cat-spaceship
+      expect(similarityCatKitten).toBeGreaterThan(similarityCatSpaceship);
+      expect(similarityCatKitten).toBeGreaterThan(0.5);
+    },
+    120_000,
+  );
+
+  it(
+    'should be deterministic (same text produces same embedding)',
+    async () => {
+      const text = 'Deterministic test for ONNX embeddings';
+      const embedding1 = await provider.embed(text);
+      const embedding2 = await provider.embed(text);
+
+      expect(embedding1).toEqual(embedding2);
+    },
+    120_000,
+  );
+
+  it(
+    'should handle empty batch',
+    async () => {
+      const embeddings = await provider.embedBatch([]);
+
+      expect(embeddings).toEqual([]);
+    },
+    120_000,
+  );
+
+  it(
+    'should handle long text (500+ characters)',
+    async () => {
+      const longText = 'This is a test sentence for embedding generation. '.repeat(15);
+      expect(longText.length).toBeGreaterThan(500);
+
+      const embedding = await provider.embed(longText);
+
+      expect(embedding).toHaveLength(384);
+      expect(embedding.every((n) => typeof n === 'number')).toBe(true);
+    },
+    120_000,
+  );
+});

--- a/packages/rag/test/integration/transformers-embedding-provider.integration.test.ts
+++ b/packages/rag/test/integration/transformers-embedding-provider.integration.test.ts
@@ -9,6 +9,8 @@ import { describe, it, expect } from 'vitest';
 
 import { TransformersEmbeddingProvider } from '../../src/embedding-providers/transformers-embedding-provider.js';
 
+import { assertBatchEmbedding } from './embedding-test-helpers.js';
+
 const DEFAULT_MODEL = 'Xenova/all-MiniLM-L6-v2';
 
 describe('TransformersEmbeddingProvider', () => {
@@ -79,13 +81,7 @@ describe('TransformersEmbeddingProvider', () => {
   });
 
   it('should embed batch of texts', async () => {
-    const texts = ['Hello', 'world', 'test'];
-    const embeddings = await provider.embedBatch(texts);
-
-    expect(embeddings).toHaveLength(3);
-    expect(embeddings[0]).toHaveLength(384);
-    expect(embeddings[1]).toHaveLength(384);
-    expect(embeddings[2]).toHaveLength(384);
+    await assertBatchEmbedding(provider, 384);
   });
 
   it('should handle empty batch', async () => {


### PR DESCRIPTION
## Summary
- Add `OnnxEmbeddingProvider` using `onnxruntime-node` for native C++ ONNX Runtime inference with GPU support (CoreML on Apple Silicon, CUDA on Linux, DirectML on Windows)
- Includes pure TypeScript WordPiece tokenizer, mean pooling, and L2 normalization — no additional native deps beyond `onnxruntime-node`
- Move both `@xenova/transformers` and `onnxruntime-node` to `optionalDependencies` with lazy dynamic imports and clear error messages, keeping the rag package lightweight
- Add comprehensive `docs/embedding-providers.md` documenting all built-in providers and how adopters can implement custom `EmbeddingProvider` implementations

## Changes
- **New**: `OnnxEmbeddingProvider` with auto model download from HuggingFace CDN
- **New**: `BertTokenizer`, `meanPooling`, `l2Normalize` pure TS utilities in `onnx-utils.ts`
- **New**: `docs/embedding-providers.md` — built-in provider guide + custom provider examples
- **Changed**: `@xenova/transformers` moved from `dependencies` → `optionalDependencies`
- **Changed**: `TransformersEmbeddingProvider` converted to lazy dynamic import pattern
- **New**: Unit tests for tokenizer, pooling, normalization (always run, no native deps needed)
- **New**: Integration tests for ONNX provider (skipped on Windows CI to avoid native binary download)
- **Refactored**: Extracted shared `assertBatchEmbedding` test helper to reduce duplication

## Test Plan
- [x] Unit tests pass for BertTokenizer, meanPooling, l2Normalize (pure TS, no model download)
- [x] Unit tests pass for OnnxEmbeddingProvider configuration and metadata
- [x] Integration tests pass on macOS/Linux with real model inference
- [x] Integration tests correctly skip on Windows and when onnxruntime-node unavailable
- [x] Existing TransformersEmbeddingProvider tests still pass
- [x] Full `bun run validate` passes (typecheck, lint, duplication, all test tiers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)