### PR TITLE
fix(rag): populate tokenCount and add chunk position metadata

### DIFF
--- a/packages/rag-lancedb/src/lancedb-rag-provider.ts
+++ b/packages/rag-lancedb/src/lancedb-rag-provider.ts
@@ -423,7 +423,8 @@ export class LanceDBRAGProvider<TMetadata extends Record<string, unknown> = Defa
       chunkingResult.chunks,
       chunkableResource,
       embeddings,
-      this.config.embeddingProvider.model
+      this.config.embeddingProvider.model,
+      this.tokenCounter,
     );
 
     // Add custom metadata from resource.frontmatter to each chunk

--- a/packages/rag-lancedb/test/schema.test.ts
+++ b/packages/rag-lancedb/test/schema.test.ts
@@ -69,6 +69,8 @@ function createTestRow(metadata: Record<string, unknown>) {
     contenthash: TEST_CONTENT_HASH,
     resourcecontenthash: TEST_RESOURCE_CONTENT_HASH,
     tokencount: 5,
+    chunkindex: -1,
+    totalchunks: -1,
     vector: TEST_EMBEDDING,
     embeddingmodel: TEST_MODEL,
     embeddedat: TEST_DATE.getTime(),
@@ -431,6 +433,8 @@ describe('round-trip serialization', () => {
       content: TEST_CONTENT,
       contentHash: TEST_CONTENT_HASH,
       tokenCount: 5,
+      chunkIndex: 2,
+      totalChunks: 5,
       embedding: TEST_EMBEDDING,
       embeddingModel: TEST_MODEL,
       embeddedAt: TEST_DATE,
@@ -453,6 +457,8 @@ describe('round-trip serialization', () => {
     expect(restored.content).toBe(chunk.content);
     expect(restored.contentHash).toBe(chunk.contentHash);
     expect(restored.tokenCount).toBe(chunk.tokenCount);
+    expect(restored.chunkIndex).toBe(chunk.chunkIndex);
+    expect(restored.totalChunks).toBe(chunk.totalChunks);
     expect(restored.embedding).toEqual(chunk.embedding);
     expect(restored.embeddingModel).toBe(chunk.embeddingModel);
     expect(restored.embeddedAt).toEqual(chunk.embeddedAt);
@@ -466,5 +472,15 @@ describe('round-trip serialization', () => {
     expect(restored.title).toBe(chunk.title);
     expect(restored.headingPath).toBe(chunk.headingPath);
     expect(restored.headingLevel).toBe(chunk.headingLevel);
+  });
+
+  it('should deserialize sentinel values (-1) for chunkIndex and totalChunks as undefined', () => {
+    const row = createTestRowWithDefaultMetadata();
+    // Simulate row with sentinel values for chunk position
+    const rowWithSentinels = { ...row, chunkindex: -1, totalchunks: -1 };
+    const chunk = lanceRowToChunk(rowWithSentinels, DefaultRAGMetadataSchema);
+
+    expect(chunk.chunkIndex).toBeUndefined();
+    expect(chunk.totalChunks).toBeUndefined();
   });
 });

--- a/packages/rag/src/chunking/chunk-resource.ts
+++ b/packages/rag/src/chunking/chunk-resource.ts
@@ -6,6 +6,7 @@
 
 import type { HeadingNode, ResourceMetadata } from '@vibe-agent-toolkit/resources';
 
+import type { TokenCounter } from '../interfaces/token-counter.js';
 import type { RAGChunk } from '../schemas/chunk.js';
 
 import { chunkByTokens } from './chunk-by-tokens.js';
@@ -181,13 +182,15 @@ function buildHeadingPath(
  * @param resource - Source chunkable resource with frontmatter
  * @param embeddings - Embedding array for each chunk
  * @param embeddingModel - Model used for embeddings
+ * @param tokenCounter - Optional token counter to compute token counts (defaults to 0 if not provided)
  * @returns Array of complete RAGChunks
  */
 export function enrichChunks(
   rawChunks: RawChunk[],
   resource: ChunkableResource,
   embeddings: number[][],
-  embeddingModel: string
+  embeddingModel: string,
+  tokenCounter?: TokenCounter,
 ): RAGChunk[] {
   const enrichedChunks: RAGChunk[] = rawChunks.map((raw, index) => {
     const chunkId = generateChunkId(resource.id, index);
@@ -198,7 +201,9 @@ export function enrichChunks(
       resourceId: resource.id,
       content: raw.content,
       contentHash,
-      tokenCount: 0, // Will be set by caller
+      tokenCount: tokenCounter ? tokenCounter.count(raw.content) : 0,
+      chunkIndex: index,
+      totalChunks: rawChunks.length,
       headingPath: raw.headingPath,
       headingLevel: raw.headingLevel,
       startLine: raw.startLine,

--- a/packages/rag/src/schemas/core-chunk.ts
+++ b/packages/rag/src/schemas/core-chunk.ts
@@ -22,6 +22,10 @@ export const CoreRAGChunkSchema = z.object({
   contentHash: z.string().describe('Hash of content for change detection'),
   tokenCount: z.number().describe('Accurate token count from TokenCounter'),
 
+  // Position within source document
+  chunkIndex: z.number().optional().describe('0-based position of this chunk within the source document'),
+  totalChunks: z.number().optional().describe('Total number of chunks for the source document'),
+
   // Vectors
   embedding: z.array(z.number()).describe('Vector embedding'),
   embeddingModel: z.string().describe('Model used: "text-embedding-3-small", "all-MiniLM-L6-v2", etc.'),


### PR DESCRIPTION
## Summary

- **Fix tokenCount bug**: `enrichChunks()` hardcoded `tokenCount: 0` — now accepts an optional `TokenCounter` parameter (Option A) and computes actual token counts when provided
- **Add chunk position metadata**: New `chunkIndex` (0-based) and `totalChunks` fields on `CoreRAGChunkSchema`, populated during enrichment and persisted through LanceDB
- **Wire up LanceDB provider**: Passes existing `this.tokenCounter` to `enrichChunks()` so all indexed chunks get real token counts

## Test plan

- [x] `enrichChunks` returns `tokenCount: 0` when no counter provided (backward compat)
- [x] `enrichChunks` returns accurate token counts when counter provided
- [x] `chunkIndex` and `totalChunks` populated correctly for multi-chunk and single-chunk cases
- [x] LanceDB round-trip: `chunkToLanceRow` → `lanceRowToChunk` preserves new fields
- [x] LanceDB sentinel values (`-1`) deserialize to `undefined` gracefully
- [x] `vv validate` passes (build, typecheck, lint, duplication, unit/integration/system tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)