### PR TITLE
fix: use pathToFileURL for Windows Node.js v24+ ESM compatibility

### DIFF
--- a/packages/vibe-agent-toolkit/bin/vat
+++ b/packages/vibe-agent-toolkit/bin/vat
@@ -7,7 +7,7 @@
 
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -17,5 +17,5 @@ const cliPkg = require.resolve('@vibe-agent-toolkit/cli/package.json');
 const cliRoot = dirname(cliPkg);
 const wrapperPath = join(cliRoot, 'dist/bin/vat.js');
 
-// Execute CLI wrapper
-import(wrapperPath);
+// Execute CLI wrapper (use file:// URL for Windows compatibility with Node.js v24+)
+import(pathToFileURL(wrapperPath).href);


### PR DESCRIPTION
## Summary

- On Windows with Node.js v24, dynamic `import()` requires `file://` URLs — bare absolute paths like `C:\...` cause `ERR_UNSUPPORTED_ESM_URL_SCHEME` because the drive letter (`C:`) is interpreted as a URL protocol
- Added `pathToFileURL()` conversion in `bin/vat` entry point, matching the pattern already used by vibe-validate's `bin/vv`

## Test plan

- [x] Verified `vat --version` works after patching the globally installed file
- [x] All 12 fast checks and unit tests pass via `bun run validate`
- [ ] CI matrix (Node 22/24 × Ubuntu/Windows) validates cross-platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)