### PR TITLE
fix(audit): resolve URL-encoded paths in skill link traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.19] - 2026-03-23
+
+### Fixed
+- **Audit: resolve URL-encoded paths in skill link traversal** — `vat audit` now correctly resolves `%20`, `%26`, and other percent-encoded characters in markdown link paths during skill link traversal; previously reported false `LINK_INTEGRITY_BROKEN` errors for files in directories with spaces or special characters (e.g., SharePoint-synced folders)
+
+### Changed
+- **Shared `resolveLocalHref` utility** — extracted common href → filesystem path resolution (anchor stripping, URL-decoding, relative path resolution) into `@vibe-agent-toolkit/resources` so both the audit and validate code paths use a single implementation
+
 ## [0.1.18] - 2026-03-20
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "yaml": "^2.8.2",
@@ -436,7 +436,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -462,7 +462,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/src/validators/skill-validator.ts
+++ b/packages/agent-skills/src/validators/skill-validator.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { basename, dirname, relative, resolve } from 'node:path';
 
-import { parseMarkdown } from '@vibe-agent-toolkit/resources';
+import { parseMarkdown, resolveLocalHref } from '@vibe-agent-toolkit/resources';
 
 import { parseFrontmatter } from '../parsers/frontmatter-parser.js';
 
@@ -117,13 +117,13 @@ function validateLocalLink(
   fileIssues: ValidationIssue[],
   issues: ValidationIssue[],
 ): { status: 'skip' | 'boundary' | 'broken' | 'valid'; resolvedPath: string } {
-  // Strip anchor fragment before resolving
-  const hrefWithoutAnchor = link.href.split('#')[0] ?? link.href;
-  if (hrefWithoutAnchor === '') {
+  // Resolve href to filesystem path (strips anchor, decodes percent-encoding)
+  const resolved = resolveLocalHref(link.href, currentPath);
+  if (!resolved) {
     return { status: 'skip', resolvedPath: '' };
   }
 
-  const resolvedPath = resolve(dirname(currentPath), hrefWithoutAnchor);
+  const resolvedPath = resolved.resolvedPath;
   const relativeToBoundary = relative(skillDir, resolvedPath);
 
   // Check boundary escape

--- a/packages/agent-skills/test/validators/skill-validator.test.ts
+++ b/packages/agent-skills/test/validators/skill-validator.test.ts
@@ -350,6 +350,44 @@ describe('transitive link traversal — links with anchors', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Edge: URL-encoded paths (%20, %26, etc.)
+// ---------------------------------------------------------------------------
+
+describe('transitive link traversal — URL-encoded paths', () => {
+  const { getTempDir } = setupTempDir('skill-url-encoded-');
+
+  it('should resolve %20-encoded spaces in link paths', async () => {
+    const files = { 'My Folder/target.md': '# Target\n\nContent.' };
+    const { result } = await createAndValidateTransitiveSkill(
+      getTempDir(), files, skillWithLink('My%20Folder/target.md', 'target'),
+    );
+
+    expect(findIssues(result, 'LINK_INTEGRITY_BROKEN')).toHaveLength(0);
+    expect(result.linkedFiles).toHaveLength(1);
+    expect(result.linkedFiles?.[0]?.path).toContain('target.md');
+  });
+
+  it('should resolve %26-encoded ampersands in link paths', async () => {
+    const files = { 'Fraud & Investigations/CLAUDE.md': '# Fraud\n\nContent.' };
+    const { result } = await createAndValidateTransitiveSkill(
+      getTempDir(), files, skillWithLink('Fraud%20%26%20Investigations/CLAUDE.md', 'fraud'),
+    );
+
+    expect(findIssues(result, 'LINK_INTEGRITY_BROKEN')).toHaveLength(0);
+  });
+
+  it('should handle invalid percent-encoding gracefully', async () => {
+    const { result } = await createAndValidateTransitiveSkill(
+      getTempDir(), {}, skillWithLink('bad%ZZencoding.md', 'bad'),
+    );
+
+    // Should not crash — falls back to raw href, reports broken link
+    const issues = findIssues(result, 'LINK_INTEGRITY_BROKEN');
+    expect(issues).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Edge: no rootDir provided — defaults to dirname(skillPath)
 // ---------------------------------------------------------------------------
 

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/src/index.ts
+++ b/packages/resources/src/index.ts
@@ -99,6 +99,9 @@ export {
 // Note: link-parser and link-validator internals are NOT exported
 // They are implementation details. Users should use ResourceRegistry API.
 
+// Export href resolution utility (shared by audit and validate code paths)
+export { resolveLocalHref } from './utils.js';
+
 // Export project config parsing
 export {
   findConfigFile,

--- a/packages/resources/src/link-validator.ts
+++ b/packages/resources/src/link-validator.ts
@@ -25,7 +25,7 @@ import {
 
 import type { ValidationIssue } from './schemas/validation-result.js';
 import type { HeadingNode, ResourceLink } from './types.js';
-import { isWithinProject, splitHrefAnchor } from './utils.js';
+import { isWithinProject, resolveLocalHref, splitHrefAnchor } from './utils.js';
 
 /**
  * Options for link validation.
@@ -240,17 +240,9 @@ async function validateLocalFile(
   href: string,
   sourceFilePath: string
 ): Promise<{ exists: boolean; resolvedPath: string; actualName?: string }> {
-  // URL-decode percent-encoded characters (e.g., %20 → space) before resolving
-  let decodedHref: string;
-  try {
-    decodedHref = decodeURIComponent(href);
-  } catch {
-    decodedHref = href;
-  }
-
-  // Resolve the path relative to the source file's directory
-  const sourceDir = path.dirname(sourceFilePath);
-  const resolvedPath = path.resolve(sourceDir, decodedHref);
+  // Resolve href to filesystem path (decode percent-encoding, resolve relative to source)
+  const resolved = resolveLocalHref(href, sourceFilePath);
+  const resolvedPath = resolved?.resolvedPath ?? path.resolve(path.dirname(sourceFilePath), href);
 
   // Check if file exists with correct case
   const verification = await verifyCaseSensitiveFilename(resolvedPath);

--- a/packages/resources/src/utils.ts
+++ b/packages/resources/src/utils.ts
@@ -73,6 +73,51 @@ export function splitHrefAnchor(href: string): [string, string | undefined] {
 }
 
 /**
+ * Resolve a markdown link href to an absolute filesystem path.
+ *
+ * Performs the standard href → path conversion used by both audit and validate:
+ * 1. Strips anchor fragment (`#section`)
+ * 2. Decodes URL-encoded characters (`%20` → space, `%26` → `&`)
+ * 3. Resolves the path relative to the source file's directory
+ *
+ * Returns `null` for anchor-only links (e.g., `#heading`).
+ *
+ * @param href - Raw href from a markdown link
+ * @param sourceFilePath - Absolute path of the file containing the link
+ * @returns Resolved path info, or null for anchor-only links
+ *
+ * @example
+ * ```typescript
+ * resolveLocalHref('My%20Folder/doc.md#intro', '/project/README.md')
+ * // { resolvedPath: '/project/My Folder/doc.md', anchor: 'intro' }
+ *
+ * resolveLocalHref('#heading', '/project/README.md')
+ * // null
+ * ```
+ */
+export function resolveLocalHref(
+  href: string,
+  sourceFilePath: string,
+): { resolvedPath: string; anchor: string | undefined } | null {
+  const [fileHref, anchor] = splitHrefAnchor(href);
+  if (fileHref === '') {
+    return null;
+  }
+
+  let decodedHref: string;
+  try {
+    decodedHref = decodeURIComponent(fileHref);
+  } catch {
+    decodedHref = fileHref;
+  }
+
+  const sourceDir = path.dirname(sourceFilePath);
+  const resolvedPath = path.resolve(sourceDir, decodedHref);
+
+  return { resolvedPath, anchor };
+}
+
+/**
  * Check if a file path is within a project directory.
  *
  * Resolves symlinks before comparison to handle cases where symlinks

--- a/packages/resources/test/resolve-local-href.test.ts
+++ b/packages/resources/test/resolve-local-href.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for resolveLocalHref — shared href → filesystem path resolution.
+ *
+ * This utility is used by both the audit (agent-skills) and validate (resources)
+ * code paths to consistently handle anchor stripping and URL-decoding.
+ */
+
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveLocalHref } from '../src/utils.js';
+
+const SOURCE = '/project/docs/README.md';
+const SOURCE_DIR = '/project/docs';
+const GUIDE_MD = './guide.md';
+
+describe('resolveLocalHref', () => {
+  it('should resolve a simple relative path', () => {
+    const result = resolveLocalHref(GUIDE_MD, SOURCE);
+    expect(result).toEqual({
+      resolvedPath: resolve(SOURCE_DIR, GUIDE_MD),
+      anchor: undefined,
+    });
+  });
+
+  it('should strip anchor and return it separately', () => {
+    const result = resolveLocalHref('./guide.md#section', SOURCE);
+    expect(result).toEqual({
+      resolvedPath: resolve(SOURCE_DIR, GUIDE_MD),
+      anchor: 'section',
+    });
+  });
+
+  it('should return null for anchor-only links', () => {
+    expect(resolveLocalHref('#heading', SOURCE)).toBeNull();
+  });
+
+  it('should decode %20 as space', () => {
+    const result = resolveLocalHref('My%20Folder/doc.md', SOURCE);
+    expect(result).toEqual({
+      resolvedPath: resolve(SOURCE_DIR, 'My Folder/doc.md'),
+      anchor: undefined,
+    });
+  });
+
+  it('should decode %26 as ampersand', () => {
+    const result = resolveLocalHref('Fraud%20%26%20Investigations/CLAUDE.md', SOURCE);
+    expect(result).toEqual({
+      resolvedPath: resolve(SOURCE_DIR, 'Fraud & Investigations/CLAUDE.md'),
+      anchor: undefined,
+    });
+  });
+
+  it('should decode percent-encoding AND strip anchor', () => {
+    const result = resolveLocalHref('My%20Folder/doc.md#intro', SOURCE);
+    expect(result).toEqual({
+      resolvedPath: resolve(SOURCE_DIR, 'My Folder/doc.md'),
+      anchor: 'intro',
+    });
+  });
+
+  it('should fall back to raw href on invalid percent-encoding', () => {
+    const result = resolveLocalHref('bad%ZZencoding.md', SOURCE);
+    expect(result).toEqual({
+      resolvedPath: resolve(SOURCE_DIR, 'bad%ZZencoding.md'),
+      anchor: undefined,
+    });
+  });
+});

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- **Bug**: `vat audit` reported false `LINK_INTEGRITY_BROKEN` errors for markdown links with percent-encoded characters (`%20`, `%26`) — the `decodeURIComponent` fix in `link-validator.ts` (resources package) was on a completely separate code path from the audit's `skill-validator.ts`
- **Fix**: Extract shared `resolveLocalHref()` utility into `@vibe-agent-toolkit/resources` that handles anchor stripping, URL-decoding, and relative path resolution — both audit and validate code paths now use it
- **Version**: Bumps to 0.1.19

## Test plan
- [x] Unit tests for `resolveLocalHref()` (7 cases: simple paths, anchors, `%20`, `%26`, combined, invalid encoding)
- [x] Unit tests in `skill-validator.test.ts` (3 cases: spaces, ampersands, invalid encoding)
- [x] Manual test against real SharePoint-synced directory with spaces and `&` in folder names — 0 errors
- [x] All 14 validation steps pass (build, typecheck, lint, duplication, unit/integration/system tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)