### PR TITLE
fix(publish): update @next dist-tag on stable npm releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,10 @@ jobs:
       - name: Build all packages
         run: bun run build
 
+      - name: Determine version type and npm tags
+        id: version_type
+        run: bun run tsx packages/dev-tools/src/determine-publish-tags.ts ${{ steps.version.outputs.version }}
+
       - name: Pre-publish checks
         run: bun run pre-publish
 
@@ -59,6 +63,7 @@ jobs:
         run: bun run publish-with-rollback ${{ steps.version.outputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          UPDATE_NEXT: ${{ steps.version_type.outputs.update_next }}
 
       - name: Extract changelog
         if: steps.version.outputs.is_stable == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`@next` dist-tag now updated on stable npm releases** — `publish.yml` now runs `determine-publish-tags.ts` to compute `update_next` and passes it to `publish-with-rollback.ts` via `UPDATE_NEXT` env; `publish-with-rollback.ts` now has a Phase 2 that applies `npm dist-tag add <pkg>@<version> next` to all packages when `UPDATE_NEXT=true`, with rollback on failure
+
 ## [0.1.20] - 2026-03-26
 
 ### Fixed

--- a/packages/dev-tools/src/publish-with-rollback.ts
+++ b/packages/dev-tools/src/publish-with-rollback.ts
@@ -178,6 +178,31 @@ function deprecatePackage(packageName: string, version: string, dryRun: boolean)
   return { success: false };
 }
 
+function addDistTag(packageName: string, version: string, tag: string, dryRun: boolean): { success: boolean; dryRun?: boolean } {
+  const fullPackageName = packageName === UMBRELLA_PACKAGE_NAME
+    ? UMBRELLA_PACKAGE_NAME
+    : `${VIBE_AGENT_TOOLKIT_SCOPE}${packageName}`;
+
+  log(`  Adding @${tag} tag to ${fullPackageName}@${version}...`, 'blue');
+
+  if (dryRun) {
+    log('    [DRY-RUN] Skipping actual tag addition', 'yellow');
+    return { success: true, dryRun: true };
+  }
+
+  const result = safeExecResult('npm', ['dist-tag', 'add', `${fullPackageName}@${version}`, tag], {
+    stdio: 'pipe',
+  });
+
+  if (result.success) {
+    log(`    ✅ @${tag} tag added`, 'green');
+    return { success: true };
+  }
+
+  log(`    ❌ Failed to add @${tag} tag`, 'red');
+  return { success: false };
+}
+
 function rollback(dryRun: boolean): void {
   log('\n🔄 ROLLBACK: Attempting to unpublish packages...', 'yellow');
   log('─'.repeat(60), 'yellow');
@@ -200,6 +225,31 @@ function rollback(dryRun: boolean): void {
   }
 
   cleanupManifest();
+}
+
+/**
+ * Phase 2: Update @next tag for stable releases if needed
+ */
+function updateNextTag(version: string, dryRun: boolean): void {
+  log('\n📋 Phase 2: Updating @next tag...', 'blue');
+  log('─'.repeat(60), 'blue');
+
+  for (const pkg of PACKAGES) {
+    const result = addDistTag(pkg, version, 'next', dryRun);
+
+    if (!result.success) {
+      log('\n❌ Failed to add @next tag!', 'red');
+      log(`   Package: ${pkg}`, 'red');
+      log('   All packages published but @next tag incomplete', 'red');
+      rollback(dryRun);
+      process.exit(1);
+    }
+  }
+
+  manifest.nextTagAdded = true;
+  saveManifest();
+  log('\n  ✅ @next tag added to all packages', 'green');
+  log('\n✅ Phase 2 complete', 'green');
 }
 
 function main(): void {
@@ -235,6 +285,7 @@ Examples:
 
   const isStable = semver.prerelease(version) === null;
   const primaryTag = isStable ? 'latest' : 'next';
+  const updateNext = isStable && process.env['UPDATE_NEXT'] === 'true';
 
   manifest.version = version;
   manifest.primaryTag = primaryTag;
@@ -243,12 +294,18 @@ Examples:
   log('\n' + '='.repeat(60), 'blue');
   log(`📦 Publishing vibe-agent-toolkit v${version}`, 'blue');
   log(`🏷️  Primary npm tag: @${primaryTag}`, 'blue');
+  if (updateNext) {
+    log('🏷️  Will also update @next tag', 'blue');
+  }
   if (dryRun) {
     log('🧪 DRY-RUN MODE', 'yellow');
   }
   log('='.repeat(60) + '\n', 'blue');
 
-  // Publish all packages
+  // Phase 1: Publish all packages with primary tag
+  log('📋 Phase 1: Publishing packages...', 'blue');
+  log('─'.repeat(60), 'blue');
+
   for (const pkg of PACKAGES) {
     const result = publishPackage(pkg, version, primaryTag, dryRun);
 
@@ -262,8 +319,24 @@ Examples:
     }
   }
 
+  log('\n✅ Phase 1 complete - all packages published', 'green');
+
+  // Phase 2: For stable versions, add @next tag if requested
+  if (updateNext) {
+    updateNextTag(version, dryRun);
+  }
+
   cleanupManifest();
-  log('\n✅ PUBLISH SUCCESSFUL', 'green');
+
+  log('\n' + '='.repeat(60), 'green');
+  log('✅ PUBLISH SUCCESSFUL', 'green');
+  log(`Version: ${version}`, 'green');
+  log(`Primary tag: @${primaryTag}`, 'green');
+  if (manifest.nextTagAdded) {
+    log('@next tag: Updated', 'green');
+  }
+  log('='.repeat(60), 'green');
+
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary

- `publish.yml` now runs `determine-publish-tags.ts` between build and publish to compute `update_next`, and passes it as `UPDATE_NEXT` env var to the publish step
- `publish-with-rollback.ts` adds a Phase 2 that calls `npm dist-tag add <pkg>@<version> next` on all packages when `UPDATE_NEXT=true` (stable release only), with rollback on failure
- Previously `@next` was only updated when publishing RCs; after a stable release it stayed pinned to the last RC indefinitely

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, tag a new version and verify the publish job shows "Will also update @next tag" in output
- [ ] `npm dist-tag ls vibe-agent-toolkit` shows `@next` pointing to the new stable version post-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)