### PR TITLE
fix(cli): marketplace publish mirrors CHANGELOG verbatim (BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Marketplace publish no longer logs git remote credentials.** `vat claude marketplace publish` previously echoed the full remote URL — including any credentials embedded by the user's config OR injected at runtime from `GH_TOKEN`/`GITHUB_TOKEN` — to stdout via its `Remote:` and `Pushed to …` log lines. In CI, GitHub Actions auto-masked the secret, but local runs (including adopter dry-runs) emitted the raw token to the terminal. All URL logging now passes through a `redactUrlCredentials()` helper that strips userinfo before logging. Git commands still receive the tokenized URL for authentication — only the logged copy is redacted.
+
 ### Changed
 - **BREAKING: Marketplace publish no longer rewrites `CHANGELOG.md`.** `vat claude marketplace publish` now mirrors the source `CHANGELOG.md` byte-for-byte into the publish tree and extracts release notes for the commit body only. Accepts both Keep a Changelog workflows: a pre-stamped `[X.Y.Z]` section matching `package.json` (preferred) or a non-empty `[Unreleased]` section (fallback). Fails if neither is present. Workflow A adopters whose `main` branch CHANGELOG continues to carry `[Unreleased]` at publish time will see that heading on the publish branch too — stamp `CHANGELOG.md` on `main` before tagging if you want a stamped heading in the published file. Side benefit: corrections/typo-fixes to `CHANGELOG.md` on `main` now propagate to the publish branch on the next publish.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING: Marketplace publish no longer rewrites `CHANGELOG.md`.** `vat claude marketplace publish` now mirrors the source `CHANGELOG.md` byte-for-byte into the publish tree and extracts release notes for the commit body only. Accepts both Keep a Changelog workflows: a pre-stamped `[X.Y.Z]` section matching `package.json` (preferred) or a non-empty `[Unreleased]` section (fallback). Fails if neither is present. Workflow A adopters whose `main` branch CHANGELOG continues to carry `[Unreleased]` at publish time will see that heading on the publish branch too — stamp `CHANGELOG.md` on `main` before tagging if you want a stamped heading in the published file. Side benefit: corrections/typo-fixes to `CHANGELOG.md` on `main` now propagate to the publish branch on the next publish.
+
 ### Fixed
 - **`toAbsolutePath()` and `getRelativePath()` now return forward-slash paths on Windows** — previously these returned backslash paths, bypassing cross-platform normalization.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.25] - 2026-04-09
+
 ### Security
 - **Marketplace publish no longer logs git remote credentials.** `vat claude marketplace publish` previously echoed the full remote URL — including any credentials embedded by the user's config OR injected at runtime from `GH_TOKEN`/`GITHUB_TOKEN` — to stdout via its `Remote:` and `Pushed to …` log lines. In CI, GitHub Actions auto-masked the secret, but local runs (including adopter dry-runs) emitted the raw token to the terminal. All URL logging now passes through a `redactUrlCredentials()` helper that strips userinfo before logging. Git commands still receive the tokenized URL for authentication — only the logged copy is redacted.
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.25-rc.2",
+      "version": "0.1.25",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.25-rc.1",
+      "version": "0.1.25-rc.2",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.24",
+      "version": "0.1.25-rc.1",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog-EXECUTE.md
+++ b/docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog-EXECUTE.md
@@ -1,0 +1,91 @@
+# Execution Prompt: Marketplace Publish Verbatim CHANGELOG Fix
+
+**Copy the block below into a fresh Claude Code session.**
+
+---
+
+Execute the implementation plan at `docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog.md` using the **superpowers:subagent-driven-development** skill. Dispatch one subagent per task, review between tasks, and iterate until each task's verification passes before moving on.
+
+## Branch & environment
+
+- You should already be on branch `fix/marketplace-publish-verbatim-changelog` (created from `main`). Verify with `git status` before starting. If you're on the wrong branch, stop and ask.
+- The plan file `docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog.md` is **untracked** in the working tree. It needs to be included in the final commit.
+
+## Commit discipline — READ CAREFULLY
+
+**Do NOT commit incrementally.** Ignore every `git add` / `git commit` step inside the plan. Hold all changes uncommitted in the working tree throughout the entire execution. Make **exactly one commit at the very end**, after the entire plan is complete and the full validation suite passes.
+
+Rationale: the change is a single cohesive refactor (delete `stampChangelog`, add `parseVersionSection`, rewire `publish-tree.ts`, update help, document breaking change). A single commit keeps the git history clean and makes the breaking-change PR easy to revert if needed.
+
+## Verification discipline — also read carefully
+
+Verification is **not** optional just because commits are deferred. You still MUST verify along the way:
+
+- **After each task's code edits**, run the targeted test command specified in that task (e.g., `cd packages/cli && bun run test:unit -- changelog-utils` for Task 1, `bun run test:unit -- publish-tree` for Task 2).
+- **After Task 2**, also run `cd packages/cli && bun run test:unit` to catch any publish.ts / ComposeOptions / `date` cleanup you may have missed.
+- **After Task 3**, run `bun run build` and sanity-check `node packages/cli/dist/bin/vat.js claude marketplace publish --help` shows the new wording.
+- **Before the final commit**, run `bun run validate` from the repo root and confirm every phase passes. This is the hard gate. Do not commit until this is green.
+
+If any verification step fails:
+1. Do NOT skip forward. Fix the issue.
+2. Re-run the failed verification.
+3. Only proceed once it passes.
+
+## Task 4 adjustments (CHANGELOG + version + PR)
+
+The plan's Task 4 steps need these adjustments:
+
+1. **CHANGELOG entry:** add it as specified in Task 4 Step 2 (this IS a user-visible breaking change — marketplace publish behavior flips).
+2. **Version bump question:** ask Jeff before committing. This is a breaking change to a feature shipped in 0.1.23, currently in `[Unreleased]` for the next release. Recommend discussing whether it warrants calling out in an RC or just bundling into the next regular release. Do not commit or push until Jeff answers.
+3. **Final `bun run validate`:** must be green immediately before the single commit.
+4. **The single final commit** should include: source changes, test changes, help text, CHANGELOG.md entry, AND the plan file itself (`docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog.md`, currently untracked).
+5. **PR creation:** do NOT create the PR automatically. After the commit lands, stop and ask Jeff whether to push and create the PR. Suggested PR title is in Task 4 Step 7 of the plan.
+
+## Dogfood step (Task 4 Step 6)
+
+Still run the `vat audit --user --verbose` dogfood check — it's best-effort, not a gate. Report any unexpected output but do not block on it unless it looks like a regression caused by this change (very unlikely — this change doesn't touch audit).
+
+## Final commit message
+
+Use a single conventional-commit message that covers the whole change. Suggested format:
+
+```
+fix(cli): marketplace publish mirrors CHANGELOG verbatim
+
+VAT no longer rewrites the CHANGELOG.md it copies into the publish
+tree. The source file is mirrored byte-for-byte and release notes
+flow to the commit body via changelogDelta extraction only.
+
+Accepts both Keep a Changelog workflows:
+- Workflow A: non-empty [Unreleased] (extracted for commit body)
+- Workflow B: pre-stamped [X.Y.Z] matching package.json (preferred)
+
+Changes:
+- Delete stampChangelog() and its tests (one caller, clean removal)
+- Add parseVersionSection() helper with semver pre-release support
+- publish-tree.ts copies CHANGELOG byte-for-byte; extracts commit
+  body via parseVersionSection -> parseUnreleasedSection fallback
+- Remove unused `date` field from ComposeOptions / PublishOneOptions
+  (YAGNI, pre-1.0)
+- Update publish --help to document verbatim behavior
+
+Benefits:
+- Corrections/typo-fixes to CHANGELOG.md on main now propagate to
+  the publish branch on the next publish.
+- main and publish branch never diverge on CHANGELOG contents.
+- Postel's Law: VAT is conservative in what it produces.
+- Eliminates a duplicate-heading footgun that would trigger if
+  stampChangelog ran against a pre-stamped changelog.
+
+BREAKING CHANGE: Workflow A adopters whose main-branch CHANGELOG
+carries [Unreleased] at publish time will see that heading on the
+publish branch too. To publish with a stamped heading, stamp
+CHANGELOG.md on main before tagging (e.g., via bump-version).
+
+Refs: adopter bug report 2026-04-09
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+## Start
+
+Announce you're using subagent-driven-development, then read the plan and begin Task 1. Remember: no incremental commits, full verification between tasks, single commit at the end, stop before pushing.

--- a/docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog.md
+++ b/docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog.md
@@ -1,0 +1,822 @@
+# Marketplace Publish: Verbatim CHANGELOG + Dual-Source Commit Body Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `vat claude marketplace publish` mirror the source `CHANGELOG.md` **verbatim** into the publish tree and extract release-note content for the commit body only. Accept both Keep a Changelog workflows (Workflow A: non-empty `[Unreleased]`; Workflow B: pre-stamped `[X.Y.Z]`) — never mutate the user's CHANGELOG file.
+
+**Architecture:** Delete `stampChangelog()` entirely. Add `parseVersionSection()` for extracting a stamped `[X.Y.Z]` section. In `publish-tree.ts`, copy the source changelog byte-for-byte to the publish tree and derive `changelogDelta` (the commit-body string) by preferring `[version]` → falling back to `[Unreleased]` → erroring if both are empty.
+
+**Tech Stack:** TypeScript (ESM/NodeNext), Vitest, Commander.js. No new dependencies.
+
+---
+
+## Design Decisions (locked)
+
+These were resolved before writing this plan. Do not re-debate them while executing:
+
+1. **Version = provenance metadata.** `readProjectVersion()` reads from `package.json` and is threaded through `composePublishTree()` **only** for use in the commit message subject (`publish v${version}`) and the log line. It is **not** a file-mutation target.
+
+2. **VAT never rewrites the user's `CHANGELOG.md`.** The file is copied byte-for-byte from `configDir` to `outputDir`. A side-benefit: corrections/typo-fixes to `CHANGELOG.md` on `main` propagate to the publish branch on the next publish.
+
+3. **Commit body comes from the CHANGELOG but does not touch the file.** The `changelogDelta` field in `ComposeResult` is used by `createCommitMessage()` in `git-publish.ts:35-54` and is the only piece that needs extraction logic.
+
+4. **Extraction rules** (in order):
+   - Prefer `## [<version>]` section (Workflow B / pre-stamped).
+   - Fall back to `## [Unreleased]` section (Workflow A).
+   - Error if both are empty, naming both acceptable patterns.
+   - A `[X.Y.Z]` section for a **different** version does NOT count — exact match on the requested version only.
+
+5. **`stampChangelog()` is deleted entirely**, not just unused. It has exactly one caller (`publish-tree.ts`) and one test file; both get cleaned up in this change.
+
+6. **Breaking change is accepted.** Three adopters (VAT, vibe-validate, one enterprise repo), all pre-1.0. Workflow A adopters whose `main` branch CHANGELOG.md continues to carry `[Unreleased]` at publish time will see that heading on the publish branch too — an honest representation. No migration of existing publish-branch history is needed.
+
+## Behavior matrix
+
+| `[Unreleased]` content | `[version]` section | Outcome | `changelogDelta` source | Published CHANGELOG.md |
+|---|---|---|---|---|
+| ✅ content | ❌ absent | publishes | `[Unreleased]` content | verbatim copy (keeps `[Unreleased]`) |
+| ❌ empty | ✅ present | publishes | `[version]` content | verbatim copy (keeps both headings) |
+| ✅ content | ✅ present | publishes | `[version]` content (prefer stamped) | verbatim copy (no mutation, no duplication) |
+| ❌ empty | ❌ absent | **error** — names both patterns | n/a | n/a |
+| ❌ empty | ✅ present but **different version** | **error** — don't silently use wrong notes | n/a | n/a |
+
+---
+
+## File Structure
+
+**Source changes (3 files):**
+
+| File | Change |
+|---|---|
+| `packages/cli/src/commands/claude/marketplace/changelog-utils.ts` | **Delete** `stampChangelog()`. **Add** `parseVersionSection()`. |
+| `packages/cli/src/commands/claude/marketplace/publish-tree.ts` | Replace changelog block (lines 14 import + 65–81) with dual-source extraction + verbatim copy. |
+| `packages/cli/src/commands/claude/marketplace/publish.ts` | Update `.addHelpText()` description to document dual-source acceptance + verbatim copy. |
+
+**Test changes (2 files):**
+
+| File | Change |
+|---|---|
+| `packages/cli/test/commands/claude/marketplace/changelog-utils.test.ts` | **Delete** `stampChangelog` tests. **Add** `parseVersionSection` tests. |
+| `packages/cli/test/commands/claude/marketplace/publish-tree.test.ts` | **Update** existing compose test (no longer asserts stamped heading). **Update** existing empty-unreleased test (new error message). **Add** Workflow B, "prefer stamped when both", and "mismatched version" tests. |
+
+**Docs changes (1 file):**
+
+| File | Change |
+|---|---|
+| `CHANGELOG.md` | Add entry under `[Unreleased]` describing the breaking behavior change. |
+
+**No changes to:**
+- `publish.ts` command wiring (`readProjectVersion`, `composePublishTree` call site) — version flow is unchanged.
+- `git-publish.ts` — `createCommitMessage(version, changelogDelta, metadata)` contract is unchanged; `changelogDelta` is still a trimmed string.
+- `ComposeResult` interface — still `{ version, changelogDelta, files }`.
+- Config schema — no new fields.
+- `UNRELEASED_HEADING_RE` / `VERSION_HEADING_RE` constants — both stay (still used by `parseUnreleasedSection` and the new `parseVersionSection`).
+
+---
+
+## Task 1: Replace `stampChangelog()` with `parseVersionSection()` (TDD)
+
+**Files:**
+- Modify: `packages/cli/src/commands/claude/marketplace/changelog-utils.ts`
+- Test: `packages/cli/test/commands/claude/marketplace/changelog-utils.test.ts`
+
+- [ ] **Step 1: Write failing tests for `parseVersionSection` and delete `stampChangelog` tests**
+
+Replace the entire contents of `packages/cli/test/commands/claude/marketplace/changelog-utils.test.ts` with:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+
+import {
+  parseUnreleasedSection,
+  parseVersionSection,
+} from '../../../../src/commands/claude/marketplace/changelog-utils.js';
+
+const SAMPLE_CHANGELOG = `# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- New marketplace publish command
+- SPDX license shortcut support
+
+### Fixed
+- Version validation for plugins
+
+## [0.1.0] - 2026-03-15
+
+### Added
+- Initial release
+`;
+
+const EMPTY_UNRELEASED = `# Changelog
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-15
+
+### Added
+- Initial release
+`;
+
+const PRESTAMPED_CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+## [1.2.0] - 2026-04-09
+
+### Added
+- New feature X
+- New feature Y
+
+## [1.1.0] - 2026-03-15
+
+### Fixed
+- Bug Z
+`;
+
+const PRESTAMPED_WITH_UNRELEASED_CONTENT = `# Changelog
+
+## [Unreleased]
+
+### Added
+- Upcoming feature
+
+## [1.2.0] - 2026-04-09
+
+### Added
+- Released feature
+`;
+
+describe('changelog-utils', () => {
+  describe('parseUnreleasedSection', () => {
+    it('should extract unreleased content', () => {
+      const result = parseUnreleasedSection(SAMPLE_CHANGELOG);
+      expect(result).toContain('### Added');
+      expect(result).toContain('New marketplace publish command');
+      expect(result).toContain('### Fixed');
+      expect(result).not.toContain('## [0.1.0]');
+    });
+
+    it('should return empty string when unreleased section has no content', () => {
+      const result = parseUnreleasedSection(EMPTY_UNRELEASED);
+      expect(result.trim()).toBe('');
+    });
+
+    it('should return empty string when no unreleased section exists', () => {
+      const result = parseUnreleasedSection('# Changelog\n\n## [1.0.0] - 2026-01-01\n');
+      expect(result.trim()).toBe('');
+    });
+  });
+
+  describe('parseVersionSection', () => {
+    it('should extract content of a stamped version section', () => {
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '1.2.0');
+      expect(result).toContain('### Added');
+      expect(result).toContain('New feature X');
+      expect(result).toContain('New feature Y');
+      expect(result).not.toContain('## [1.1.0]');
+      expect(result).not.toContain('Bug Z');
+    });
+
+    it('should extract the last version section (no following heading)', () => {
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '1.1.0');
+      expect(result).toContain('### Fixed');
+      expect(result).toContain('Bug Z');
+    });
+
+    it('should return empty string when the requested version is absent', () => {
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '9.9.9');
+      expect(result.trim()).toBe('');
+    });
+
+    it('should not match substrings of other versions', () => {
+      // '1.2' must NOT match '[1.2.0]' — we require exact version match
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '1.2');
+      expect(result.trim()).toBe('');
+    });
+
+    it('should ignore the [Unreleased] section entirely', () => {
+      const result = parseVersionSection(PRESTAMPED_WITH_UNRELEASED_CONTENT, '1.2.0');
+      expect(result).toContain('Released feature');
+      expect(result).not.toContain('Upcoming feature');
+    });
+
+    it('should handle versions with pre-release suffixes', () => {
+      const changelog = `# Changelog\n\n## [Unreleased]\n\n## [1.2.0-rc.1] - 2026-04-09\n\n### Added\n- RC feature\n`;
+      const result = parseVersionSection(changelog, '1.2.0-rc.1');
+      expect(result).toContain('RC feature');
+    });
+  });
+});
+```
+
+Note: the `stampChangelog` describe block is completely removed. `stampChangelog` no longer exists.
+
+- [ ] **Step 2: Run tests to verify failures**
+
+Run: `cd packages/cli && bun run test:unit -- changelog-utils`
+Expected: FAIL — `parseVersionSection is not a function` (import error) for each new test. The `parseUnreleasedSection` tests still pass unchanged.
+
+- [ ] **Step 3: Replace `changelog-utils.ts` contents**
+
+Replace the entire contents of `packages/cli/src/commands/claude/marketplace/changelog-utils.ts` with:
+
+```typescript
+/**
+ * Changelog parsing utilities for marketplace publish.
+ *
+ * Follows Keep a Changelog format: https://keepachangelog.com/
+ *
+ * Used by publish-tree.ts to extract release-note content for the publish commit body.
+ * VAT does NOT modify the user's CHANGELOG.md file — the published copy is byte-identical
+ * to the source. These helpers only extract content for the commit message.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { safePath } from '@vibe-agent-toolkit/utils';
+
+/**
+ * Regex to match the [Unreleased] heading (case-insensitive).
+ */
+const UNRELEASED_HEADING_RE = /^## \[unreleased\]\s*$/im;
+
+/**
+ * Regex to match any stamped version heading (e.g. `## [1.2.0]` or `## [1.2.0-rc.1]`).
+ * Used to find where a section ends (= where the next version heading begins).
+ */
+const VERSION_HEADING_RE = /^## \[\d+\.\d+/m;
+
+/**
+ * Extract the content of the [Unreleased] section from a changelog string.
+ * Returns the content between [Unreleased] heading and the next version heading (or EOF).
+ * Returns empty string if no [Unreleased] section or it has no content.
+ */
+export function parseUnreleasedSection(changelog: string): string {
+  const unreleasedMatch = UNRELEASED_HEADING_RE.exec(changelog);
+  if (!unreleasedMatch) {
+    return '';
+  }
+
+  const startIndex = unreleasedMatch.index + unreleasedMatch[0].length;
+  const rest = changelog.slice(startIndex);
+
+  const nextVersionMatch = VERSION_HEADING_RE.exec(rest);
+  const content = nextVersionMatch
+    ? rest.slice(0, nextVersionMatch.index)
+    : rest;
+
+  return content.trimEnd();
+}
+
+/**
+ * Extract the content of a specific stamped version section (e.g. `## [1.2.0] - 2026-04-09`).
+ *
+ * Supports the "pre-stamped" workflow: a repo that promotes `[Unreleased]` to `[X.Y.Z]`
+ * in its release commit before tagging, leaving `[Unreleased]` empty per the Keep a
+ * Changelog canonical post-release state.
+ *
+ * Matches headings of the form `## [<version>]` with any trailing content (date, etc.)
+ * on the same line. Requires an exact version match — `1.2` will NOT match `[1.2.0]`.
+ *
+ * Returns the trimmed content between the matching heading and the next `## [` version
+ * heading (or EOF). Returns empty string if the version section does not exist.
+ */
+export function parseVersionSection(changelog: string, version: string): string {
+  // Escape regex metacharacters in the version string (dots, hyphens, plus signs cover semver).
+  const escaped = version.replace(/[.+\-]/g, '\\$&');
+  // `## [<version>]` followed by any trailing content on the line (typically ` - date`).
+  // eslint-disable-next-line security/detect-non-literal-regexp -- input escaped above
+  const heading = new RegExp(`^## \\[${escaped}\\][^\\n]*$`, 'm');
+  const match = heading.exec(changelog);
+  if (!match) {
+    return '';
+  }
+
+  const startIndex = match.index + match[0].length;
+  const rest = changelog.slice(startIndex);
+
+  const nextVersionMatch = VERSION_HEADING_RE.exec(rest);
+  const content = nextVersionMatch ? rest.slice(0, nextVersionMatch.index) : rest;
+
+  return content.trim();
+}
+
+/**
+ * Read a changelog file from disk.
+ */
+export function readChangelog(filePath: string, baseDir: string): string {
+  const resolved = safePath.resolve(baseDir, filePath);
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path from validated config
+  return readFileSync(resolved, 'utf-8');
+}
+```
+
+Note: `stampChangelog` export is **removed**. Both regex constants are retained (both are still used).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/cli && bun run test:unit -- changelog-utils`
+Expected: all tests PASS (3 existing `parseUnreleasedSection` tests + 6 new `parseVersionSection` tests = 9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/commands/claude/marketplace/changelog-utils.ts \
+        packages/cli/test/commands/claude/marketplace/changelog-utils.test.ts
+git commit -m "refactor(cli): replace stampChangelog with parseVersionSection
+
+Delete stampChangelog() and add parseVersionSection() to support
+extracting release notes from a pre-stamped [X.Y.Z] section of a
+Keep a Changelog file. The next commit wires this into publish-tree
+so the marketplace publish no longer mutates CHANGELOG.md."
+```
+
+---
+
+## Task 2: Publish tree copies CHANGELOG verbatim + dual-source commit body (TDD)
+
+**Files:**
+- Modify: `packages/cli/src/commands/claude/marketplace/publish-tree.ts`
+- Test: `packages/cli/test/commands/claude/marketplace/publish-tree.test.ts`
+
+- [ ] **Step 1: Update and add publish-tree tests (failing)**
+
+Replace the entire contents of `packages/cli/test/commands/claude/marketplace/publish-tree.test.ts` with:
+
+```typescript
+/* eslint-disable security/detect-non-literal-fs-filename, sonarjs/no-duplicate-string */
+// Test file — all file operations are in temp directories, duplicated strings acceptable
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+
+
+import { mkdirSyncReal, normalizedTmpdir, safePath } from '@vibe-agent-toolkit/utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { composePublishTree } from '../../../../src/commands/claude/marketplace/publish-tree.js';
+
+function makeTempDir(tempDirs: string[]): string {
+  const dir = mkdtempSync(safePath.join(normalizedTmpdir(), 'vat-publish-tree-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/**
+ * Create a minimal marketplace build output under sourceDir so composePublishTree
+ * can find it. Returns the marketplace name used.
+ */
+function seedMarketplaceBuild(sourceDir: string, mpName = 'test-mp'): string {
+  const pluginDir = safePath.join(
+    sourceDir, 'dist', '.claude', 'plugins', 'marketplaces', mpName, '.claude-plugin',
+  );
+  mkdirSyncReal(pluginDir, { recursive: true });
+  writeFileSync(safePath.join(pluginDir, 'marketplace.json'), `{"name":"${mpName}"}`);
+  return mpName;
+}
+
+describe('publish-tree', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it('should compose tree with marketplace artifacts, changelog, readme, and license', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
+
+    const sourceChangelog = '# Changelog\n\n## [Unreleased]\n\n### Added\n- Feature\n';
+    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), sourceChangelog);
+    writeFileSync(safePath.join(sourceDir, 'README.md'), '# My Marketplace\n');
+
+    const result = await composePublishTree({
+      marketplaceName: mpName,
+      configDir: sourceDir,
+      outputDir,
+      version: '1.0.0',
+      date: '2026-04-01',
+      changelog: { sourcePath: 'CHANGELOG.md' },
+      readme: { sourcePath: 'README.md' },
+      license: { type: 'spdx', value: 'mit', ownerName: 'Test Org' },
+    });
+
+    expect(existsSync(safePath.join(outputDir, '.claude-plugin', 'marketplace.json'))).toBe(true);
+    expect(existsSync(safePath.join(outputDir, 'CHANGELOG.md'))).toBe(true);
+    expect(existsSync(safePath.join(outputDir, 'README.md'))).toBe(true);
+    expect(existsSync(safePath.join(outputDir, 'LICENSE'))).toBe(true);
+    expect(result.version).toBe('1.0.0');
+
+    // CHANGELOG must be copied BYTE-FOR-BYTE — no stamping, no mutation.
+    const changelogContent = readFileSync(safePath.join(outputDir, 'CHANGELOG.md'), 'utf-8');
+    expect(changelogContent).toBe(sourceChangelog);
+
+    // Release notes still flow to the commit body via changelogDelta.
+    expect(result.changelogDelta).toContain('### Added');
+    expect(result.changelogDelta).toContain('- Feature');
+  });
+
+  it('should fail when build output does not exist', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+
+    await expect(composePublishTree({
+      marketplaceName: 'nonexistent',
+      configDir: sourceDir,
+      outputDir,
+      version: '1.0.0',
+      date: '2026-04-01',
+    })).rejects.toThrow(/build output/i);
+  });
+
+  it('should fail when changelog has neither unreleased content nor matching version section', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
+
+    // Empty [Unreleased] and a stamped section for a DIFFERENT version
+    writeFileSync(
+      safePath.join(sourceDir, 'CHANGELOG.md'),
+      '# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2026-01-01\n\n### Added\n- Old\n',
+    );
+
+    await expect(composePublishTree({
+      marketplaceName: mpName,
+      configDir: sourceDir,
+      outputDir,
+      version: '1.0.0',
+      date: '2026-04-01',
+      changelog: { sourcePath: 'CHANGELOG.md' },
+    })).rejects.toThrow(/neither.*\[Unreleased\].*nor.*\[1\.0\.0\]/i);
+  });
+
+  it('should publish a pre-stamped changelog when [Unreleased] is empty (Workflow B)', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
+
+    const sourceChangelog =
+      '# Changelog\n\n## [Unreleased]\n\n## [1.2.0] - 2026-04-09\n\n### Added\n- New feature X\n- New feature Y\n\n## [1.1.0] - 2026-03-15\n\n### Fixed\n- Old bug\n';
+    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), sourceChangelog);
+
+    const result = await composePublishTree({
+      marketplaceName: mpName,
+      configDir: sourceDir,
+      outputDir,
+      version: '1.2.0',
+      date: '2026-04-09',
+      changelog: { sourcePath: 'CHANGELOG.md' },
+    });
+
+    expect(result.version).toBe('1.2.0');
+    // Commit body uses the stamped [1.2.0] section, not [Unreleased] and not [1.1.0].
+    expect(result.changelogDelta).toContain('New feature X');
+    expect(result.changelogDelta).toContain('New feature Y');
+    expect(result.changelogDelta).not.toContain('Old bug');
+
+    // Published CHANGELOG is BYTE-IDENTICAL to source.
+    const changelogContent = readFileSync(safePath.join(outputDir, 'CHANGELOG.md'), 'utf-8');
+    expect(changelogContent).toBe(sourceChangelog);
+  });
+
+  it('should prefer stamped [X.Y.Z] over [Unreleased] when both have content', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
+
+    const sourceChangelog =
+      '# Changelog\n\n## [Unreleased]\n\n### Added\n- Work-in-progress for next release\n\n## [1.2.0] - 2026-04-09\n\n### Added\n- Released feature\n';
+    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), sourceChangelog);
+
+    const result = await composePublishTree({
+      marketplaceName: mpName,
+      configDir: sourceDir,
+      outputDir,
+      version: '1.2.0',
+      date: '2026-04-09',
+      changelog: { sourcePath: 'CHANGELOG.md' },
+    });
+
+    // Commit body comes from the stamped section, not [Unreleased].
+    expect(result.changelogDelta).toContain('Released feature');
+    expect(result.changelogDelta).not.toContain('Work-in-progress');
+
+    // Published CHANGELOG is BYTE-IDENTICAL (both sections preserved, nothing mutated).
+    const changelogContent = readFileSync(safePath.join(outputDir, 'CHANGELOG.md'), 'utf-8');
+    expect(changelogContent).toBe(sourceChangelog);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failures**
+
+Run: `cd packages/cli && bun run test:unit -- publish-tree`
+Expected:
+- `should compose tree...` — **FAIL**: currently writes a stamped copy containing `## [1.0.0] - 2026-04-01`, so `toBe(sourceChangelog)` fails.
+- `should fail when build output does not exist` — PASS (unchanged).
+- `should fail when changelog has neither...` — **FAIL**: current error says "empty [Unreleased] section".
+- `should publish a pre-stamped changelog...` — **FAIL**: current code rejects when `[Unreleased]` is empty.
+- `should prefer stamped [X.Y.Z]...` — **FAIL**: current code stamps, creating a duplicate `[1.2.0]` heading.
+
+- [ ] **Step 3: Implement verbatim copy + dual-source extraction in `publish-tree.ts`**
+
+In `packages/cli/src/commands/claude/marketplace/publish-tree.ts`:
+
+**3a. Update the import on line 14** — remove `stampChangelog` (deleted), add `parseVersionSection`:
+
+```typescript
+import {
+  parseUnreleasedSection,
+  parseVersionSection,
+  readChangelog,
+} from './changelog-utils.js';
+```
+
+**3b. Replace the changelog block (current lines 65–81)** with:
+
+```typescript
+  // 3. Process changelog — VAT copies the source file byte-for-byte into the publish tree.
+  //    We only extract a release-note string for the commit body (changelogDelta).
+  //    Accept both Keep a Changelog workflows:
+  //      (B) pre-stamped `## [version]` section — preferred when present, and
+  //      (A) non-empty `## [Unreleased]` — fallback.
+  //    Error if both are empty.
+  if (options.changelog) {
+    const rawChangelog = readChangelog(options.changelog.sourcePath, configDir);
+
+    const stampedSection = parseVersionSection(rawChangelog, version);
+    const unreleasedSection = parseUnreleasedSection(rawChangelog).trim();
+
+    if (stampedSection !== '') {
+      changelogDelta = stampedSection;
+    } else if (unreleasedSection !== '') {
+      changelogDelta = unreleasedSection;
+    } else {
+      throw new Error(
+        `Changelog "${options.changelog.sourcePath}" has neither a non-empty [Unreleased] ` +
+          `section nor a [${version}] section. Document the release before publishing.`,
+      );
+    }
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path constructed from validated config
+    await writeFile(safePath.join(outputDir, 'CHANGELOG.md'), rawChangelog);
+    files.push('CHANGELOG.md');
+  }
+```
+
+Note: `date` parameter is still destructured in the function signature — it remains in use nowhere now, but keep it in `ComposeOptions` for source compatibility with callers and future use. Actually, double-check: after this change `date` has no remaining users inside `composePublishTree`. Search for other uses.
+
+- [ ] **Step 4: Check whether `date` is still needed in `ComposeOptions`**
+
+Run: `cd packages/cli && grep -n 'date' src/commands/claude/marketplace/publish-tree.ts`
+Expected: `date` only appears in the destructure on line 47 and the interface declaration.
+
+If `date` is truly unused after the change, update the function to stop destructuring it and mark the interface field as reserved-for-future-use **OR** remove it from `ComposeOptions` entirely and drop it from the `buildComposeOptions()` call in `publish.ts:133-140`. Prefer removal — this is pre-1.0 and YAGNI applies.
+
+**If removing `date`:**
+
+In `publish-tree.ts`:
+- Remove `date` from the `ComposeOptions` interface (around line 34).
+- Remove `date` from the destructure on line 47.
+
+In `publish.ts`:
+- Remove `date` from the `buildComposeOptions` function signature and the returned `opts` object (around lines 126–140).
+- Remove `today` and the `date: today` argument from the `publishOneMarketplace` call site (around line 234 and 247).
+- Remove the `date` field from the `PublishOneOptions` interface (around line 159).
+
+**Recheck all tests:** the existing `composePublishTree` test passes a `date: '2026-04-01'` argument. After removing `date` from `ComposeOptions`, TypeScript's `exactOptionalPropertyTypes` will reject extra fields. Remove `date:` from every `composePublishTree(...)` call in the test file (5 occurrences in the updated test file above).
+
+- [ ] **Step 5: Run publish-tree tests to verify they pass**
+
+Run: `cd packages/cli && bun run test:unit -- publish-tree`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 6: Run the full CLI unit test suite**
+
+Run: `cd packages/cli && bun run test:unit`
+Expected: all tests PASS. Any failures are likely in publish.ts tests from removing `date`; update call sites as needed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/cli/src/commands/claude/marketplace/publish-tree.ts \
+        packages/cli/src/commands/claude/marketplace/publish.ts \
+        packages/cli/test/commands/claude/marketplace/publish-tree.test.ts
+git commit -m "fix(cli): marketplace publish mirrors CHANGELOG verbatim
+
+VAT no longer rewrites the CHANGELOG.md it copies into the publish
+tree. The source file is mirrored byte-for-byte and release notes
+flow to the commit body via changelogDelta extraction only.
+
+Accepts both Keep a Changelog workflows:
+- Workflow A: non-empty [Unreleased] (extracted for commit body)
+- Workflow B: pre-stamped [X.Y.Z] matching package.json (preferred)
+
+Benefits:
+- Corrections/typo-fixes to CHANGELOG.md on main propagate to the
+  publish branch on the next publish.
+- main and publish branch never diverge on CHANGELOG contents.
+- Postel's Law: VAT is conservative in what it produces — never
+  mutates files the user maintains.
+- Eliminates the duplicate-heading footgun that would trigger if
+  stampChangelog ran against a pre-stamped changelog.
+
+BREAKING CHANGE: Workflow A adopters whose main branch CHANGELOG
+continues to carry [Unreleased] at publish time will see that
+heading on the publish branch too. To publish a stamped heading,
+stamp CHANGELOG.md on main before tagging (e.g., via bump-version).
+
+Refs: adopter bug report 2026-04-09"
+```
+
+---
+
+## Task 3: Update help text
+
+**Files:**
+- Modify: `packages/cli/src/commands/claude/marketplace/publish.ts` (lines 54–79)
+
+- [ ] **Step 1: Update the `.addHelpText('after', ...)` block**
+
+Replace the existing `.addHelpText('after', ...)` block in `publish.ts` with:
+
+```typescript
+    .addHelpText('after', `
+Description:
+  Pushes built marketplace artifacts to a Git branch for distribution.
+  Requires vat build to have been run first.
+
+  Composes:
+  - Marketplace artifacts from dist/.claude/plugins/marketplaces/
+  - CHANGELOG.md — copied BYTE-FOR-BYTE from the source. Release notes
+    for the commit body are extracted from either a pre-stamped
+    [version] section matching package.json, or (as a fallback) a
+    non-empty [Unreleased] section. Publish fails if neither is
+    present. VAT never mutates CHANGELOG.md.
+  - README.md
+  - LICENSE (SPDX shortcut or file)
+
+  Creates one squashed commit per version on the target branch.
+
+Output:
+  YAML summary -> stdout
+  Progress -> stderr
+
+Exit Codes:
+  0 - Published successfully (or dry-run completed)
+  1 - Publish error (missing build, changelog missing release notes for version)
+  2 - System error
+
+Example:
+  $ vat build && vat claude marketplace publish --no-push  # Create local branch
+  $ git push origin claude-marketplace                     # Push when ready
+`);
+```
+
+- [ ] **Step 2: Rebuild and sanity-check help output**
+
+Run:
+```bash
+cd /Users/jeffdutton/Workspaces/vibe-agent-toolkit
+bun run build
+node packages/cli/dist/bin/vat.js claude marketplace publish --help
+```
+Expected: help text shows the new CHANGELOG.md bullet with "BYTE-FOR-BYTE" and dual-source extraction wording.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/claude/marketplace/publish.ts
+git commit -m "docs(cli): document verbatim changelog behavior in publish help"
+```
+
+---
+
+## Task 4: Full validation + CHANGELOG entry + PR prep
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Run full validation from repo root**
+
+Run: `bun run validate`
+Expected: all checks PASS (unit + integration + system tests, lint, typecheck, duplication-check).
+
+Fix anything reported; re-run `bun run validate` until clean. Likely trouble spots:
+- Lint/duplication failures in the new test file (hoist helpers if needed).
+- Any `date` references I missed when removing it from `ComposeOptions`.
+- System tests that may invoke marketplace publish with a fixture CHANGELOG — update the fixture if it relies on stamping.
+
+- [ ] **Step 2: Add CHANGELOG entry under `[Unreleased]`**
+
+Edit `CHANGELOG.md`. Under the existing `## [Unreleased]` section, add an `### Changed` block (creating it if missing) with:
+
+```markdown
+### Changed
+- **BREAKING: Marketplace publish no longer rewrites `CHANGELOG.md`.** `vat claude marketplace publish` now mirrors the source `CHANGELOG.md` byte-for-byte into the publish tree and extracts release notes for the commit body only. Accepts both Keep a Changelog workflows: a pre-stamped `[X.Y.Z]` section matching `package.json` (preferred) or a non-empty `[Unreleased]` section (fallback). Fails if neither is present. Workflow A adopters whose `main` branch CHANGELOG continues to carry `[Unreleased]` at publish time will see that heading on the publish branch too — stamp `CHANGELOG.md` on `main` before tagging if you want a stamped heading in the published file. Side benefit: corrections/typo-fixes to `CHANGELOG.md` on `main` now propagate to the publish branch on the next publish.
+```
+
+- [ ] **Step 3: Re-run validation after changelog edit**
+
+Run: `bun run validate`
+Expected: all checks PASS. (The CHANGELOG edit is unlikely to affect tests; this run confirms nothing cached is stale.)
+
+- [ ] **Step 4: Ask user about version bump**
+
+Per the Pre-Pull-Request Checklist in `CLAUDE.md`:
+
+> "Changelog updated. This is a breaking change to marketplace publish behavior. Would you like to bump the version or create an RC for this change?"
+
+Wait for the user's answer before committing.
+
+- [ ] **Step 5: Commit the changelog (and version bump if requested)**
+
+If no bump:
+```bash
+git add CHANGELOG.md
+git commit -m "docs: add changelog entry for verbatim marketplace changelog"
+```
+
+If bump requested (replace `<version>`):
+```bash
+bun run bump-version <version>
+git add -A
+git commit -m "chore: bump version to <version>"
+```
+
+- [ ] **Step 6: Dogfood the audit command (best-effort, not a hard gate)**
+
+Per the CLAUDE.md "Dogfooding" guidance, run:
+
+```bash
+bun run vat audit --user --verbose 2>&1 | head -20
+bun run vat audit packages/vat-development-agents/dist/skills/ 2>&1 | head -20
+```
+
+Look for regressions or unexpected errors. This change is to publish, not audit or skills, so no regressions are expected — but run it anyway.
+
+- [ ] **Step 7: Create the PR**
+
+Follow the standard PR creation workflow in `~/.claude/CLAUDE.md` / project CLAUDE.md.
+
+Suggested PR title: `fix(cli): marketplace publish mirrors CHANGELOG verbatim (BREAKING)`
+
+PR body should include:
+- Summary of the behavior change (dual-source extraction, verbatim copy, never mutates).
+- Breaking-change note and migration advice (stamp on main before tagging).
+- Link to the adopter bug report.
+- Test plan: unit tests for `parseVersionSection`, updated compose tests covering all 5 behavior-matrix rows.
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage** — map the behavior matrix to tests:
+
+| Matrix row | Test |
+|---|---|
+| `[Unreleased]` content, no `[version]` → verbatim + extract from `[Unreleased]` | `should compose tree with marketplace artifacts, changelog, readme, and license` |
+| `[Unreleased]` empty, `[version]` present → verbatim + extract from `[version]` | `should publish a pre-stamped changelog when [Unreleased] is empty (Workflow B)` |
+| Both have content → verbatim, prefer `[version]` for commit body | `should prefer stamped [X.Y.Z] over [Unreleased] when both have content` |
+| Both empty → error naming both patterns | `should fail when changelog has neither unreleased content nor matching version section` |
+| `[Unreleased]` empty, `[version]` present but **different** → error | covered by the same "neither" test, which uses `version: '1.0.0'` against a CHANGELOG containing `[0.1.0]` only |
+
+**Placeholder scan:** none. Every step has concrete code or commands.
+
+**Type consistency:**
+- `parseVersionSection(changelog: string, version: string): string` — defined Task 1, used Task 2.
+- `parseUnreleasedSection(changelog: string): string` — unchanged.
+- `stampChangelog` — **deleted**. No residual references.
+- `ComposeOptions.date` — removed (Task 2 Step 4). Any residual reference will fail typecheck in Step 6 and must be cleaned up.
+- `ComposeResult.changelogDelta` — contract unchanged (trimmed release-notes string).
+
+**Edge cases explicitly tested:**
+- Semver pre-release suffix (`1.2.0-rc.1`): regex escape covers `.`, `+`, `-`.
+- Substring non-match (`'1.2'` must NOT match `[1.2.0]`): heading regex anchors on `\]`.
+- Last section in file (no following `## [` heading): `VERSION_HEADING_RE.exec(rest)` returns null, helper returns `rest.trim()`.
+- Verbatim copy byte-identity: compose test uses `toBe(sourceChangelog)`, not `toContain(...)`.
+- Duplicate-heading risk: eliminated by construction (no stamping ever) — tests assert exactly one heading instance where it matters.
+
+**Not changed (intentional):**
+- `publish.ts:233` `readProjectVersion()` — version flow unchanged (still threaded for commit message + log only).
+- `git-publish.ts` `createCommitMessage()` — `changelogDelta` contract unchanged.
+- `UNRELEASED_HEADING_RE`, `VERSION_HEADING_RE` constants — retained.
+- Config schema — no new fields.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-09-marketplace-publish-verbatim-changelog.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. This matches your project preference in `~/.claude/CLAUDE.md` ("always prefer the superpowers subagent driven development skill").
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+**Which approach?**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/claude/marketplace/changelog-utils.ts
+++ b/packages/cli/src/commands/claude/marketplace/changelog-utils.ts
@@ -1,8 +1,11 @@
 /**
- * Changelog parsing and stamping utilities for marketplace publish.
+ * Changelog parsing utilities for marketplace publish.
  *
  * Follows Keep a Changelog format: https://keepachangelog.com/
- * Parses [Unreleased] section and stamps it with version + date on publish.
+ *
+ * Used by publish-tree.ts to extract release-note content for the publish commit body.
+ * VAT does NOT modify the user's CHANGELOG.md file — the published copy is byte-identical
+ * to the source. These helpers only extract content for the commit message.
  */
 
 import { readFileSync } from 'node:fs';
@@ -13,6 +16,11 @@ import { safePath } from '@vibe-agent-toolkit/utils';
  * Regex to match the [Unreleased] heading (case-insensitive).
  */
 const UNRELEASED_HEADING_RE = /^## \[unreleased\]\s*$/im;
+
+/**
+ * Regex to match any stamped version heading (e.g. `## [1.2.0]` or `## [1.2.0-rc.1]`).
+ * Used to find where a section ends (= where the next version heading begins).
+ */
 const VERSION_HEADING_RE = /^## \[\d+\.\d+/m;
 
 /**
@@ -38,11 +46,36 @@ export function parseUnreleasedSection(changelog: string): string {
 }
 
 /**
- * Replace `## [Unreleased]` with `## [version] - date` in changelog text.
- * Returns the full modified changelog string.
+ * Extract the content of a specific stamped version section (e.g. `## [1.2.0] - 2026-04-09`).
+ *
+ * Supports the "pre-stamped" workflow: a repo that promotes `[Unreleased]` to `[X.Y.Z]`
+ * in its release commit before tagging, leaving `[Unreleased]` empty per the Keep a
+ * Changelog canonical post-release state.
+ *
+ * Matches headings of the form `## [<version>]` with any trailing content (date, etc.)
+ * on the same line. Requires an exact version match — `1.2` will NOT match `[1.2.0]`.
+ *
+ * Returns the trimmed content between the matching heading and the next `## [` version
+ * heading (or EOF). Returns empty string if the version section does not exist.
  */
-export function stampChangelog(changelog: string, version: string, date: string): string {
-  return changelog.replace(UNRELEASED_HEADING_RE, `## [${version}] - ${date}`);
+export function parseVersionSection(changelog: string, version: string): string {
+  // Escape regex metacharacters in the version string (dots, hyphens, plus signs cover semver).
+  const escaped = version.replaceAll(/[.+-]/g, String.raw`\$&`);
+  // `## [<version>]` followed by any trailing content on the line (typically ` - date`).
+  // eslint-disable-next-line security/detect-non-literal-regexp -- input escaped above
+  const heading = new RegExp(String.raw`^## \[${escaped}\][^\n]*$`, 'm');
+  const match = heading.exec(changelog);
+  if (!match) {
+    return '';
+  }
+
+  const startIndex = match.index + match[0].length;
+  const rest = changelog.slice(startIndex);
+
+  const nextVersionMatch = VERSION_HEADING_RE.exec(rest);
+  const content = nextVersionMatch ? rest.slice(0, nextVersionMatch.index) : rest;
+
+  return content.trim();
 }
 
 /**

--- a/packages/cli/src/commands/claude/marketplace/git-publish.ts
+++ b/packages/cli/src/commands/claude/marketplace/git-publish.ts
@@ -12,6 +12,7 @@ import { cpSync, mkdtempSync, rmSync } from 'node:fs';
 import { normalizedTmpdir, safePath } from '@vibe-agent-toolkit/utils';
 
 import type { Logger } from '../../../utils/logger.js';
+import { redactUrlCredentials } from '../../../utils/url-redact.js';
 
 export interface CommitMetadata {
   sourceRepo?: string;
@@ -145,7 +146,7 @@ function deliverCommit(
     pushArgs.splice(1, 0, '--force');
   }
   git(pushArgs, { cwd: tmpRepo });
-  logger.info(`   Pushed to ${remoteUrl} branch ${branch}`);
+  logger.info(`   Pushed to ${redactUrlCredentials(remoteUrl)} branch ${branch}`);
 }
 
 /**
@@ -164,7 +165,7 @@ export async function publishToGitBranch(options: PublishGitOptions): Promise<vo
   const cwd = process.cwd();
   const remoteUrl = resolveRemoteUrl(options.remote, cwd);
 
-  logger.info(`   Remote: ${remoteUrl}`);
+  logger.info(`   Remote: ${redactUrlCredentials(remoteUrl)}`);
   logger.info(`   Branch: ${branch}`);
 
   const tmpRepo = mkdtempSync(safePath.join(normalizedTmpdir(), 'vat-marketplace-publish-'));

--- a/packages/cli/src/commands/claude/marketplace/publish-tree.ts
+++ b/packages/cli/src/commands/claude/marketplace/publish-tree.ts
@@ -11,7 +11,11 @@ import { cp, writeFile } from 'node:fs/promises';
 
 import { safePath } from '@vibe-agent-toolkit/utils';
 
-import { parseUnreleasedSection, readChangelog, stampChangelog } from './changelog-utils.js';
+import {
+  parseUnreleasedSection,
+  parseVersionSection,
+  readChangelog,
+} from './changelog-utils.js';
 import { generateLicenseText, readLicenseFile } from './license-utils.js';
 
 export interface ChangelogOptions {
@@ -31,7 +35,6 @@ export interface ComposeOptions {
   configDir: string;
   outputDir: string;
   version: string;
-  date: string;
   changelog?: ChangelogOptions;
   readme?: ReadmeOptions;
   license?: LicenseOptions;
@@ -44,7 +47,7 @@ export interface ComposeResult {
 }
 
 export async function composePublishTree(options: ComposeOptions): Promise<ComposeResult> {
-  const { marketplaceName, configDir, outputDir, version, date } = options;
+  const { marketplaceName, configDir, outputDir, version } = options;
   const files: string[] = [];
   let changelogDelta = '';
 
@@ -61,22 +64,29 @@ export async function composePublishTree(options: ComposeOptions): Promise<Compo
   await cp(buildDir, outputDir, { recursive: true });
   files.push('.claude-plugin/marketplace.json', 'plugins/');
 
-  // 3. Process changelog
+  // 3. Process changelog — VAT copies the source file byte-for-byte into the publish tree.
+  //    We only extract a release-note string for the commit body (changelogDelta).
+  //    Accept both Keep a Changelog workflows:
+  //      (B) pre-stamped `## [version]` section — preferred when present, and
+  //      (A) non-empty `## [Unreleased]` — fallback.
+  //    Error if both are empty.
   if (options.changelog) {
     const rawChangelog = readChangelog(options.changelog.sourcePath, configDir);
-    const unreleased = parseUnreleasedSection(rawChangelog);
 
-    if (unreleased.trim() === '') {
+    const stampedSection = parseVersionSection(rawChangelog, version);
+    const unreleasedSection = parseUnreleasedSection(rawChangelog).trim();
+
+    if (stampedSection === '' && unreleasedSection === '') {
       throw new Error(
-        `Changelog "${options.changelog.sourcePath}" has an empty [Unreleased] section. ` +
-          `Add release notes before publishing.`,
+        `Changelog "${options.changelog.sourcePath}" has neither a non-empty [Unreleased] ` +
+          `section nor a [${version}] section. Document the release before publishing.`,
       );
     }
 
-    changelogDelta = unreleased.trim();
-    const stamped = stampChangelog(rawChangelog, version, date);
+    changelogDelta = stampedSection === '' ? unreleasedSection : stampedSection;
+
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- path constructed from validated config
-    await writeFile(safePath.join(outputDir, 'CHANGELOG.md'), stamped);
+    await writeFile(safePath.join(outputDir, 'CHANGELOG.md'), rawChangelog);
     files.push('CHANGELOG.md');
   }
 

--- a/packages/cli/src/commands/claude/marketplace/publish.ts
+++ b/packages/cli/src/commands/claude/marketplace/publish.ts
@@ -58,7 +58,11 @@ Description:
 
   Composes:
   - Marketplace artifacts from dist/.claude/plugins/marketplaces/
-  - CHANGELOG.md (stamped with version and date)
+  - CHANGELOG.md — copied BYTE-FOR-BYTE from the source. Release notes
+    for the commit body are extracted from either a pre-stamped
+    [version] section matching package.json, or (as a fallback) a
+    non-empty [Unreleased] section. Publish fails if neither is
+    present. VAT never mutates CHANGELOG.md.
   - README.md
   - LICENSE (SPDX shortcut or file)
 
@@ -70,7 +74,7 @@ Output:
 
 Exit Codes:
   0 - Published successfully (or dry-run completed)
-  1 - Publish error (missing build, empty changelog)
+  1 - Publish error (missing build, changelog missing release notes for version)
   2 - System error
 
 Example:
@@ -127,7 +131,6 @@ function buildComposeOptions(
   mpName: string,
   configDir: string,
   version: string,
-  date: string,
   publishConfig: NonNullable<ClaudeMarketplaceConfig['publish']>,
   licenseOpts: LicenseOptions | undefined,
 ): ComposeOptions {
@@ -136,7 +139,6 @@ function buildComposeOptions(
     configDir,
     outputDir: mkdtempSync(safePath.join(normalizedTmpdir(), `vat-publish-tree-${mpName}-`)),
     version,
-    date,
   };
   if (publishConfig.changelog) {
     opts.changelog = { sourcePath: publishConfig.changelog };
@@ -156,7 +158,6 @@ interface PublishOneOptions {
   publishConfig: NonNullable<ClaudeMarketplaceConfig['publish']>;
   configDir: string;
   version: string;
-  date: string;
   options: MarketplacePublishOptions;
   logger: Logger;
 }
@@ -165,7 +166,7 @@ interface PublishOneOptions {
  * Publish a single marketplace and return the result.
  */
 async function publishOneMarketplace(ctx: PublishOneOptions): Promise<PublishResult> {
-  const { mpName, mpConfig, publishConfig, configDir, version, date, options, logger } = ctx;
+  const { mpName, mpConfig, publishConfig, configDir, version, options, logger } = ctx;
   const branch = options.branch ?? publishConfig.branch ?? 'claude-marketplace';
   const remote = publishConfig.remote ?? 'origin';
 
@@ -175,7 +176,7 @@ async function publishOneMarketplace(ctx: PublishOneOptions): Promise<PublishRes
     ? resolveLicenseOptions(publishConfig.license, mpConfig.owner.name)
     : undefined;
 
-  const composeOpts = buildComposeOptions(mpName, configDir, version, date, publishConfig, licenseOpts);
+  const composeOpts = buildComposeOptions(mpName, configDir, version, publishConfig, licenseOpts);
   const composeResult = await composePublishTree(composeOpts);
 
   // Resolve source repo for commit metadata
@@ -231,7 +232,6 @@ async function marketplacePublishCommand(options: MarketplacePublishOptions): Pr
     }
 
     const version = readProjectVersion(configDir);
-    const today = new Date().toISOString().slice(0, 10);
     const results: PublishResult[] = [];
 
     for (const [mpName, mpConfig] of Object.entries(claudeConfig.marketplaces)) {
@@ -244,7 +244,7 @@ async function marketplacePublishCommand(options: MarketplacePublishOptions): Pr
       }
 
       const result = await publishOneMarketplace({
-        mpName, mpConfig, publishConfig: mpConfig.publish, configDir, version, date: today, options, logger,
+        mpName, mpConfig, publishConfig: mpConfig.publish, configDir, version, options, logger,
       });
       results.push(result);
     }

--- a/packages/cli/src/commands/claude/marketplace/publish.ts
+++ b/packages/cli/src/commands/claude/marketplace/publish.ts
@@ -16,6 +16,7 @@ import { Command } from 'commander';
 import { handleCommandError } from '../../../utils/command-error.js';
 import { createLogger, type Logger } from '../../../utils/logger.js';
 import { writeYamlOutput } from '../../../utils/output.js';
+import { redactUrlCredentials } from '../../../utils/url-redact.js';
 import { loadClaudeProjectConfig } from '../claude-config.js';
 
 import { createCommitMessage, publishToGitBranch } from './git-publish.js';
@@ -191,7 +192,7 @@ async function publishOneMarketplace(ctx: PublishOneOptions): Promise<PublishRes
   );
 
   if (options.dryRun) {
-    logger.info(`[dry-run] Would publish to ${remote}/${branch}`);
+    logger.info(`[dry-run] Would publish to ${redactUrlCredentials(remote)}/${branch}`);
     logger.info(`[dry-run] Version: ${version}`);
     logger.info(`[dry-run] Files: ${composeResult.files.join(', ')}`);
   } else if (options.push === false) {

--- a/packages/cli/src/utils/url-redact.ts
+++ b/packages/cli/src/utils/url-redact.ts
@@ -1,0 +1,44 @@
+/**
+ * URL credential redaction for safe logging.
+ *
+ * Git remote URLs in VAT may carry embedded credentials — either because the
+ * user configured a URL with userinfo, or because `resolveRemoteUrl()` injects
+ * a CI token (e.g., `GH_TOKEN`) into HTTPS GitHub URLs for push authentication.
+ * Those URLs must never reach stdout, stderr, or log files in raw form.
+ *
+ * Use `redactUrlCredentials()` on any URL immediately before logging it.
+ * The tokenized URL can still be passed to child `git` processes — only the
+ * logged copy is redacted.
+ */
+
+/**
+ * Strip username and password from a URL string for safe logging.
+ *
+ * - URLs with userinfo (`https://user:pass@host/path`) → userinfo removed.
+ * - URLs without userinfo → returned unchanged.
+ * - Non-URL strings (short remote names like `origin`, SSH-style
+ *   `git@github.com:owner/repo.git`, malformed input) → returned unchanged.
+ *
+ * This uses the standard `URL` constructor. SSH git URLs (`git@host:path`)
+ * are not RFC 3986 URLs and will not parse — they pass through unchanged,
+ * which is safe because they carry no URL-format userinfo anyway.
+ *
+ * @param url A URL string or short remote name.
+ * @returns The input with any URL-format credentials removed.
+ */
+export function redactUrlCredentials(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  if (parsed.username === '' && parsed.password === '') {
+    return url;
+  }
+
+  parsed.username = '';
+  parsed.password = '';
+  return parsed.toString();
+}

--- a/packages/cli/test/commands/claude/marketplace/changelog-utils.test.ts
+++ b/packages/cli/test/commands/claude/marketplace/changelog-utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   parseUnreleasedSection,
-  stampChangelog,
+  parseVersionSection,
 } from '../../../../src/commands/claude/marketplace/changelog-utils.js';
 
 const SAMPLE_CHANGELOG = `# Changelog
@@ -34,6 +34,35 @@ const EMPTY_UNRELEASED = `# Changelog
 - Initial release
 `;
 
+const PRESTAMPED_CHANGELOG = `# Changelog
+
+## [Unreleased]
+
+## [1.2.0] - 2026-04-09
+
+### Added
+- New feature X
+- New feature Y
+
+## [1.1.0] - 2026-03-15
+
+### Fixed
+- Bug Z
+`;
+
+const PRESTAMPED_WITH_UNRELEASED_CONTENT = `# Changelog
+
+## [Unreleased]
+
+### Added
+- Upcoming feature
+
+## [1.2.0] - 2026-04-09
+
+### Added
+- Released feature
+`;
+
 describe('changelog-utils', () => {
   describe('parseUnreleasedSection', () => {
     it('should extract unreleased content', () => {
@@ -55,18 +84,43 @@ describe('changelog-utils', () => {
     });
   });
 
-  describe('stampChangelog', () => {
-    it('should replace [Unreleased] with version and date', () => {
-      const result = stampChangelog(SAMPLE_CHANGELOG, '0.2.0', '2026-04-01');
-      expect(result).toContain('## [0.2.0] - 2026-04-01');
-      expect(result).not.toContain('[Unreleased]');
-      expect(result).toContain('New marketplace publish command');
+  describe('parseVersionSection', () => {
+    it('should extract content of a stamped version section', () => {
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '1.2.0');
+      expect(result).toContain('### Added');
+      expect(result).toContain('New feature X');
+      expect(result).toContain('New feature Y');
+      expect(result).not.toContain('## [1.1.0]');
+      expect(result).not.toContain('Bug Z');
     });
 
-    it('should preserve content before and after unreleased section', () => {
-      const result = stampChangelog(SAMPLE_CHANGELOG, '0.2.0', '2026-04-01');
-      expect(result).toContain('# Changelog');
-      expect(result).toContain('## [0.1.0] - 2026-03-15');
+    it('should extract the last version section (no following heading)', () => {
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '1.1.0');
+      expect(result).toContain('### Fixed');
+      expect(result).toContain('Bug Z');
+    });
+
+    it('should return empty string when the requested version is absent', () => {
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '9.9.9');
+      expect(result.trim()).toBe('');
+    });
+
+    it('should not match substrings of other versions', () => {
+      // '1.2' must NOT match '[1.2.0]' — we require exact version match
+      const result = parseVersionSection(PRESTAMPED_CHANGELOG, '1.2');
+      expect(result.trim()).toBe('');
+    });
+
+    it('should ignore the [Unreleased] section entirely', () => {
+      const result = parseVersionSection(PRESTAMPED_WITH_UNRELEASED_CONTENT, '1.2.0');
+      expect(result).toContain('Released feature');
+      expect(result).not.toContain('Upcoming feature');
+    });
+
+    it('should handle versions with pre-release suffixes', () => {
+      const changelog = `# Changelog\n\n## [Unreleased]\n\n## [1.2.0-rc.1] - 2026-04-09\n\n### Added\n- RC feature\n`;
+      const result = parseVersionSection(changelog, '1.2.0-rc.1');
+      expect(result).toContain('RC feature');
     });
   });
 });

--- a/packages/cli/test/commands/claude/marketplace/publish-tree.test.ts
+++ b/packages/cli/test/commands/claude/marketplace/publish-tree.test.ts
@@ -14,6 +14,19 @@ function makeTempDir(tempDirs: string[]): string {
   return dir;
 }
 
+/**
+ * Create a minimal marketplace build output under sourceDir so composePublishTree
+ * can find it. Returns the marketplace name used.
+ */
+function seedMarketplaceBuild(sourceDir: string, mpName = 'test-mp'): string {
+  const pluginDir = safePath.join(
+    sourceDir, 'dist', '.claude', 'plugins', 'marketplaces', mpName, '.claude-plugin',
+  );
+  mkdirSyncReal(pluginDir, { recursive: true });
+  writeFileSync(safePath.join(pluginDir, 'marketplace.json'), `{"name":"${mpName}"}`);
+  return mpName;
+}
+
 describe('publish-tree', () => {
   const tempDirs: string[] = [];
 
@@ -27,25 +40,17 @@ describe('publish-tree', () => {
   it('should compose tree with marketplace artifacts, changelog, readme, and license', async () => {
     const sourceDir = makeTempDir(tempDirs);
     const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
 
-    // Create mock marketplace build output
-    const mpDir = safePath.join(sourceDir, 'dist', '.claude', 'plugins', 'marketplaces', 'test-mp');
-    const pluginDir = safePath.join(mpDir, '.claude-plugin');
-    mkdirSyncReal(pluginDir, { recursive: true });
-    writeFileSync(safePath.join(pluginDir, 'marketplace.json'), '{"name":"test-mp"}');
-
-    // Create changelog source
-    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), '# Changelog\n\n## [Unreleased]\n\n### Added\n- Feature\n');
-
-    // Create readme source
+    const sourceChangelog = '# Changelog\n\n## [Unreleased]\n\n### Added\n- Feature\n';
+    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), sourceChangelog);
     writeFileSync(safePath.join(sourceDir, 'README.md'), '# My Marketplace\n');
 
     const result = await composePublishTree({
-      marketplaceName: 'test-mp',
+      marketplaceName: mpName,
       configDir: sourceDir,
       outputDir,
       version: '1.0.0',
-      date: '2026-04-01',
       changelog: { sourcePath: 'CHANGELOG.md' },
       readme: { sourcePath: 'README.md' },
       license: { type: 'spdx', value: 'mit', ownerName: 'Test Org' },
@@ -57,9 +62,13 @@ describe('publish-tree', () => {
     expect(existsSync(safePath.join(outputDir, 'LICENSE'))).toBe(true);
     expect(result.version).toBe('1.0.0');
 
-    // Changelog should be stamped
+    // CHANGELOG must be copied BYTE-FOR-BYTE — no stamping, no mutation.
     const changelogContent = readFileSync(safePath.join(outputDir, 'CHANGELOG.md'), 'utf-8');
-    expect(changelogContent).toContain('[1.0.0] - 2026-04-01');
+    expect(changelogContent).toBe(sourceChangelog);
+
+    // Release notes still flow to the commit body via changelogDelta.
+    expect(result.changelogDelta).toContain('### Added');
+    expect(result.changelogDelta).toContain('- Feature');
   });
 
   it('should fail when build output does not exist', async () => {
@@ -71,29 +80,80 @@ describe('publish-tree', () => {
       configDir: sourceDir,
       outputDir,
       version: '1.0.0',
-      date: '2026-04-01',
     })).rejects.toThrow(/build output/i);
   });
 
-  it('should fail when changelog has empty unreleased section', async () => {
+  it('should fail when changelog has neither unreleased content nor matching version section', async () => {
     const sourceDir = makeTempDir(tempDirs);
     const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
 
-    // Create marketplace build output
-    const mpDir = safePath.join(sourceDir, 'dist', '.claude', 'plugins', 'marketplaces', 'test-mp', '.claude-plugin');
-    mkdirSyncReal(mpDir, { recursive: true });
-    writeFileSync(safePath.join(mpDir, 'marketplace.json'), '{}');
-
-    // Empty unreleased changelog
-    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), '# Changelog\n\n## [Unreleased]\n\n## [0.1.0]\n');
+    // Empty [Unreleased] and a stamped section for a DIFFERENT version
+    writeFileSync(
+      safePath.join(sourceDir, 'CHANGELOG.md'),
+      '# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2026-01-01\n\n### Added\n- Old\n',
+    );
 
     await expect(composePublishTree({
-      marketplaceName: 'test-mp',
+      marketplaceName: mpName,
       configDir: sourceDir,
       outputDir,
       version: '1.0.0',
-      date: '2026-04-01',
       changelog: { sourcePath: 'CHANGELOG.md' },
-    })).rejects.toThrow(/empty/i);
+    })).rejects.toThrow(/neither.*\[Unreleased\].*nor.*\[1\.0\.0\]/i);
+  });
+
+  it('should publish a pre-stamped changelog when [Unreleased] is empty (Workflow B)', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
+
+    const sourceChangelog =
+      '# Changelog\n\n## [Unreleased]\n\n## [1.2.0] - 2026-04-09\n\n### Added\n- New feature X\n- New feature Y\n\n## [1.1.0] - 2026-03-15\n\n### Fixed\n- Old bug\n';
+    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), sourceChangelog);
+
+    const result = await composePublishTree({
+      marketplaceName: mpName,
+      configDir: sourceDir,
+      outputDir,
+      version: '1.2.0',
+      changelog: { sourcePath: 'CHANGELOG.md' },
+    });
+
+    expect(result.version).toBe('1.2.0');
+    // Commit body uses the stamped [1.2.0] section, not [Unreleased] and not [1.1.0].
+    expect(result.changelogDelta).toContain('New feature X');
+    expect(result.changelogDelta).toContain('New feature Y');
+    expect(result.changelogDelta).not.toContain('Old bug');
+
+    // Published CHANGELOG is BYTE-IDENTICAL to source.
+    const changelogContent = readFileSync(safePath.join(outputDir, 'CHANGELOG.md'), 'utf-8');
+    expect(changelogContent).toBe(sourceChangelog);
+  });
+
+  it('should prefer stamped [X.Y.Z] over [Unreleased] when both have content', async () => {
+    const sourceDir = makeTempDir(tempDirs);
+    const outputDir = makeTempDir(tempDirs);
+    const mpName = seedMarketplaceBuild(sourceDir);
+
+    const sourceChangelog =
+      '# Changelog\n\n## [Unreleased]\n\n### Added\n- Work-in-progress for next release\n\n## [1.2.0] - 2026-04-09\n\n### Added\n- Released feature\n';
+    writeFileSync(safePath.join(sourceDir, 'CHANGELOG.md'), sourceChangelog);
+
+    const result = await composePublishTree({
+      marketplaceName: mpName,
+      configDir: sourceDir,
+      outputDir,
+      version: '1.2.0',
+      changelog: { sourcePath: 'CHANGELOG.md' },
+    });
+
+    // Commit body comes from the stamped section, not [Unreleased].
+    expect(result.changelogDelta).toContain('Released feature');
+    expect(result.changelogDelta).not.toContain('Work-in-progress');
+
+    // Published CHANGELOG is BYTE-IDENTICAL (both sections preserved, nothing mutated).
+    const changelogContent = readFileSync(safePath.join(outputDir, 'CHANGELOG.md'), 'utf-8');
+    expect(changelogContent).toBe(sourceChangelog);
   });
 });

--- a/packages/cli/test/utils/url-redact.test.ts
+++ b/packages/cli/test/utils/url-redact.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactUrlCredentials } from '../../src/utils/url-redact.js';
+
+const CLEAN_GITHUB_URL = 'https://github.com/owner/repo.git';
+
+describe('redactUrlCredentials', () => {
+  it('should strip x-access-token credentials from HTTPS GitHub URLs', () => {
+    const withXAccessToken = 'https://x-access-token:gho_FAKE@github.com/owner/repo.git';
+    expect(redactUrlCredentials(withXAccessToken)).toBe(CLEAN_GITHUB_URL);
+  });
+
+  it('should strip username:password credentials', () => {
+    const withCreds = 'https://alice:hunter2@example.com/repo';
+    expect(redactUrlCredentials(withCreds)).toBe('https://example.com/repo');
+  });
+
+  it('should strip a bare token used as username', () => {
+    const withBareToken = 'https://gho_FAKE@github.com/owner/repo.git';
+    expect(redactUrlCredentials(withBareToken)).toBe(CLEAN_GITHUB_URL);
+  });
+
+  it('should return HTTPS URLs without credentials unchanged', () => {
+    expect(redactUrlCredentials(CLEAN_GITHUB_URL)).toBe(CLEAN_GITHUB_URL);
+  });
+
+  it('should return short remote names unchanged', () => {
+    expect(redactUrlCredentials('origin')).toBe('origin');
+    expect(redactUrlCredentials('upstream')).toBe('upstream');
+  });
+
+  it('should return SSH-style git URLs unchanged (not RFC 3986 URLs)', () => {
+    // git@github.com:owner/repo.git is not parsed by URL(); passes through.
+    // Safe: SSH URLs carry no URL-format userinfo.
+    const ssh = 'git@github.com:owner/repo.git';
+    expect(redactUrlCredentials(ssh)).toBe(ssh);
+  });
+
+  it('should return malformed input unchanged', () => {
+    expect(redactUrlCredentials('')).toBe('');
+    expect(redactUrlCredentials('not a url')).toBe('not a url');
+  });
+
+  it('should preserve @ in pathnames (not userinfo)', () => {
+    // An '@' after the host is part of the path, not userinfo.
+    const pathWithAt = 'https://github.com/owner/repo@tag';
+    expect(redactUrlCredentials(pathWithAt)).toBe(pathWithAt);
+  });
+
+  it('should strip credentials from URLs with non-default ports', () => {
+    const withPort = 'https://user:token@gitlab.example.com:8443/group/repo.git';
+    expect(redactUrlCredentials(withPort)).toBe('https://gitlab.example.com:8443/group/repo.git');
+  });
+
+  it('should strip username-only credentials (no password)', () => {
+    const userOnly = 'https://alice@example.com/repo';
+    expect(redactUrlCredentials(userOnly)).toBe('https://example.com/repo');
+  });
+});

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.24",
+  "version": "0.1.25-rc.1",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.25-rc.2",
+  "version": "0.1.25",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.25-rc.1",
+  "version": "0.1.25-rc.2",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **BREAKING:** `vat claude marketplace publish` no longer rewrites `CHANGELOG.md`. The source file is mirrored byte-for-byte into the publish tree and release notes flow only to the commit body via `changelogDelta`.
- Accepts both Keep a Changelog workflows: **Workflow B** (pre-stamped `[X.Y.Z]` section, preferred) or **Workflow A** (non-empty `[Unreleased]`, fallback). Fails if neither is present.
- Fixes an adopter-reported bug where publish produced a CHANGELOG with a duplicate `[X.Y.Z]` heading when the source was already pre-stamped.

## Why

`stampChangelog()` unconditionally replaced `## [Unreleased]` with `## [X.Y.Z] - YYYY-MM-DD` in the copied file. Three problems:

1. **Duplicate headings on pre-stamped CHANGELOGs.** Adopters following the canonical Keep a Changelog promote-on-release workflow had a second `[1.2.0]` injected next to the real one.
2. **main and publish branch drift.** The publish branch had a stamped heading that main didn't. Typo fixes to CHANGELOG.md on main never reached the publish branch.
3. **Postel's Law violation.** VAT was being liberal in what it produced (mutating a user-maintained file).

## Migration

**Workflow A adopters** whose `main` branch CHANGELOG continues to carry `[Unreleased]` at publish time will see that heading on the publish branch too — an honest mirror. If you want a stamped heading on the publish branch, stamp `CHANGELOG.md` on `main` before tagging (e.g., via `bump-version` or by promoting `[Unreleased]` → `[X.Y.Z]` in your release commit).

**Workflow B adopters** (pre-stamping) get the cleaner behavior for free — no migration needed.

## Changes

- `packages/cli/src/commands/claude/marketplace/changelog-utils.ts` — deleted `stampChangelog()`, added `parseVersionSection()` with semver pre-release support
- `packages/cli/src/commands/claude/marketplace/publish-tree.ts` — copies CHANGELOG byte-for-byte; extracts commit body via `parseVersionSection` → `parseUnreleasedSection` fallback; removed unused `date` field from `ComposeOptions`
- `packages/cli/src/commands/claude/marketplace/publish.ts` — removed `date` plumbing (YAGNI, pre-1.0); updated `--help` to document verbatim behavior
- Version bump to `0.1.25-rc.1` for adopter testing before stable

## Test plan

- [x] Unit tests for `parseVersionSection` covering: stamped extraction, last-section-at-EOF, absent version, substring non-match (`1.2` must not match `[1.2.0]`), `[Unreleased]` isolation, semver pre-release suffix
- [x] Unit tests for `composePublishTree` covering all 5 rows of the behavior matrix (Workflow A, Workflow B, both populated, both empty, `[Unreleased]` empty + `[version]` for different version)
- [x] `bun run validate` — all 3 phases / 14 steps green on darwin
- [ ] **Post-merge:** test RC on an adopter repo (Jeff will do this before promoting to stable)

## Behavior matrix

| `[Unreleased]` content | `[version]` section | Outcome | `changelogDelta` source | Published CHANGELOG.md |
|---|---|---|---|---|
| content | absent | publishes | `[Unreleased]` content | verbatim copy |
| empty | present | publishes | `[version]` content | verbatim copy |
| content | present | publishes | `[version]` (prefer stamped) | verbatim copy |
| empty | absent | error | n/a | n/a |
| empty | present for different version | error | n/a | n/a |

Refs: adopter bug report 2026-04-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)