### PR TITLE
fix(dev-tools): pre-release checks + CHANGELOG auto-stamp + v0.1.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.27] - 2026-04-11
+
 ### Breaking
 - **Removed top-level `vat install` command.** Install of flat skills now uses `vat skills install <source> --target <target> --scope <user|project>`. Install of Claude plugins uses `vat claude plugin install <source>`.
 
 ### Added
 - `vat skills install <source> --target <target> --scope <user|project>` — cross-platform flat skill installer. Supports 7 targets (claude, codex, copilot, gemini, cursor, windsurf, agents) and 2 scopes (user, project). Sources: local directory, `.zip`, `.tgz`, or `npm:@scope/package`. Pre-verifies all skills before touching the filesystem (all-or-nothing).
 - `vat skills list npm:@scope/package` — inspect what skills are in an npm package without installing.
+- `bun run pre-release` — pre-tag validation command that confirms CHANGELOG is stamped, no stale tags exist on remote, marketplace dry-run passes, and version section has content. Prevents failed CI publishes from unready state.
+- `bun run bump-version` now auto-stamps CHANGELOG.md for stable versions — moves `[Unreleased]` content under a new `## [X.Y.Z] - date` heading. Safety guards: fails if `[Unreleased]` is empty, refuses to stamp if version already exists in CHANGELOG (prevents corruption from backward bumps or re-stamps). Skips for RC/prerelease versions.
+
+### Fixed
+- **CHANGELOG check in pre-publish no longer skipped during `bun run validate`** — the CHANGELOG stamp check was incorrectly gated behind `--skip-git-checks` (a git check flag), but it's a content check. Now runs unconditionally.
 
 ### Changed
 - Published VAT skills updated to describe the new `vat skills install` command surface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,12 +513,25 @@ bun run vat audit packages/vat-development-agents/dist/skills/
 
 2. **Ask about version bump** — Ask the developer: *"Would you like to bump the version or create an RC for this change?"*
    - If yes: run `bun run bump-version <version>` (e.g., `0.1.16-rc.5`) and commit the version bump
+   - For **stable** versions, `bump-version` auto-stamps CHANGELOG.md (moves `[Unreleased]` content under a new `## [X.Y.Z] - date` heading)
    - If no: proceed with just the changelog update
    - RC versions (e.g., `0.1.16-rc.5`) stay in the `[Unreleased]` section — they are NOT given their own version heading
 
 3. **Run `bun run validate`** one final time after the changelog/version changes to ensure nothing broke
 
 **For AI assistants:** This is a hard gate. Do NOT create a PR without updating the changelog and asking about the version bump first. Forgetting this creates extra work for the maintainer.
+
+### Pre-Release Checklist (MANDATORY — before tagging)
+
+**After the PR is merged to main, ALWAYS run the pre-release check BEFORE creating any version tag:**
+
+1. **Run `bun run pre-release`** — Confirms CHANGELOG is stamped, no stale tags on remote, marketplace dry-run passes, and version section has content.
+2. **Only after pre-release passes:** Tag: `git tag v{version}`
+3. **Push:** `git push origin main v{version}`
+
+**Why this matters:** CI publish is triggered by the tag push. If CHANGELOG isn't stamped or artifacts aren't built, the publish fails and you have to delete the tag and re-do it. `bun run pre-release` catches all of these issues locally before you create the tag.
+
+**For AI assistants:** Never suggest tagging without running `bun run pre-release` first. This is non-negotiable.
 
 ### Running vat CLI During Development
 
@@ -595,9 +608,10 @@ See [packages/cli/CLAUDE.md](packages/cli/CLAUDE.md) for more CLI development gu
 See [docs/publishing.md](docs/publishing.md) for complete publishing workflow, versioning, and rollback procedures.
 
 **Quick Reference:**
-- Use `bun run bump-version <version>` for all version changes
+- Use `bun run bump-version <version>` for all version changes (stable bumps auto-stamp CHANGELOG)
 - All packages share same version (unified versioning)
 - RC versions stay in `[Unreleased]` section of CHANGELOG
+- **ALWAYS run `bun run pre-release` before tagging** — validates CHANGELOG, tag, and marketplace
 - Publishing is triggered by pushing a git tag: `git tag vX.Y.Z && git push origin main vX.Y.Z`
 - GitHub Actions then auto-publishes to npm and creates the GitHub release
 - Commands: `bun run build`, `bun run build:clean`

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prepare": "husky",
     "bump-version": "tsx packages/dev-tools/src/bump-version.ts",
     "pre-publish": "tsx packages/dev-tools/src/pre-publish-check.ts",
+    "pre-release": "tsx packages/dev-tools/src/pre-publish-check.ts --release-readiness",
     "determine-publish-tags": "tsx packages/dev-tools/src/determine-publish-tags.ts",
     "publish-with-rollback": "tsx packages/dev-tools/src/publish-with-rollback.ts",
     "extract-changelog": "tsx packages/dev-tools/src/extract-changelog.ts",

--- a/packages/dev-tools/src/bump-version.ts
+++ b/packages/dev-tools/src/bump-version.ts
@@ -37,6 +37,29 @@ import semver from 'semver';
 import { PROJECT_ROOT, log, processWorkspacePackages, type PackageProcessResult } from './common.js';
 
 const PACKAGE_JSON = 'package.json';
+const CHANGELOG_PATH = safePath.join(PROJECT_ROOT, 'CHANGELOG.md');
+const UNRELEASED_HEADING = '## [Unreleased]';
+
+interface ChangelogUnreleasedSection {
+  content: string;
+  body: string;
+  unreleasedIndex: number;
+  afterHeading: number;
+  nextSectionOffset: number;
+}
+
+function parseChangelogUnreleased(): ChangelogUnreleasedSection {
+  const content = readFileSync(CHANGELOG_PATH, 'utf8');
+  const unreleasedIndex = content.indexOf(UNRELEASED_HEADING);
+  if (unreleasedIndex === -1) {
+    throw new Error('CHANGELOG.md is missing the [Unreleased] section');
+  }
+  const afterHeading = unreleasedIndex + UNRELEASED_HEADING.length;
+  const nextSectionMatch = /\n## \[/.exec(content.slice(afterHeading));
+  const nextSectionOffset = nextSectionMatch?.index ?? content.slice(afterHeading).length;
+  const body = content.slice(afterHeading, afterHeading + nextSectionOffset);
+  return { content, body, unreleasedIndex, afterHeading, nextSectionOffset };
+}
 
 // Parse command-line arguments
 const args = process.argv.slice(2);
@@ -140,6 +163,35 @@ if (['patch', 'minor', 'major'].includes(versionArg)) {
     log(`✗ Invalid version format: ${newVersion}`, 'red');
     log('  Expected format: X.Y.Z or X.Y.Z-prerelease', 'yellow');
     log('  Examples: 1.0.0, 2.0.0, 1.0.0-beta.1, patch, minor, major', 'yellow');
+    process.exit(1);
+  }
+}
+
+// Pre-flight: validate CHANGELOG before touching any files (prevents dirty state on failure)
+const isPrerelease = semver.prerelease(newVersion) !== null;
+if (!isPrerelease) {
+  try {
+    const { content, body } = parseChangelogUnreleased();
+
+    // Safety: refuse to stamp if this version already exists in CHANGELOG
+    const escapedVersion = newVersion.replaceAll('.', String.raw`\.`);
+    // eslint-disable-next-line security/detect-non-literal-regexp -- version is from CLI arg, already validated by semver
+    const existingPattern = new RegExp(String.raw`^## \[${escapedVersion}\]`, 'm');
+    if (existingPattern.test(content)) {
+      log(`✗ CHANGELOG.md already has an entry for [${newVersion}]. Refusing to stamp to avoid corruption.`, 'red');
+      console.log('  If you need to re-stamp, manually remove the existing entry first.');
+      process.exit(1);
+    }
+
+    if (!body.trim()) {
+      log('✗ CHANGELOG.md has no content under [Unreleased]. Add release notes before bumping to a stable version.', 'red');
+      process.exit(1);
+    }
+
+    log('✓ CHANGELOG.md pre-flight check passed', 'green');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`✗ Failed to validate CHANGELOG.md: ${message}`, 'red');
     process.exit(1);
   }
 }
@@ -267,12 +319,42 @@ try {
   log('  You may need to run "bun install" manually', 'yellow');
 }
 
+// Stamp CHANGELOG.md for stable releases (pre-flight already validated, just do the write)
+if (isPrerelease) {
+  log('⊘ CHANGELOG stamp skipped (prerelease version)', 'yellow');
+} else {
+  try {
+    const { content, body, afterHeading, nextSectionOffset } = parseChangelogUnreleased();
+    const today = new Date().toISOString().split('T')[0] ?? '';
+    const versionHeading = `## [${newVersion}] - ${today}`;
+
+    const before = content.slice(0, afterHeading);
+    const after = content.slice(afterHeading + nextSectionOffset);
+    const updatedChangelog = `${before}\n\n${versionHeading}\n${body.replace(/^\n/, '')}${after}`;
+
+    writeFileSync(CHANGELOG_PATH, updatedChangelog, 'utf8');
+    log(`✓ CHANGELOG.md stamped for v${newVersion}`, 'green');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log(`✗ Failed to stamp CHANGELOG.md: ${message}`, 'red');
+    process.exit(1);
+  }
+}
+
 console.log('');
 console.log('Next steps:');
 console.log(`  1. Review changes: git diff`);
-console.log(`  2. Commit: git add -A && git commit -m "chore: Release v${newVersion}"`);
-console.log(`  3. Tag: git tag v${newVersion}`);
-console.log(`  4. Push: git push origin main && git push origin v${newVersion}`);
+console.log(`  2. Commit: git add -A && git commit -m "chore: bump version to v${newVersion}"`);
+if (isPrerelease) {
+  console.log(`  3. Push: git push origin main`);
+  console.log(`  (RC versions are not tagged — content stays under [Unreleased] in CHANGELOG)`);
+} else {
+  console.log(`  3. Merge to main, then run: bun run pre-release`);
+  console.log(`  4. Only after pre-release passes: git tag v${newVersion}`);
+  console.log(`  5. Push: git push origin main v${newVersion}`);
+  console.log('');
+  log('⚠ Do NOT tag until bun run pre-release passes. Tags trigger CI publish.', 'yellow');
+}
 console.log('');
 
 process.exit(0);

--- a/packages/dev-tools/src/pre-publish-check.ts
+++ b/packages/dev-tools/src/pre-publish-check.ts
@@ -12,12 +12,17 @@
  * 8. Workspace dependencies are correct
  * 9. All packages have proper "files" field
  * 10. All packages have required metadata (repository, author, license)
- * 11. CHANGELOG.md has entry for current version (publish mode only)
+ * 11. CHANGELOG.md has entry for current version
+ *
+ * Release-readiness checks (--release-readiness only):
  * 12. Marketplace publish dry-run (validates build artifacts, changelog, tree composition)
+ * 13. Tag doesn't already exist on remote
+ * 14. No stale unreleased content (stable versions only)
+ * 15. CHANGELOG section non-empty (stable versions only)
  *
  * Usage:
- *   tsx tools/pre-publish-check.ts [--allow-branch BRANCH] [--skip-git-checks]
- *   bun run pre-publish [--allow-branch BRANCH] [--skip-git-checks]
+ *   tsx tools/pre-publish-check.ts [--allow-branch BRANCH] [--skip-git-checks] [--release-readiness]
+ *   bun run pre-publish [--allow-branch BRANCH] [--skip-git-checks] [--release-readiness]
  *
  * Exit codes:
  *   0 - Ready to publish
@@ -81,6 +86,7 @@ const args = process.argv.slice(2);
 let allowedBranch = 'main';
 let allowCustomBranch = false;
 let skipGitChecks = false;
+let releaseReadiness = false;
 
 let i = 0;
 while (i < args.length) {
@@ -89,9 +95,11 @@ while (i < args.length) {
     allowedBranch = nextArg;
     allowCustomBranch = true;
     i += 2;
+    continue;
   } else if (args[i] === '--skip-git-checks') {
     skipGitChecks = true;
-    i += 1;
+  } else if (args[i] === '--release-readiness') {
+    releaseReadiness = true;
   } else if (args[i] === '--help' || args[i] === '-h') {
     console.log(`
 Pre-Publish Validation Check
@@ -104,6 +112,11 @@ Options:
   --allow-branch BRANCH  Allow publishing from a specific branch (default: main)
   --skip-git-checks      Skip git-related checks (branch, uncommitted changes, untracked files)
                          Use this when running in vibe-validate during development
+  --release-readiness    Run additional release-readiness checks:
+                           - Marketplace publish dry-run
+                           - Tag doesn't already exist on remote
+                           - No stale unreleased content
+                           - CHANGELOG section non-empty
   --help, -h             Show this help message
 
 Exit codes:
@@ -529,73 +542,80 @@ try {
   process.exit(1);
 }
 
-// Check 11: CHANGELOG.md has entry for current version (skip in development mode)
-if (skipGitChecks) {
-  log('⊘ CHANGELOG check skipped (development mode)', 'yellow');
-} else {
-  console.log('');
-  console.log('Checking CHANGELOG.md...');
+// Check 11: CHANGELOG.md has entry for current version (content check, always runs)
+console.log('');
+console.log('Checking CHANGELOG.md...');
 
-  try {
-    // Read version from umbrella package (monorepo canonical version)
-    const umbrellaPkgJsonPath = safePath.join(packagesDir, 'vibe-agent-toolkit', 'package.json');
-    if (!existsSync(umbrellaPkgJsonPath)) {
-      throw new Error('Umbrella package (vibe-agent-toolkit) package.json not found');
-    }
+// Read version from umbrella package (monorepo canonical version) — hoisted for use by release-readiness checks
+let currentVersion: string;
+try {
+  const umbrellaPkgJsonPath = safePath.join(packagesDir, 'vibe-agent-toolkit', 'package.json');
+  if (!existsSync(umbrellaPkgJsonPath)) {
+    throw new Error('Umbrella package (vibe-agent-toolkit) package.json not found');
+  }
 
-    const umbrellaPkgJson = JSON.parse(readFileSync(umbrellaPkgJsonPath, 'utf8')) as Record<string, unknown>;
-    const version = umbrellaPkgJson['version'];
-    if (typeof version !== 'string') {
-      throw new TypeError('Version not found in umbrella package (vibe-agent-toolkit) package.json');
-    }
+  const umbrellaPkgJson = JSON.parse(readFileSync(umbrellaPkgJsonPath, 'utf8')) as Record<string, unknown>;
+  const version = umbrellaPkgJson['version'];
+  if (typeof version !== 'string') {
+    throw new TypeError('Version not found in umbrella package (vibe-agent-toolkit) package.json');
+  }
+  currentVersion = version;
+} catch (error) {
+  log('✗ Failed to read version from umbrella package', 'red');
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+}
 
-    // Read CHANGELOG.md
-    const changelogPath = safePath.join(PROJECT_ROOT, 'CHANGELOG.md');
-    if (!existsSync(changelogPath)) {
-      log('✗ CHANGELOG.md not found', 'red');
-      console.log('  Create CHANGELOG.md to document releases');
+try {
+  // Read CHANGELOG.md
+  const changelogPath = safePath.join(PROJECT_ROOT, 'CHANGELOG.md');
+  if (!existsSync(changelogPath)) {
+    log('✗ CHANGELOG.md not found', 'red');
+    console.log('  Create CHANGELOG.md to document releases');
+    process.exit(1);
+  }
+
+  // Skip CHANGELOG check for prerelease versions (RC, alpha, beta, etc.)
+  const isPrerelease = /-(rc|alpha|beta|dev|canary)\./i.test(currentVersion);
+  if (isPrerelease) {
+    log(`⊘ CHANGELOG check skipped (prerelease version: ${currentVersion})`, 'yellow');
+  } else {
+    const changelogContent = readFileSync(changelogPath, 'utf8');
+
+    // Look for version entry: ## [X.Y.Z] - YYYY-MM-DD
+    // Escape dots in version string for regex matching
+    const escapedVersion = currentVersion.replaceAll('.', String.raw`\.`);
+    // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
+    const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\] - \d{4}-\d{2}-\d{2}`, 'm');
+
+    if (!versionPattern.test(changelogContent)) {
+      log(`✗ CHANGELOG.md missing entry for version ${currentVersion}`, 'red');
+      console.log('');
+      console.log('  Recovery instructions:');
+      console.log(`  1. Add version entry to CHANGELOG.md:`);
+      console.log(`     ## [${currentVersion}] - ${String(new Date().toISOString().split('T')[0] ?? '')}`);
+      console.log('  2. Document changes under the version header');
+      console.log('  3. Run pre-publish-check again');
+      console.log('');
       process.exit(1);
     }
 
-    // Skip CHANGELOG check for prerelease versions (RC, alpha, beta, etc.)
-    const isPrerelease = /-(rc|alpha|beta|dev|canary)\./i.test(version);
-    if (isPrerelease) {
-      log(`⊘ CHANGELOG check skipped (prerelease version: ${version})`, 'yellow');
-    } else {
-      const changelogContent = readFileSync(changelogPath, 'utf8');
-
-      // Look for version entry: ## [X.Y.Z] - YYYY-MM-DD
-      // Escape dots in version string for regex matching
-      const escapedVersion = version.replaceAll('.', String.raw`\.`);
-      // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
-      const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\] - \d{4}-\d{2}-\d{2}`, 'm');
-
-      if (!versionPattern.test(changelogContent)) {
-        log(`✗ CHANGELOG.md missing entry for version ${version}`, 'red');
-        console.log('');
-        console.log('  Recovery instructions:');
-        console.log(`  1. Add version entry to CHANGELOG.md:`);
-        console.log(`     ## [${version}] - ${String(new Date().toISOString().split('T')[0] ?? '')}`);
-        console.log('  2. Document changes under the version header');
-        console.log('  3. Run pre-publish-check again');
-        console.log('');
-        process.exit(1);
-      }
-
-      log(`✓ CHANGELOG.md has entry for version ${version}`, 'green');
-    }
-  } catch (error) {
-    log('✗ Failed to check CHANGELOG.md', 'red');
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(message);
-    process.exit(1);
+    log(`✓ CHANGELOG.md has entry for version ${currentVersion}`, 'green');
   }
+} catch (error) {
+  log('✗ Failed to check CHANGELOG.md', 'red');
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
 }
 
-// Check 12: Marketplace publish dry-run (validates build artifacts, changelog, tree composition)
-if (skipGitChecks) {
-  log('⊘ Marketplace dry-run skipped (development mode)', 'yellow');
-} else {
+// Release-readiness checks (only when --release-readiness is passed)
+if (releaseReadiness) {
+  console.log('');
+  console.log('Running release-readiness checks...');
+
+  // Check 12: Marketplace publish dry-run (validates build artifacts, changelog, tree composition)
   console.log('');
   console.log('Checking marketplace publish readiness...');
 
@@ -619,18 +639,98 @@ if (skipGitChecks) {
   } else {
     log('⊘ Marketplace dry-run skipped (no vat-development-agents config)', 'yellow');
   }
+
+  // Check 13: Tag doesn't already exist on remote
+  console.log('');
+  console.log(`Checking remote tag v${currentVersion}...`);
+
+  {
+    const tagResult = safeExecResult('git', ['ls-remote', '--tags', 'origin', `refs/tags/v${currentVersion}`], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+
+    if (tagResult.success && tagResult.stdout.trim().length > 0) {
+      log(`✗ v${currentVersion} tag already exists on remote`, 'red');
+      console.log(`  The tag v${currentVersion} has already been pushed to the remote.`);
+      console.log('  Bump the version before releasing.');
+      process.exit(1);
+    }
+
+    log(`✓ v${currentVersion} tag does not exist on remote`, 'green');
+  }
+
+  // Check 14 & 15: CHANGELOG content checks (stable versions only)
+  const isPrerelease = /-(rc|alpha|beta|dev|canary)\./i.test(currentVersion);
+  if (isPrerelease) {
+    log(`⊘ CHANGELOG content checks skipped (prerelease version: ${currentVersion})`, 'yellow');
+  } else {
+    const changelogPath = safePath.join(PROJECT_ROOT, 'CHANGELOG.md');
+    const changelogContent = readFileSync(changelogPath, 'utf8');
+
+    // Check 14: No stale unreleased content
+    // If the version IS stamped (has ## [version] heading) but no tag exists on remote,
+    // and [Unreleased] has content, warn.
+    console.log('');
+    console.log('Checking for stale unreleased content...');
+
+    {
+      const escapedVersion = currentVersion.replaceAll('.', String.raw`\.`);
+      // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
+      const versionPattern = new RegExp(String.raw`^## \[${escapedVersion}\]`, 'm');
+      const isStamped = versionPattern.test(changelogContent);
+
+      if (isStamped) {
+        // Check if [Unreleased] has content
+        const unreleasedMatch = /^## \[Unreleased\]([\s\S]*?)(?=^## \[|$)/m.exec(changelogContent);
+        const unreleasedContent = unreleasedMatch?.[1]?.trim() ?? '';
+        if (unreleasedContent.length > 0) {
+          log(`⚠ v${currentVersion} is stamped but not yet released. New changes should go under [${currentVersion}], not [Unreleased].`, 'yellow');
+        } else {
+          log('✓ No stale unreleased content', 'green');
+        }
+      } else {
+        log('✓ No stale unreleased content', 'green');
+      }
+    }
+
+    // Check 15: CHANGELOG section non-empty
+    console.log('');
+    console.log(`Checking CHANGELOG section for v${currentVersion} is non-empty...`);
+
+    {
+      const escapedVersion = currentVersion.replaceAll('.', String.raw`\.`);
+      // eslint-disable-next-line security/detect-non-literal-regexp -- version from package.json is trusted
+      const sectionPattern = new RegExp(String.raw`^## \[${escapedVersion}\][^\n]*\n([\s\S]*?)(?=^## \[|\z)`, 'm');
+      const sectionMatch = sectionPattern.exec(changelogContent);
+      const sectionContent = sectionMatch?.[1]?.trim() ?? '';
+
+      if (sectionContent.length === 0) {
+        log(`✗ CHANGELOG section for v${currentVersion} is empty`, 'red');
+        console.log('  Add at least one entry under the version heading before releasing.');
+        process.exit(1);
+      }
+
+      log(`✓ CHANGELOG section for v${currentVersion} has content`, 'green');
+    }
+  }
 }
 
 // Success!
 console.log('');
-log('✅ Repository is ready to publish!', 'green');
-console.log('');
-console.log('Next steps:');
-console.log('  1. Update package versions: bun run bump-version patch (or minor/major)');
-console.log('  2. Commit version changes: git commit -am \'Release vX.Y.Z\'');
-console.log('  3. Create git tag: git tag -a vX.Y.Z -m \'Release vX.Y.Z\'');
-console.log('  4. Push to GitHub: git push origin main --tags');
-console.log('  5. Publish to npm: (add your publish script)');
+if (releaseReadiness) {
+  log(`✅ Release v${currentVersion} is ready! Safe to tag and push.`, 'green');
+  console.log('');
+  console.log('Next steps:');
+  console.log(`  1. Tag:  git tag v${currentVersion}`);
+  console.log(`  2. Push: git push origin main v${currentVersion}`);
+  console.log('');
+  console.log('CI will publish to npm and create the GitHub release automatically.');
+} else {
+  log('✅ Validation checks passed.', 'green');
+  console.log('');
+  console.log('Before tagging a release, run: bun run pre-release');
+}
 console.log('');
 
 process.exit(0);


### PR DESCRIPTION
## Summary

- **Pre-flight CHANGELOG validation in `bump-version`** — validates CHANGELOG before touching any files. Prevents dirty repo state when validation fails (existing version, empty `[Unreleased]`, missing section). Auto-stamps CHANGELOG on stable bumps; skips for RC/prerelease.
- **`bun run pre-release`** — new pre-tag validation command. Confirms CHANGELOG is stamped, tag doesn't exist on remote, no stale `[Unreleased]` content, marketplace dry-run passes. Run this BEFORE `git tag`.
- **CHANGELOG check no longer skipped during `bun run validate`** — was incorrectly gated behind `--skip-git-checks` (a git flag), but it's a content check.
- **Fixed `--allow-branch` arg parsing bug** in pre-publish-check.ts (`i += 2` plus `i++` at loop end skipped too many args).
- **All "Next steps" output updated** to enforce running `pre-release` before tagging.
- **Stamps CHANGELOG for v0.1.27** — includes both the `vat skills install` content from PR #76 and the pre-release tooling improvements from this PR.

## Test plan

- [x] `bun run bump-version 0.1.27` — fails before touching files (version exists in CHANGELOG)
- [x] `bun run bump-version 0.99.0` — fails before touching files (empty `[Unreleased]`)
- [x] `bun run bump-version 0.99.0-rc.1` — succeeds, skips CHANGELOG stamp, correct RC next-steps
- [x] `bun run pre-publish -- --skip-git-checks` — CHANGELOG check runs (no longer skipped)
- [x] `bun run pre-release --allow-branch fix/pre-release-checks` — all checks pass including release-readiness
- [x] `bun run validate` — all 14 steps green
- [x] Code duplication check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)