### PR TITLE
fix: exclude gitignored files from skill bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- **Skill bundler no longer silently bundles gitignored files** — `walkLinkGraph` now checks `isGitIgnored()` before bundling linked files. Gitignored targets are excluded with reason `'gitignored'`, preventing accidental data leaks when SKILL.md links reference files in gitignored directories (e.g., `data/`).
-- **`isGitIgnored()` now handles symlinks in gitignored directories** — when `git check-ignore` fails with "beyond a symbolic link" (exit 128), walks up ancestor directories to detect if any parent is gitignored. Fixes false negatives for paths like `data/symlink/file.md` where `data/` is gitignored.
+- **Skill bundler no longer silently bundles gitignored files** — when a SKILL.md links to files inside a gitignored directory (e.g., `data/`), those files are now excluded from the bundle instead of being silently packaged and published. This includes files reached through symlinks in gitignored directories (e.g., OneDrive/shared drive mounts). Previously required manual `excludeReferencesFromBundle` workarounds; now handled automatically.
 
 ## [0.1.27] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Skill bundler no longer silently bundles gitignored files** — `walkLinkGraph` now checks `isGitIgnored()` before bundling linked files. Gitignored targets are excluded with reason `'gitignored'`, preventing accidental data leaks when SKILL.md links reference files in gitignored directories (e.g., `data/`).
+
 ## [0.1.27] - 2026-04-11
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Skill bundler no longer silently bundles gitignored files** — `walkLinkGraph` now checks `isGitIgnored()` before bundling linked files. Gitignored targets are excluded with reason `'gitignored'`, preventing accidental data leaks when SKILL.md links reference files in gitignored directories (e.g., `data/`).
+- **`isGitIgnored()` now handles symlinks in gitignored directories** — when `git check-ignore` fails with "beyond a symbolic link" (exit 128), walks up ancestor directories to detect if any parent is gitignored. Fixes false negatives for paths like `data/symlink/file.md` where `data/` is gitignored.
 
 ## [0.1.27] - 2026-04-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.28] - 2026-04-14
+
 ### Fixed
 - **Skill bundler no longer silently bundles gitignored files** — when a SKILL.md links to files inside a gitignored directory (e.g., `data/`), those files are now excluded from the bundle instead of being silently packaged and published. This includes files reached through symlinks in gitignored directories (e.g., OneDrive/shared drive mounts). Previously required manual `excludeReferencesFromBundle` workarounds; now handled automatically.
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.28-rc.1",
+      "version": "0.1.28-rc.2",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.28-rc.3",
+      "version": "0.1.28",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.28-rc.2",
+      "version": "0.1.28-rc.3",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/src/validators/packaging-validator.ts
+++ b/packages/agent-skills/src/validators/packaging-validator.ts
@@ -60,7 +60,7 @@ export interface SkillPackagingConfig {
 /** Excluded reference detail for verbose output */
 export interface ExcludedReferenceDetail {
   path: string;
-  reason: 'depth-exceeded' | 'pattern-matched' | 'outside-project' | 'navigation-file' | 'skill-definition';
+  reason: 'depth-exceeded' | 'pattern-matched' | 'outside-project' | 'navigation-file' | 'skill-definition' | 'gitignored';
   matchedPattern?: string | undefined;
 }
 
@@ -463,6 +463,7 @@ function mapExcludeReason(
     case 'pattern-matched': return 'pattern-matched';
     case 'navigation-file': return 'navigation-file';
     case 'skill-definition': return 'skill-definition';
+    case 'gitignored': return 'gitignored';
     case 'depth-exceeded':
     case EXCLUDE_REASON_DIRECTORY:
     case EXCLUDE_REASON_OUTSIDE_PROJECT:

--- a/packages/agent-skills/src/walk-link-graph.ts
+++ b/packages/agent-skills/src/walk-link-graph.ts
@@ -14,7 +14,7 @@ import { existsSync, statSync } from 'node:fs';
 import { basename, dirname } from 'node:path';
 
 import type { ResourceLink, ResourceMetadata } from '@vibe-agent-toolkit/resources';
-import { toForwardSlash, safePath } from '@vibe-agent-toolkit/utils';
+import { isGitIgnored, toForwardSlash, safePath } from '@vibe-agent-toolkit/utils';
 import picomatch from 'picomatch';
 
 import { NAVIGATION_FILE_PATTERNS } from './validators/validation-rules.js';
@@ -28,7 +28,7 @@ export interface LinkResolution {
   /** Whether the file will be bundled */
   bundled: boolean;
   /** Reason it was excluded (only set when bundled is false) */
-  excludeReason?: 'depth-exceeded' | 'pattern-matched' | 'directory-target' | 'outside-project' | 'navigation-file' | 'skill-definition' | undefined;
+  excludeReason?: 'depth-exceeded' | 'pattern-matched' | 'directory-target' | 'outside-project' | 'navigation-file' | 'skill-definition' | 'gitignored' | undefined;
   /** The rule that matched (only set for pattern-matched exclusions) */
   matchedRule?: ExcludeRule | undefined;
   /** Link text from the source markdown */
@@ -200,6 +200,12 @@ function checkExclusions(
   const matchedExclude = excludeMatchers.find((m) => m.isMatch(relativePath));
   if (matchedExclude) {
     excludedReferences.push(makeExclusion(targetPath, 'pattern-matched', link, matchedExclude.rule));
+    return true;
+  }
+
+  // Check if the file is gitignored (prevents leaking data from ignored directories)
+  if (isGitIgnored(targetPath, options.projectRoot)) {
+    excludedReferences.push(makeExclusion(targetPath, 'gitignored', link));
     return true;
   }
 

--- a/packages/agent-skills/test/walk-link-graph.test.ts
+++ b/packages/agent-skills/test/walk-link-graph.test.ts
@@ -1,9 +1,21 @@
 
 import type { ResourceLink, ResourceMetadata } from '@vibe-agent-toolkit/resources';
 import { safePath } from '@vibe-agent-toolkit/utils';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { walkLinkGraph, type ExcludeRule, type WalkableRegistry, type WalkLinkGraphOptions } from '../src/walk-link-graph.js';
+
+// Mock isGitIgnored — default to false (not ignored), override in specific tests
+vi.mock('@vibe-agent-toolkit/utils', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    isGitIgnored: vi.fn().mockReturnValue(false),
+  };
+});
+
+// Import after mock setup so we get the mocked version
+const { isGitIgnored } = await import('@vibe-agent-toolkit/utils');
 
 // ============================================================================
 // Constants
@@ -151,6 +163,10 @@ function expectEmptyWalkResult(result: ReturnType<typeof walkLinkGraph>): void {
 // ============================================================================
 // Tests
 // ============================================================================
+
+afterEach(() => {
+  vi.mocked(isGitIgnored).mockReturnValue(false);
+});
 
 describe('walkLinkGraph', () => {
   describe('skill resource not found', () => {
@@ -391,6 +407,51 @@ describe('walkLinkGraph', () => {
 
       expectBundledIds(result, [skillsDocId]);
       expect(result.excludedReferences).toHaveLength(0);
+    });
+  });
+
+  // ============================================================================
+  // Gitignored file exclusion
+  // ============================================================================
+
+  describe('gitignored file exclusion', () => {
+    it('should exclude gitignored markdown files with gitignored reason', () => {
+      vi.mocked(isGitIgnored).mockImplementation((filePath: string) =>
+        filePath === GUIDE_PATH,
+      );
+
+      const registry = createSkillGuideRegistry();
+      const result = walkLinkGraph(SKILL_ID, registry, defaultOptions());
+
+      expect(result.bundledResources).toHaveLength(0);
+      expect(result.excludedReferences).toHaveLength(1);
+      expect(result.excludedReferences[0]?.excludeReason).toBe('gitignored');
+      expect(result.excludedReferences[0]?.path).toBe(GUIDE_PATH);
+    });
+
+    it('should NOT exclude files that are not gitignored', () => {
+      // isGitIgnored returns false by default (from mock setup)
+      const registry = createSkillGuideRegistry();
+      const result = walkLinkGraph(SKILL_ID, registry, defaultOptions());
+
+      expectBundledIds(result, [GUIDE_ID]);
+      expect(result.excludedReferences).toHaveLength(0);
+    });
+
+    it('should exclude gitignored file found via transitive link', () => {
+      // skill -> guide -> ref, where ref is gitignored
+      vi.mocked(isGitIgnored).mockImplementation((filePath: string) =>
+        filePath === REF_PATH,
+      );
+
+      const registry = createSkillGuideRefRegistry();
+      const result = walkLinkGraph(SKILL_ID, registry, defaultOptions());
+
+      // Guide should be bundled, but ref should be excluded as gitignored
+      expectBundledIds(result, [GUIDE_ID]);
+      expect(result.excludedReferences).toHaveLength(1);
+      expect(result.excludedReferences[0]?.excludeReason).toBe('gitignored');
+      expect(result.excludedReferences[0]?.path).toBe(REF_PATH);
     });
   });
 

--- a/packages/agent-skills/test/walk-link-graph.test.ts
+++ b/packages/agent-skills/test/walk-link-graph.test.ts
@@ -427,6 +427,8 @@ describe('walkLinkGraph', () => {
       expect(result.excludedReferences).toHaveLength(1);
       expect(result.excludedReferences[0]?.excludeReason).toBe('gitignored');
       expect(result.excludedReferences[0]?.path).toBe(GUIDE_PATH);
+      // Verify projectRoot is passed as cwd so git checks ignore rules in the right directory
+      expect(vi.mocked(isGitIgnored)).toHaveBeenCalledWith(GUIDE_PATH, PROJECT_ROOT);
     });
 
     it('should NOT exclude files that are not gitignored', () => {

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/utils/src/git-utils.ts
+++ b/packages/utils/src/git-utils.ts
@@ -178,6 +178,12 @@ export function isGitIgnored(filePath: string, cwd: string = process.cwd()): boo
  * Much more efficient than calling `isGitIgnored()` in a loop - uses a single
  * git subprocess with stdin instead of N subprocesses.
  *
+ * **Limitation**: Unlike `isGitIgnored()`, this function does NOT handle symlink
+ * traversal (exit code 128). Paths that go through symlinks in gitignored directories
+ * will silently appear as non-ignored. If you need symlink-aware checking, use
+ * `isGitIgnored()` per-file instead. This is acceptable for discovery scanning
+ * (which typically doesn't follow symlinks), but NOT for bundling/packaging guards.
+ *
  * @param filePaths - Array of absolute or relative paths to check
  * @param cwd - Working directory (defaults to process.cwd())
  * @returns Map of filePath -> isIgnored (true if gitignored, false otherwise)

--- a/packages/utils/src/git-utils.ts
+++ b/packages/utils/src/git-utils.ts
@@ -178,11 +178,10 @@ export function isGitIgnored(filePath: string, cwd: string = process.cwd()): boo
  * Much more efficient than calling `isGitIgnored()` in a loop - uses a single
  * git subprocess with stdin instead of N subprocesses.
  *
- * **Limitation**: Unlike `isGitIgnored()`, this function does NOT handle symlink
- * traversal (exit code 128). Paths that go through symlinks in gitignored directories
- * will silently appear as non-ignored. If you need symlink-aware checking, use
- * `isGitIgnored()` per-file instead. This is acceptable for discovery scanning
- * (which typically doesn't follow symlinks), but NOT for bundling/packaging guards.
+ * **Symlink handling**: After the batch check, any paths that were not reported as
+ * ignored are re-checked individually via `isGitIgnored()`, which handles exit code
+ * 128 ("beyond a symbolic link") by walking up ancestor directories. This ensures
+ * paths through symlinks in gitignored directories are correctly detected.
  *
  * @param filePaths - Array of absolute or relative paths to check
  * @param cwd - Working directory (defaults to process.cwd())
@@ -197,58 +196,56 @@ export function isGitIgnored(filePath: string, cwd: string = process.cwd()): boo
  * // ignoreMap.get('node_modules/baz.js') === true
  * ```
  */
-export function gitCheckIgnoredBatch(
-  filePaths: string[],
-  cwd: string = process.cwd()
-): Map<string, boolean> {
+/** Build the normalized→original path map and initialize result map. */
+function initBatchMaps(filePaths: string[]): {
+  normalizedPaths: string[];
+  pathMap: Map<string, string>;
+  result: Map<string, boolean>;
+} {
+  const normalizedPaths = filePaths.map(p => toForwardSlash(p));
+  const pathMap = new Map<string, string>();
   const result = new Map<string, boolean>();
 
-  // No files to check
-  if (filePaths.length === 0) {
-    return result;
-  }
-
-  // Normalize paths to forward slashes for cross-platform consistency
-  // Git on Windows returns forward slashes, so we normalize input paths to match
-  const normalizedPaths = filePaths.map(p => toForwardSlash(p));
-
-  // Create map with normalized paths as keys
-  const pathMap = new Map<string, string>(); // normalized -> original
   for (const [index, normalizedPath] of normalizedPaths.entries()) {
     const originalPath = filePaths[index];
     if (originalPath !== undefined) {
       pathMap.set(normalizedPath, originalPath);
     }
   }
-
-  // Initialize all as not ignored (using original paths as keys)
   for (const filePath of filePaths) {
     result.set(filePath, false);
   }
 
+  return { normalizedPaths, pathMap, result };
+}
+
+export function gitCheckIgnoredBatch(
+  filePaths: string[],
+  cwd: string = process.cwd()
+): Map<string, boolean> {
+  if (filePaths.length === 0) {
+    return new Map<string, boolean>();
+  }
+
+  const { normalizedPaths, pathMap, result } = initBatchMaps(filePaths);
+
   try {
-    // Resolve git path using which for security (avoids PATH manipulation)
     const gitPath = which.sync('git');
 
-    // git check-ignore --stdin reads paths from stdin and outputs ignored ones
-    // Send normalized paths to git
     const gitResult = spawnSync(gitPath, ['check-ignore', '--stdin'], {
       cwd,
       encoding: 'utf-8',
       input: normalizedPaths.join('\n'),
       stdio: 'pipe',
-      shell: false, // No shell interpreter for security
+      shell: false,
     });
 
-    // Exit code 0 = at least one file ignored, 1 = none ignored
-    // Parse stdout to get which files are ignored
     if (gitResult.status === 0 && gitResult.stdout) {
       const ignoredPaths = gitResult.stdout
         .split('\n')
         .map((line) => line.trim())
         .filter((line) => line.length > 0);
 
-      // Mark ignored files (convert back to original paths)
       for (const ignoredPath of ignoredPaths) {
         const originalPath = pathMap.get(ignoredPath);
         if (originalPath !== undefined) {
@@ -257,9 +254,16 @@ export function gitCheckIgnoredBatch(
       }
     }
 
+    // Fallback: re-check paths that batch reported as not-ignored using isGitIgnored(),
+    // which handles symlink traversal (exit code 128) via ancestor walk.
+    for (const [filePath, ignored] of result) {
+      if (!ignored && isGitIgnored(filePath, cwd)) {
+        result.set(filePath, true);
+      }
+    }
+
     return result;
   } catch {
-    // If git is not available or other error, return all as not ignored
     return result;
   }
 }

--- a/packages/utils/src/git-utils.ts
+++ b/packages/utils/src/git-utils.ts
@@ -103,10 +103,17 @@ export function gitLsFiles(options: {
 /**
  * Check if a file path is ignored by git
  *
- * Uses git check-ignore which respects .gitignore, .git/info/exclude, and global gitignore
+ * Uses git check-ignore which respects .gitignore, .git/info/exclude, and global gitignore.
  *
- * **Performance warning**: This spawns a git subprocess for each file.
- * For checking multiple files, use `gitCheckIgnoredBatch()` instead.
+ * **Symlink handling**: When `git check-ignore` fails with exit code 128 ("beyond a symbolic
+ * link"), this function walks up ancestor directories and checks each one. If any ancestor is
+ * gitignored (e.g., `data/` is in `.gitignore`), the file is considered gitignored too. This
+ * handles the common pattern where a gitignored directory contains symlinks to external content
+ * (e.g., OneDrive, shared drives).
+ *
+ * **Performance warning**: This spawns a git subprocess for each file (plus up to N ancestor
+ * checks when the path traverses a symlink). For checking multiple files, use
+ * `gitCheckIgnoredBatch()` instead.
  *
  * @param filePath - Absolute or relative path to check
  * @param cwd - Working directory (defaults to process.cwd())
@@ -116,16 +123,49 @@ export function isGitIgnored(filePath: string, cwd: string = process.cwd()): boo
   try {
     // Resolve git path using which for security (avoids PATH manipulation)
     const gitPath = which.sync('git');
+    const checkIgnoreArgs = ['check-ignore', '-q'] as const;
 
     // git check-ignore returns exit code 0 if file is ignored, 1 if not
-    const result = spawnSync(gitPath, ['check-ignore', '-q', filePath], {
+    const result = spawnSync(gitPath, [...checkIgnoreArgs, filePath], {
       cwd,
       encoding: 'utf-8',
       stdio: 'pipe',
       shell: false, // No shell interpreter for security
     });
 
-    return result.status === 0;
+    if (result.status === 0) {
+      return true;
+    }
+
+    // Exit code 128 = fatal error (e.g., path beyond a symbolic link).
+    // Walk up ancestor directories to check if a parent is gitignored.
+    // Example: data/ is gitignored, data/symlink/deep/file.md fails with 128,
+    // but checking data/ directly returns 0.
+    if (result.status !== 1) {
+      const resolvedCwd = safePath.resolve(cwd);
+      const resolvedFile = safePath.resolve(cwd, filePath);
+      let current = dirname(resolvedFile);
+
+      while (current !== resolvedCwd && !current.endsWith(parse(current).root)) {
+        const ancestorResult = spawnSync(gitPath, [...checkIgnoreArgs, current], {
+          cwd,
+          encoding: 'utf-8',
+          stdio: 'pipe',
+          shell: false,
+        });
+        if (ancestorResult.status === 0) {
+          return true;
+        }
+        // If this ancestor check also fails fatally, keep walking up
+        // If it returns 1 (not ignored), the parent is tracked — stop walking
+        if (ancestorResult.status === 1) {
+          break;
+        }
+        current = dirname(current);
+      }
+    }
+
+    return false;
   } catch {
     // If git is not available or other error, assume not ignored
     return false;

--- a/packages/utils/test/git-utils.test.ts
+++ b/packages/utils/test/git-utils.test.ts
@@ -23,22 +23,35 @@ const { isGitIgnored, gitCheckIgnoredBatch } = await import('../src/git-utils.js
 
 /** Helper to create a spawnSync return value. */
 function makeSpawnResult(status: number, stdout = ''): SpawnSyncReturns<string> {
-  return {
-    status,
-    stdout,
-    stderr: '',
-    pid: 0,
-    output: [],
-    signal: null,
-  };
+  return { status, stdout, stderr: '', pid: 0, output: [], signal: null };
+}
+
+/**
+ * Create a spawnSync mock that returns exit codes based on a path → status map.
+ * Handles both per-file mode (check-ignore -q <path>) and batch mode (check-ignore --stdin).
+ * Unmapped paths return the fallback status (default: 1 = not ignored).
+ */
+function mockSpawnByPath(
+  pathStatusMap: Record<string, number>,
+  options?: { batchStdout?: string; fallbackStatus?: number },
+): void {
+  const fallback = options?.fallbackStatus ?? 1;
+  vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+    const argsArray = args as string[];
+    // Batch mode: check-ignore --stdin
+    if (argsArray[1] === '--stdin' && options?.batchStdout !== undefined) {
+      return makeSpawnResult(0, options.batchStdout);
+    }
+    // Per-file mode: check-ignore -q <path> — pathArg is args[2]
+    const pathArg = argsArray[2];
+    if (pathArg !== undefined && pathArg in pathStatusMap) {
+      return makeSpawnResult(pathStatusMap[pathArg] as number);
+    }
+    return makeSpawnResult(fallback);
+  });
 }
 
 const CWD = safePath.resolve('/project');
-const CHECK_IGNORE = 'check-ignore';
-const STDIN_FLAG = '--stdin';
-const QUIET_FLAG = '-q';
-const SYMLINK_FILE = 'data/symlink/file.md';
-const DIST_OUT = 'dist/out.js';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -60,78 +73,44 @@ describe('isGitIgnored', () => {
   it('returns true when exit 128 and ancestor walk finds a gitignored parent', () => {
     const filePath = 'data/symlink/deep/file.md';
 
-    // Walk: file -> data/symlink/deep -> data/symlink -> data
-    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
-      const pathArg = (args as string[])[2];
-      if (pathArg === filePath) {
-        // Initial check on the file itself → exit 128 (beyond symlink)
-        return makeSpawnResult(128);
-      }
-      // Ancestor: data/symlink/deep
-      const deepDir = safePath.resolve(CWD, 'data/symlink/deep');
-      if (pathArg === deepDir) {
-        return makeSpawnResult(128);
-      }
-      // Ancestor: data/symlink
-      const symlinkDir = safePath.resolve(CWD, 'data/symlink');
-      if (pathArg === symlinkDir) {
-        return makeSpawnResult(128);
-      }
-      // Ancestor: data → gitignored
-      const dataDir = safePath.resolve(CWD, 'data');
-      if (pathArg === dataDir) {
-        return makeSpawnResult(0);
-      }
-      // Fallback
-      return makeSpawnResult(1);
+    // Walk: file(128) -> data/symlink/deep(128) -> data/symlink(128) -> data(0=ignored)
+    mockSpawnByPath({
+      [filePath]: 128,
+      [safePath.resolve(CWD, 'data/symlink/deep')]: 128,
+      [safePath.resolve(CWD, 'data/symlink')]: 128,
+      [safePath.resolve(CWD, 'data')]: 0,
     });
 
     expect(isGitIgnored(filePath, CWD)).toBe(true);
-
-    // Verify we checked the file + ancestors (at least 2 calls)
     expect(vi.mocked(spawnSync).mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
   it('returns false when exit 128 and ancestor walk is exhausted without finding ignored parent', () => {
-    // All calls return 128 until we hit cwd
     vi.mocked(spawnSync).mockReturnValue(makeSpawnResult(128));
 
-    expect(isGitIgnored(SYMLINK_FILE, CWD)).toBe(false);
+    expect(isGitIgnored('data/symlink/file.md', CWD)).toBe(false);
   });
 
   it('returns false when exit 128 and ancestor walk hits a tracked parent (exit 1)', () => {
     const filePath = 'src/symlink/deep/file.md';
 
-    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
-      const pathArg = (args as string[])[2];
-      if (pathArg === filePath) {
-        return makeSpawnResult(128); // File beyond symlink
-      }
-      // deep dir → also behind symlink
-      const deepDir = safePath.resolve(CWD, 'src/symlink/deep');
-      if (pathArg === deepDir) {
-        return makeSpawnResult(128);
-      }
-      // symlink dir → tracked (exit 1), stop walking
-      const symlinkDir = safePath.resolve(CWD, 'src/symlink');
-      if (pathArg === symlinkDir) {
-        return makeSpawnResult(1);
-      }
-      // src dir — should NOT be reached
-      return makeSpawnResult(0);
+    // Walk: file(128) -> src/symlink/deep(128) -> src/symlink(1=tracked, stop)
+    // src should NOT be reached — exit 1 means parent is tracked, stop walking
+    mockSpawnByPath({
+      [filePath]: 128,
+      [safePath.resolve(CWD, 'src/symlink/deep')]: 128,
+      [safePath.resolve(CWD, 'src/symlink')]: 1,
+      [safePath.resolve(CWD, 'src')]: 0, // should never reach this
     });
 
-    const result = isGitIgnored(filePath, CWD);
-    expect(result).toBe(false);
+    expect(isGitIgnored(filePath, CWD)).toBe(false);
 
-    // Verify we did NOT check 'src' (the walk should have stopped at 'src/symlink')
+    // Verify we did NOT check 'src' (walk stopped at 'src/symlink')
     const checkedPaths = vi.mocked(spawnSync).mock.calls.map((c) => (c[1] as string[])[2]);
-    const srcDir = safePath.resolve(CWD, 'src');
-    expect(checkedPaths).not.toContain(srcDir);
+    expect(checkedPaths).not.toContain(safePath.resolve(CWD, 'src'));
   });
 
   it('returns false when git is not available (which.sync throws)', async () => {
-    // Re-mock which to throw
     const whichModule = await import('which');
     vi.mocked(whichModule.default.sync).mockImplementation(() => {
       throw new Error('not found');
@@ -143,15 +122,7 @@ describe('isGitIgnored', () => {
 
 describe('gitCheckIgnoredBatch', () => {
   it('returns correct map for normal batch check', () => {
-    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
-      const argsArray = args as string[];
-      if (argsArray[0] === CHECK_IGNORE && argsArray[1] === STDIN_FLAG) {
-        // Batch mode: return only ignored files in stdout
-        return makeSpawnResult(0, 'dist/bar.js\nnode_modules/baz.js\n');
-      }
-      // Per-file fallback (isGitIgnored) — not ignored
-      return makeSpawnResult(1);
-    });
+    mockSpawnByPath({}, { batchStdout: 'dist/bar.js\nnode_modules/baz.js\n' });
 
     const files = ['src/foo.ts', 'dist/bar.js', 'node_modules/baz.js'];
     const result = gitCheckIgnoredBatch(files, CWD);
@@ -162,42 +133,30 @@ describe('gitCheckIgnoredBatch', () => {
   });
 
   it('uses isGitIgnored fallback for symlink paths missed by batch', () => {
-    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
-      const argsArray = args as string[];
-      if (argsArray[0] === CHECK_IGNORE && argsArray[1] === STDIN_FLAG) {
-        // Batch mode: symlink path silently skipped, only dist/ reported
-        return makeSpawnResult(0, `${DIST_OUT}\n`);
-      }
-      // Per-file isGitIgnored fallback calls use ['check-ignore', '-q', path]
-      if (argsArray[0] === CHECK_IGNORE && argsArray[1] === QUIET_FLAG) {
-        const pathArg = argsArray[2];
-        if (pathArg === SYMLINK_FILE) {
-          // Initial check → exit 128 (beyond symlink)
-          return makeSpawnResult(128);
-        }
-        // Ancestor: data → gitignored
-        const dataDir = safePath.resolve(CWD, 'data');
-        if (pathArg === dataDir) {
-          return makeSpawnResult(0);
-        }
-        // Any other ancestor → also 128
-        return makeSpawnResult(128);
-      }
-      return makeSpawnResult(1);
-    });
+    const symlinkFile = 'data/symlink/file.md';
+    const distOut = 'dist/out.js';
 
-    const files = ['src/ok.ts', DIST_OUT, SYMLINK_FILE];
+    // Batch reports only dist/out.js; symlink path silently skipped.
+    // Per-file fallback: symlink file → 128, ancestor data/ → 0 (ignored)
+    mockSpawnByPath(
+      {
+        [symlinkFile]: 128,
+        [safePath.resolve(CWD, 'data')]: 0,
+      },
+      { batchStdout: `${distOut}\n`, fallbackStatus: 128 },
+    );
+
+    const files = ['src/ok.ts', distOut, symlinkFile];
     const result = gitCheckIgnoredBatch(files, CWD);
 
     expect(result.get('src/ok.ts')).toBe(false);
-    expect(result.get(DIST_OUT)).toBe(true);
-    expect(result.get(SYMLINK_FILE)).toBe(true);
+    expect(result.get(distOut)).toBe(true);
+    expect(result.get(symlinkFile)).toBe(true);
   });
 
   it('returns empty map for empty input', () => {
     const result = gitCheckIgnoredBatch([], CWD);
     expect(result.size).toBe(0);
-    // spawnSync should not be called at all
     expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
   });
 });

--- a/packages/utils/test/git-utils.test.ts
+++ b/packages/utils/test/git-utils.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for git-utils: isGitIgnored ancestor walk and gitCheckIgnoredBatch symlink fallback.
+ */
+
+import { spawnSync } from 'node:child_process';
+import type { SpawnSyncReturns } from 'node:child_process';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { safePath } from '../src/path-utils.js';
+
+// Mock modules before importing the code under test
+vi.mock('node:child_process', () => ({
+  spawnSync: vi.fn(),
+}));
+
+vi.mock('which', () => ({
+  default: { sync: vi.fn().mockReturnValue('/usr/bin/git') },
+}));
+
+// Import after mocks are set up
+const { isGitIgnored, gitCheckIgnoredBatch } = await import('../src/git-utils.js');
+
+/** Helper to create a spawnSync return value. */
+function makeSpawnResult(status: number, stdout = ''): SpawnSyncReturns<string> {
+  return {
+    status,
+    stdout,
+    stderr: '',
+    pid: 0,
+    output: [],
+    signal: null,
+  };
+}
+
+const CWD = safePath.resolve('/project');
+const CHECK_IGNORE = 'check-ignore';
+const STDIN_FLAG = '--stdin';
+const QUIET_FLAG = '-q';
+const SYMLINK_FILE = 'data/symlink/file.md';
+const DIST_OUT = 'dist/out.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isGitIgnored', () => {
+  it('returns true when git check-ignore exits 0 (file is ignored)', () => {
+    vi.mocked(spawnSync).mockReturnValue(makeSpawnResult(0));
+
+    expect(isGitIgnored('node_modules/foo.js', CWD)).toBe(true);
+  });
+
+  it('returns false when git check-ignore exits 1 (file is not ignored)', () => {
+    vi.mocked(spawnSync).mockReturnValue(makeSpawnResult(1));
+
+    expect(isGitIgnored('src/index.ts', CWD)).toBe(false);
+  });
+
+  it('returns true when exit 128 and ancestor walk finds a gitignored parent', () => {
+    const filePath = 'data/symlink/deep/file.md';
+
+    // Walk: file -> data/symlink/deep -> data/symlink -> data
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const pathArg = (args as string[])[2];
+      if (pathArg === filePath) {
+        // Initial check on the file itself → exit 128 (beyond symlink)
+        return makeSpawnResult(128);
+      }
+      // Ancestor: data/symlink/deep
+      const deepDir = safePath.resolve(CWD, 'data/symlink/deep');
+      if (pathArg === deepDir) {
+        return makeSpawnResult(128);
+      }
+      // Ancestor: data/symlink
+      const symlinkDir = safePath.resolve(CWD, 'data/symlink');
+      if (pathArg === symlinkDir) {
+        return makeSpawnResult(128);
+      }
+      // Ancestor: data → gitignored
+      const dataDir = safePath.resolve(CWD, 'data');
+      if (pathArg === dataDir) {
+        return makeSpawnResult(0);
+      }
+      // Fallback
+      return makeSpawnResult(1);
+    });
+
+    expect(isGitIgnored(filePath, CWD)).toBe(true);
+
+    // Verify we checked the file + ancestors (at least 2 calls)
+    expect(vi.mocked(spawnSync).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('returns false when exit 128 and ancestor walk is exhausted without finding ignored parent', () => {
+    // All calls return 128 until we hit cwd
+    vi.mocked(spawnSync).mockReturnValue(makeSpawnResult(128));
+
+    expect(isGitIgnored(SYMLINK_FILE, CWD)).toBe(false);
+  });
+
+  it('returns false when exit 128 and ancestor walk hits a tracked parent (exit 1)', () => {
+    const filePath = 'src/symlink/deep/file.md';
+
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const pathArg = (args as string[])[2];
+      if (pathArg === filePath) {
+        return makeSpawnResult(128); // File beyond symlink
+      }
+      // deep dir → also behind symlink
+      const deepDir = safePath.resolve(CWD, 'src/symlink/deep');
+      if (pathArg === deepDir) {
+        return makeSpawnResult(128);
+      }
+      // symlink dir → tracked (exit 1), stop walking
+      const symlinkDir = safePath.resolve(CWD, 'src/symlink');
+      if (pathArg === symlinkDir) {
+        return makeSpawnResult(1);
+      }
+      // src dir — should NOT be reached
+      return makeSpawnResult(0);
+    });
+
+    const result = isGitIgnored(filePath, CWD);
+    expect(result).toBe(false);
+
+    // Verify we did NOT check 'src' (the walk should have stopped at 'src/symlink')
+    const checkedPaths = vi.mocked(spawnSync).mock.calls.map((c) => (c[1] as string[])[2]);
+    const srcDir = safePath.resolve(CWD, 'src');
+    expect(checkedPaths).not.toContain(srcDir);
+  });
+
+  it('returns false when git is not available (which.sync throws)', async () => {
+    // Re-mock which to throw
+    const whichModule = await import('which');
+    vi.mocked(whichModule.default.sync).mockImplementation(() => {
+      throw new Error('not found');
+    });
+
+    expect(isGitIgnored('file.md', CWD)).toBe(false);
+  });
+});
+
+describe('gitCheckIgnoredBatch', () => {
+  it('returns correct map for normal batch check', () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const argsArray = args as string[];
+      if (argsArray[0] === CHECK_IGNORE && argsArray[1] === STDIN_FLAG) {
+        // Batch mode: return only ignored files in stdout
+        return makeSpawnResult(0, 'dist/bar.js\nnode_modules/baz.js\n');
+      }
+      // Per-file fallback (isGitIgnored) — not ignored
+      return makeSpawnResult(1);
+    });
+
+    const files = ['src/foo.ts', 'dist/bar.js', 'node_modules/baz.js'];
+    const result = gitCheckIgnoredBatch(files, CWD);
+
+    expect(result.get('src/foo.ts')).toBe(false);
+    expect(result.get('dist/bar.js')).toBe(true);
+    expect(result.get('node_modules/baz.js')).toBe(true);
+  });
+
+  it('uses isGitIgnored fallback for symlink paths missed by batch', () => {
+    vi.mocked(spawnSync).mockImplementation((_cmd, args) => {
+      const argsArray = args as string[];
+      if (argsArray[0] === CHECK_IGNORE && argsArray[1] === STDIN_FLAG) {
+        // Batch mode: symlink path silently skipped, only dist/ reported
+        return makeSpawnResult(0, `${DIST_OUT}\n`);
+      }
+      // Per-file isGitIgnored fallback calls use ['check-ignore', '-q', path]
+      if (argsArray[0] === CHECK_IGNORE && argsArray[1] === QUIET_FLAG) {
+        const pathArg = argsArray[2];
+        if (pathArg === SYMLINK_FILE) {
+          // Initial check → exit 128 (beyond symlink)
+          return makeSpawnResult(128);
+        }
+        // Ancestor: data → gitignored
+        const dataDir = safePath.resolve(CWD, 'data');
+        if (pathArg === dataDir) {
+          return makeSpawnResult(0);
+        }
+        // Any other ancestor → also 128
+        return makeSpawnResult(128);
+      }
+      return makeSpawnResult(1);
+    });
+
+    const files = ['src/ok.ts', DIST_OUT, SYMLINK_FILE];
+    const result = gitCheckIgnoredBatch(files, CWD);
+
+    expect(result.get('src/ok.ts')).toBe(false);
+    expect(result.get(DIST_OUT)).toBe(true);
+    expect(result.get(SYMLINK_FILE)).toBe(true);
+  });
+
+  it('returns empty map for empty input', () => {
+    const result = gitCheckIgnoredBatch([], CWD);
+    expect(result.size).toBe(0);
+    // spawnSync should not be called at all
+    expect(vi.mocked(spawnSync)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/utils/test/integration/git-utils.integration.test.ts
+++ b/packages/utils/test/integration/git-utils.integration.test.ts
@@ -233,6 +233,30 @@ describe('isGitIgnored', () => {
 
     expect(result).toBe(true);
   });
+
+  it('should detect gitignored files through symlinks via ancestor walk', () => {
+    // Simulate: data/ is gitignored, data/linked-content is a symlink to external dir
+    // git check-ignore fails with "beyond a symbolic link" for paths through symlinks,
+    // but ancestor walk should detect that data/ itself is gitignored
+    const dataDir = safePath.join(tempDir, 'data');
+    const externalDir = safePath.join(tempDir, 'external-content');
+    const linkedDir = safePath.join(dataDir, 'linked-content');
+
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test file uses controlled temp directory
+    fs.mkdirSync(dataDir);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test file uses controlled temp directory
+    fs.mkdirSync(externalDir);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test file uses controlled temp directory
+    fs.writeFileSync(safePath.join(externalDir, 'doc.md'), '# Test');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test file uses controlled temp directory
+    fs.symlinkSync(externalDir, linkedDir);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- test file uses controlled temp directory
+    fs.writeFileSync(safePath.join(tempDir, GITIGNORE_FILENAME), 'data/\n');
+
+    const result = isGitIgnored(safePath.join(tempDir, 'data', 'linked-content', 'doc.md'), tempDir);
+
+    expect(result).toBe(true);
+  });
 });
 
 describe('gitCheckIgnoredBatch', () => {

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28-rc.3",
+  "version": "0.1.28",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28-rc.1",
+  "version": "0.1.28-rc.2",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28-rc.2",
+  "version": "0.1.28-rc.3",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Skill bundler no longer silently bundles gitignored files — when a SKILL.md links to files inside a gitignored directory (e.g., `data/`), those files are now excluded from the bundle instead of being silently packaged and published
- Handles symlinks in gitignored directories (e.g., OneDrive/shared drive mounts) via ancestor directory walk when `git check-ignore` fails with exit 128
- `gitCheckIgnoredBatch()` also fixed to fall back to per-file `isGitIgnored()` for symlink paths

Closes #79

## Test plan
- [x] Unit tests for `isGitIgnored` ancestor walk logic (6 tests)
- [x] Unit tests for `gitCheckIgnoredBatch` symlink fallback (3 tests)  
- [x] Unit tests for `walkLinkGraph` gitignored exclusion (3 tests)
- [x] Integration test for `isGitIgnored` through real symlinks in real git repo
- [x] E2E verified against avonrisk-sdlc halo skill (gitignored OneDrive symlink files no longer bundled)
- [x] `vv validate` passes, `bun run pre-release` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)