### PR TITLE
feat(cli): add skill distribution consistency checks + fix flaky system tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`vat verify --consistency-check`** — post-build verification that skill distribution config in `vibe-agent-toolkit.config.yaml` and `package.json` are consistent. Detects skills missing from `package.json`, orphaned entries, and publish opt-out mismatches. Runs automatically as part of `vat verify`.
+
+### Fixed
+- **Discovery scanner no longer traverses git worktrees** — `.worktrees/` and `.claude/worktrees/` added to `PERFORMANCE_POISON` exclusions, preventing the crawler from physically walking into worktree copies of the repo during scans.
+- **System tests no longer flaky from vitest worker timeout** — refactored `skills-list.system.test.ts` to run CLI spawns once in `beforeAll` instead of 5 redundant full-project scans. Same coverage, 70% faster (90s → 27s), eliminates the `onTaskUpdate` timeout.
+
 ## [0.1.28] - 2026-04-14
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,22 @@ vat resources validate docs/ --frontmatter-schema schema.json
 }
 ```
 
+### Skill Distribution Architecture
+
+Skills, config, and packaging each have a distinct role. These boundaries are intentional:
+
+| Surface | Role | Owns |
+|---------|------|------|
+| **SKILL.md frontmatter** | Portable skill metadata | Skill identity, description, triggers — standard schema, never VAT-specific fields |
+| **vibe-agent-toolkit.config.yaml** | VAT source of truth | All VAT-specific config — discovery globs, packaging, `publish` flag, plugin assignment |
+| **package.json `vat.skills`** | npm packaging hint | Declares which skills ship in this npm package — validated by `vat verify`, never used as input for build |
+
+**Key rules:**
+- `vat verify` drives validation from config.yaml discovery, checking package.json as a suspect
+- `publish: false` in `skills.config.<name>` opts a skill out of distribution checks (default: `true`)
+- Error messages always reference the config mechanism so developers discover the fix from the error
+- No VAT-specific fields in SKILL.md frontmatter — skills are portable artifacts
+
 ### Resource Collections and Per-Directory Schema Validation
 
 **The `collections` key in `vibe-agent-toolkit.config.yaml` enables per-directory (or per-pattern) frontmatter schema validation.** This is the primary tool for projects with multiple document types, each requiring different frontmatter.

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "ignore": "^6.0.0",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.28",
+      "version": "0.1.29-rc.1",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/consistency-check.ts
+++ b/packages/cli/src/commands/consistency-check.ts
@@ -1,0 +1,428 @@
+/**
+ * Consistency check module — cross-references discovered skills against
+ * package.json vat.skills and plugin assignments.
+ *
+ * Config.yaml discovery is the SOURCE OF TRUTH for what skills exist.
+ * package.json is a SUSPECT being validated, never an input for truth.
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+
+import type { ProjectConfig, SkillPackagingConfig } from '@vibe-agent-toolkit/resources';
+import { safePath } from '@vibe-agent-toolkit/utils';
+
+import type { DiscoveredSkill } from './skills/command-helpers.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ConsistencyIssueSeverity = 'error' | 'warning' | 'info';
+
+export interface ConsistencyIssue {
+  severity: ConsistencyIssueSeverity;
+  code: string;
+  message: string;
+  fix: string;
+}
+
+export interface ConsistencyCheckResult {
+  issues: ConsistencyIssue[];
+  summary: {
+    discoveredSkills: number;
+    publishedSkills: number;
+    unpublishedSkills: number;
+    errors: number;
+    warnings: number;
+    infos: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether a skill is published.
+ * `publish` defaults to `true` when not set in skills.config.
+ */
+export function isSkillPublished(
+  skillName: string,
+  config: ProjectConfig
+): boolean {
+  const perSkill: SkillPackagingConfig | undefined =
+    config.skills?.config?.[skillName];
+
+  // Default to true when publish is not explicitly set
+  if (perSkill?.publish === undefined) {
+    return true;
+  }
+
+  return perSkill.publish;
+}
+
+/**
+ * Read the `vat.skills` array from `package.json` at the given project root.
+ * Returns `undefined` when no `package.json` or no `vat.skills` field exists.
+ */
+export function readVatSkillsFromPackageJson(
+  projectRoot: string
+): string[] | undefined {
+  const pkgPath = safePath.join(projectRoot, 'package.json');
+
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- pkgPath derived from projectRoot parameter
+  if (!existsSync(pkgPath)) {
+    return undefined;
+  }
+
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- pkgPath derived from projectRoot parameter
+    const raw = readFileSync(pkgPath, 'utf-8');
+    const pkg = JSON.parse(raw) as Record<string, unknown>;
+    const vat = pkg['vat'] as Record<string, unknown> | undefined;
+
+    if (!vat || !Array.isArray(vat['skills'])) {
+      return undefined;
+    }
+
+    return vat['skills'] as string[];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Match a skill name against a simple glob selector.
+ *
+ * Supported forms:
+ * - exact match: `"my-skill"`
+ * - prefix wildcard: `"prefix*"`
+ * - suffix wildcard: `"*suffix"`
+ * - contains wildcard: `"*fragment*"`
+ */
+export function matchesSimpleGlob(
+  skillName: string,
+  selector: string
+): boolean {
+  if (selector === '*') {
+    return true;
+  }
+
+  const startsWithStar = selector.startsWith('*');
+  const endsWithStar = selector.endsWith('*');
+
+  if (startsWithStar && endsWithStar) {
+    // *contains*
+    const fragment = selector.slice(1, -1);
+    return fragment.length > 0 && skillName.includes(fragment);
+  }
+
+  if (endsWithStar) {
+    // prefix*
+    const prefix = selector.slice(0, -1);
+    return skillName.startsWith(prefix);
+  }
+
+  if (startsWithStar) {
+    // *suffix
+    const suffix = selector.slice(1);
+    return skillName.endsWith(suffix);
+  }
+
+  // exact match
+  return skillName === selector;
+}
+
+/**
+ * Add published skills matching a plugin's skill selector to the assigned set.
+ */
+function addMatchingSkills(
+  assigned: Set<string>,
+  pluginSkills: '*' | string[],
+  publishedSkillNames: string[]
+): void {
+  if (pluginSkills === '*') {
+    for (const name of publishedSkillNames) {
+      assigned.add(name);
+    }
+    return;
+  }
+  for (const selector of pluginSkills) {
+    for (const name of publishedSkillNames) {
+      if (matchesSimpleGlob(name, selector)) {
+        assigned.add(name);
+      }
+    }
+  }
+}
+
+/**
+ * Resolve which published skills are assigned to at least one plugin.
+ *
+ * Returns the set of published skill names that matched at least one
+ * plugin skill selector across all marketplaces.
+ */
+export function resolveAssignedSkills(
+  config: ProjectConfig,
+  publishedSkillNames: string[]
+): Set<string> {
+  const assigned = new Set<string>();
+  const marketplaces = config.claude?.marketplaces;
+
+  if (!marketplaces) {
+    return assigned;
+  }
+
+  for (const marketplace of Object.values(marketplaces)) {
+    for (const plugin of marketplace.plugins) {
+      addMatchingSkills(assigned, plugin.skills, publishedSkillNames);
+    }
+  }
+
+  return assigned;
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+function checkConfigReferencesUnknownSkill(
+  discoveredNames: Set<string>,
+  config: ProjectConfig
+): ConsistencyIssue[] {
+  const issues: ConsistencyIssue[] = [];
+  const configuredSkills = config.skills?.config;
+
+  if (!configuredSkills) {
+    return issues;
+  }
+
+  for (const name of Object.keys(configuredSkills)) {
+    if (!discoveredNames.has(name)) {
+      issues.push({
+        severity: 'error',
+        code: 'CONFIG_REFERENCES_UNKNOWN_SKILL',
+        message: `skills.config references skill "${name}" but no SKILL.md with that name was discovered by config globs.`,
+        fix: `Check for typos in vibe-agent-toolkit.config.yaml: skills.config.${name}. The skill name must match the "name" field in a discovered SKILL.md frontmatter.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function checkPublishedSkillNotInPackageJson(
+  publishedNames: string[],
+  vatSkills: string[] | undefined
+): ConsistencyIssue[] {
+  if (vatSkills === undefined) {
+    // No package.json or no vat.skills — nothing to validate against
+    return [];
+  }
+
+  const issues: ConsistencyIssue[] = [];
+  const vatSkillsSet = new Set(vatSkills);
+
+  for (const name of publishedNames) {
+    if (!vatSkillsSet.has(name)) {
+      issues.push({
+        severity: 'error',
+        code: 'PUBLISHED_SKILL_NOT_IN_PACKAGE_JSON',
+        message: `Skill "${name}" is published (skills.config.${name}.publish is true by default) but not listed in package.json vat.skills.`,
+        fix: `Either add "${name}" to the vat.skills array in package.json, or opt out of publishing by setting publish: false in vibe-agent-toolkit.config.yaml: skills.config.${name}.publish: false`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function checkPackageJsonListsUnknownSkill(
+  discoveredNames: Set<string>,
+  vatSkills: string[] | undefined
+): ConsistencyIssue[] {
+  if (vatSkills === undefined) {
+    return [];
+  }
+
+  const issues: ConsistencyIssue[] = [];
+
+  for (const name of vatSkills) {
+    if (!discoveredNames.has(name)) {
+      issues.push({
+        severity: 'error',
+        code: 'PACKAGE_JSON_LISTS_UNKNOWN_SKILL',
+        message: `package.json vat.skills lists "${name}" but no SKILL.md with that name was discovered by config globs.`,
+        fix: `Remove "${name}" from the vat.skills array in package.json, or ensure a SKILL.md with name "${name}" exists and is matched by the include patterns in vibe-agent-toolkit.config.yaml: skills.include.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function checkUnpublishedSkillInPackageJson(
+  unpublishedNames: string[],
+  vatSkills: string[] | undefined
+): ConsistencyIssue[] {
+  if (vatSkills === undefined) {
+    return [];
+  }
+
+  const issues: ConsistencyIssue[] = [];
+  const vatSkillsSet = new Set(vatSkills);
+
+  for (const name of unpublishedNames) {
+    if (vatSkillsSet.has(name)) {
+      issues.push({
+        severity: 'warning',
+        code: 'UNPUBLISHED_SKILL_IN_PACKAGE_JSON',
+        message: `Skill "${name}" is marked publish: false but is still listed in package.json vat.skills. This is contradictory.`,
+        fix: `Either remove "${name}" from the vat.skills array in package.json, or remove the publish: false setting in vibe-agent-toolkit.config.yaml: skills.config.${name}.publish.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function checkPublishedSkillNotInPlugin(
+  publishedNames: string[],
+  config: ProjectConfig,
+  assignedSkills: Set<string>
+): ConsistencyIssue[] {
+  if (!config.claude?.marketplaces) {
+    return [];
+  }
+
+  const issues: ConsistencyIssue[] = [];
+
+  for (const name of publishedNames) {
+    if (!assignedSkills.has(name)) {
+      issues.push({
+        severity: 'error',
+        code: 'PUBLISHED_SKILL_NOT_IN_PLUGIN',
+        message: `Skill "${name}" is published but not assigned to any plugin in claude.marketplaces.`,
+        fix: `Either add "${name}" to a plugin's skills array in vibe-agent-toolkit.config.yaml: claude.marketplaces.<marketplace>.plugins[].skills, or opt out of publishing by setting publish: false in vibe-agent-toolkit.config.yaml: skills.config.${name}.publish: false`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Check a single plugin's skill selectors against discovered skill names.
+ */
+function checkPluginSelectors(
+  pluginSkills: string[],
+  pluginName: string,
+  marketplaceName: string,
+  discoveredNames: Set<string>
+): ConsistencyIssue[] {
+  const issues: ConsistencyIssue[] = [];
+
+  for (const selector of pluginSkills) {
+    const matchesAny = [...discoveredNames].some((name) =>
+      matchesSimpleGlob(name, selector)
+    );
+
+    if (!matchesAny) {
+      issues.push({
+        severity: 'error',
+        code: 'PLUGIN_REFERENCES_UNKNOWN_SKILL',
+        message: `Plugin "${pluginName}" in marketplace "${marketplaceName}" references skill selector "${selector}" which matches no discovered skill.`,
+        fix: `Check for typos in vibe-agent-toolkit.config.yaml: claude.marketplaces.${marketplaceName}.plugins (plugin "${pluginName}"). The selector must match at least one discovered SKILL.md name.`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+function checkPluginReferencesUnknownSkill(
+  discoveredNames: Set<string>,
+  config: ProjectConfig
+): ConsistencyIssue[] {
+  const marketplaces = config.claude?.marketplaces;
+
+  if (!marketplaces) {
+    return [];
+  }
+
+  const issues: ConsistencyIssue[] = [];
+
+  for (const [marketplaceName, marketplace] of Object.entries(marketplaces)) {
+    for (const plugin of marketplace.plugins) {
+      if (plugin.skills === '*') {
+        continue;
+      }
+      issues.push(...checkPluginSelectors(plugin.skills, plugin.name, marketplaceName, discoveredNames));
+    }
+  }
+
+  return issues;
+}
+
+function checkSkillUnpublished(
+  unpublishedNames: string[]
+): ConsistencyIssue[] {
+  return unpublishedNames.map((name) => ({
+    severity: 'info' as const,
+    code: 'SKILL_UNPUBLISHED',
+    message: `Skill "${name}" is marked publish: false — not distributed.`,
+    fix: `To publish this skill, remove the publish: false setting in vibe-agent-toolkit.config.yaml: skills.config.${name}.publish.`,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all consistency checks.
+ *
+ * @param discoveredSkills - Skills found via config.yaml glob discovery (source of truth)
+ * @param config - Parsed project configuration
+ * @param projectRoot - Project root directory (for reading package.json)
+ * @returns Consistency check result with issues and summary
+ */
+export function runConsistencyChecks(
+  discoveredSkills: DiscoveredSkill[],
+  config: ProjectConfig,
+  projectRoot: string
+): ConsistencyCheckResult {
+  const discoveredNames = new Set(discoveredSkills.map((s) => s.name));
+
+  const publishedNames: string[] = [];
+  const unpublishedNames: string[] = [];
+  for (const s of discoveredSkills) {
+    (isSkillPublished(s.name, config) ? publishedNames : unpublishedNames).push(s.name);
+  }
+
+  const vatSkills = readVatSkillsFromPackageJson(projectRoot);
+  const assignedSkills = resolveAssignedSkills(config, publishedNames);
+
+  // Run checks in specified order
+  const issues: ConsistencyIssue[] = [
+    ...checkConfigReferencesUnknownSkill(discoveredNames, config),
+    ...checkPublishedSkillNotInPackageJson(publishedNames, vatSkills),
+    ...checkPackageJsonListsUnknownSkill(discoveredNames, vatSkills),
+    ...checkUnpublishedSkillInPackageJson(unpublishedNames, vatSkills),
+    ...checkPublishedSkillNotInPlugin(publishedNames, config, assignedSkills),
+    ...checkPluginReferencesUnknownSkill(discoveredNames, config),
+    ...checkSkillUnpublished(unpublishedNames),
+  ];
+
+  return {
+    issues,
+    summary: {
+      discoveredSkills: discoveredSkills.length,
+      publishedSkills: publishedNames.length,
+      unpublishedSkills: unpublishedNames.length,
+      errors: issues.filter((i) => i.severity === 'error').length,
+      warnings: issues.filter((i) => i.severity === 'warning').length,
+      infos: issues.filter((i) => i.severity === 'info').length,
+    },
+  };
+}

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -5,6 +5,7 @@
  *   1. vat resources validate  (link integrity, collection schemas)
  *   2. vat skills validate     (SKILL.md frontmatter validation)
  *   3. vat claude marketplace validate  (strict marketplace validation, when configured)
+ *   4. consistency check  (skill distribution integrity — package.json, plugin assignment)
  */
 
 import { existsSync } from 'node:fs';
@@ -15,10 +16,12 @@ import { Command } from 'commander';
 
 import { handleCommandError } from '../utils/command-error.js';
 import { loadConfig } from '../utils/config-loader.js';
-import { type createLogger } from '../utils/logger.js';
+import { createLogger } from '../utils/logger.js';
 import { writeYamlOutput } from '../utils/output.js';
 
-import { createPhaseContext, runPhase, type Phase, type PhaseResult } from './phase-utils.js';
+import { runConsistencyChecks, type ConsistencyIssue } from './consistency-check.js';
+import { resolveBinPath, runPhase, type Phase, type PhaseResult } from './phase-utils.js';
+import { discoverSkillsFromConfig } from './skills/skill-discovery.js';
 
 export interface VerifyCommandOptions {
   only?: string;
@@ -29,8 +32,8 @@ export function createVerifyTopLevelCommand(): Command {
   const command = new Command('verify');
 
   command
-    .description('Verify all project artifacts in dependency order (resources → skills → marketplace)')
-    .option('--only <phase>', 'Verify only a specific phase: resources, skills, marketplace')
+    .description('Verify all project artifacts in dependency order (resources → skills → marketplace → consistency)')
+    .option('--only <phase>', 'Verify only a specific phase: resources, skills, marketplace, consistency')
     .option('--debug', 'Enable debug logging')
     .action(verifyTopLevelCommand)
     .addHelpText(
@@ -44,6 +47,7 @@ Description:
     resources    → link integrity, collection frontmatter schemas
     skills       → SKILL.md frontmatter and packaging validation
     marketplace  → strict marketplace validation (when configured)
+    consistency  → skill distribution integrity (package.json, plugin assignment)
 
 Output:
   YAML summary for each phase → stdout
@@ -161,6 +165,32 @@ function reportFilesDestErrors(
   }
 }
 
+/**
+ * Log consistency check issues to stderr.
+ */
+function reportConsistencyIssues(
+  issues: ConsistencyIssue[],
+  logger: ReturnType<typeof createLogger>
+): void {
+  logger.error('\n▶ Phase: consistency');
+
+  const errors = issues.filter((i) => i.severity === 'error');
+  const warnings = issues.filter((i) => i.severity === 'warning');
+  const infos = issues.filter((i) => i.severity === 'info');
+
+  for (const issue of errors) {
+    logger.error(`  ERROR [${issue.code}]: ${issue.message}`);
+    logger.error(`    Fix: ${issue.fix}`);
+  }
+  for (const issue of warnings) {
+    logger.error(`  WARN [${issue.code}]: ${issue.message}`);
+    logger.error(`    Fix: ${issue.fix}`);
+  }
+  for (const issue of infos) {
+    logger.info(`  INFO [${issue.code}]: ${issue.message}`);
+  }
+}
+
 function buildPhaseList(options: VerifyCommandOptions): Phase[] {
   const { only } = options;
   const phases: Phase[] = [];
@@ -188,9 +218,46 @@ function buildPhaseList(options: VerifyCommandOptions): Phase[] {
   return phases;
 }
 
+/**
+ * Run the consistency check phase and return whether errors were found.
+ */
+async function runConsistencyPhase(
+  logger: ReturnType<typeof createLogger>,
+  phaseResults: PhaseResult[]
+): Promise<boolean> {
+  const config = loadConfig(process.cwd());
+  if (!config?.skills) {
+    return false;
+  }
+
+  const discoveredSkills = await discoverSkillsFromConfig(config.skills, process.cwd());
+  const consistencyResult = runConsistencyChecks(discoveredSkills, config, process.cwd());
+
+  if (consistencyResult.summary.errors > 0) {
+    reportConsistencyIssues(consistencyResult.issues, logger);
+    phaseResults.push({ name: 'consistency', status: 'failed' });
+    return true;
+  }
+
+  if (consistencyResult.summary.warnings > 0 || consistencyResult.summary.infos > 0) {
+    reportConsistencyIssues(consistencyResult.issues, logger);
+  }
+  phaseResults.push({ name: 'consistency', status: 'passed' });
+  return false;
+}
+
 async function verifyTopLevelCommand(options: VerifyCommandOptions): Promise<void> {
   const phases = buildPhaseList(options);
-  const { logger, startTime, binPath } = createPhaseContext(options.debug, phases, options.only, 'resources, skills, marketplace');
+
+  // Consistency is an in-process phase, not a subprocess. Allow --only consistency
+  // to produce an empty subprocess phase list without throwing.
+  if (phases.length === 0 && options.only !== 'consistency') {
+    throw new Error(`Unknown phase: ${options.only ?? ''}. Valid phases: resources, skills, marketplace, consistency`);
+  }
+
+  const logger = createLogger(options.debug ? { debug: true } : {});
+  const startTime = Date.now();
+  const binPath = resolveBinPath();
 
   try {
     logger.info(`🔍 vat verify (phases: ${phases.map((p) => p.name).join(' → ')})`);
@@ -210,6 +277,14 @@ async function verifyTopLevelCommand(options: VerifyCommandOptions): Promise<voi
         hasErrors = true;
         reportFilesDestErrors(filesDestResults, logger);
         phaseResults.push({ name: 'files-config-dests', status: 'failed' });
+      }
+    }
+
+    // Consistency check: cross-reference discovered skills vs package.json and plugin assignments
+    if (!options.only || options.only === 'consistency' || options.only === 'skills') {
+      const consistencyHasErrors = await runConsistencyPhase(logger, phaseResults);
+      if (consistencyHasErrors) {
+        hasErrors = true;
       }
     }
 

--- a/packages/cli/test/system/consistency-check.system.test.ts
+++ b/packages/cli/test/system/consistency-check.system.test.ts
@@ -1,0 +1,185 @@
+/**
+ * System tests for skill distribution consistency checks in vat verify.
+ */
+
+import { mkdirSyncReal, safePath } from '@vibe-agent-toolkit/utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createSkillMarkdown,
+  createTempDirTracker,
+  executeCli,
+  getBinPath,
+  writeTestFile,
+} from './test-common.js';
+
+const VAT_CONFIG_FILENAME = 'vibe-agent-toolkit.config.yaml';
+
+function setupConsistencyTestSuite() {
+  const binPath = getBinPath(import.meta.url);
+  const { createTempDir, cleanupTempDirs: cleanup } = createTempDirTracker('vat-consistency-test-');
+
+  const createSkillSource = (tempDir: string, skillName: string) => {
+    const dir = safePath.join(tempDir, 'skills', skillName);
+    mkdirSyncReal(dir, { recursive: true });
+    writeTestFile(safePath.join(dir, 'SKILL.md'), createSkillMarkdown(skillName));
+  };
+
+  const writeConfig = (tempDir: string, content: string) => {
+    writeTestFile(safePath.join(tempDir, VAT_CONFIG_FILENAME), content);
+  };
+
+  /** Config with skills.include only (no claude section) */
+  const writeSkillsOnlyConfig = (tempDir: string, extra = '') => {
+    writeConfig(tempDir, `version: 1\nskills:\n  include:\n    - "skills/**/SKILL.md"\n${extra}`);
+  };
+
+  /** Config with skills + marketplace with specified plugin skills selector */
+  const writeMarketplaceConfig = (tempDir: string, pluginSkills: string, extra = '') => {
+    writeConfig(tempDir, `version: 1\nskills:\n  include:\n    - "skills/**/SKILL.md"\n${extra}claude:\n  marketplaces:\n    test-mp:\n      owner:\n        name: Test Org\n      plugins:\n        - name: test-plugin\n          ${pluginSkills}\n`);
+  };
+
+  const writePackageJson = (tempDir: string, vatSkills?: string[]) => {
+    const pkg: Record<string, unknown> = { name: 'test-pkg', version: '1.0.0' };
+    if (vatSkills !== undefined) {
+      pkg['vat'] = { skills: vatSkills };
+    }
+    writeTestFile(safePath.join(tempDir, 'package.json'), JSON.stringify(pkg));
+  };
+
+  const runVerify = (tempDir: string) => {
+    return executeCli(binPath, ['--cwd', tempDir, 'verify', '--only', 'consistency']);
+  };
+
+  /** Common setup: two skills (skill-a, skill-b) with package.json and marketplace config */
+  const setupTwoSkillsWithMarketplace = (vatSkills: string[], pluginSkills: string) => {
+    const tempDir = createTempDir();
+    createSkillSource(tempDir, 'skill-a');
+    createSkillSource(tempDir, 'skill-b');
+    writePackageJson(tempDir, vatSkills);
+    writeMarketplaceConfig(tempDir, pluginSkills);
+    return tempDir;
+  };
+
+  return { createTempDir, cleanup, createSkillSource, writeConfig, writeSkillsOnlyConfig, writeMarketplaceConfig, writePackageJson, runVerify, setupTwoSkillsWithMarketplace };
+}
+
+describe('vat verify consistency checks (system test)', () => {
+  const suite = setupConsistencyTestSuite();
+
+  afterEach(() => {
+    suite.cleanup();
+  });
+
+  it('should pass when all skills are in package.json and assigned to plugins', () => {
+    const tempDir = suite.setupTwoSkillsWithMarketplace(['skill-a', 'skill-b'], 'skills: "*"');
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('should error when published skill is missing from package.json vat.skills', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.createSkillSource(tempDir, 'skill-b');
+    suite.writePackageJson(tempDir, ['skill-a']);
+    suite.writeSkillsOnlyConfig(tempDir);
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('skill-b');
+    expect(result.stderr).toContain('PUBLISHED_SKILL_NOT_IN_PACKAGE_JSON');
+    expect(result.stderr).toContain('publish: false');
+  });
+
+  it('should error when package.json vat.skills lists undiscovered skill', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.writePackageJson(tempDir, ['skill-a', 'ghost-skill']);
+    suite.writeSkillsOnlyConfig(tempDir);
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('ghost-skill');
+    expect(result.stderr).toContain('PACKAGE_JSON_LISTS_UNKNOWN_SKILL');
+  });
+
+  it('should error when published skill is not assigned to any plugin', () => {
+    const tempDir = suite.setupTwoSkillsWithMarketplace(
+      ['skill-a', 'skill-b'],
+      'skills:\n            - "skill-a"'
+    );
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('skill-b');
+    expect(result.stderr).toContain('PUBLISHED_SKILL_NOT_IN_PLUGIN');
+  });
+
+  it('should suppress checks for skills with publish: false', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.createSkillSource(tempDir, 'dev-skill');
+    suite.writePackageJson(tempDir, ['skill-a']);
+    suite.writeMarketplaceConfig(tempDir, 'skills:\n            - "skill-a"', '  config:\n    dev-skill:\n      publish: false\n');
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('SKILL_UNPUBLISHED');
+    expect(result.stderr).toContain('dev-skill');
+  });
+
+  it('should warn when unpublished skill is listed in package.json', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.writePackageJson(tempDir, ['skill-a']);
+    suite.writeSkillsOnlyConfig(tempDir, '  config:\n    skill-a:\n      publish: false\n');
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain('UNPUBLISHED_SKILL_IN_PACKAGE_JSON');
+  });
+
+  it('should error when skills.config references unknown skill name', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.writePackageJson(tempDir, ['skill-a']);
+    suite.writeSkillsOnlyConfig(tempDir, '  config:\n    typo-skill:\n      publish: false\n');
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('typo-skill');
+    expect(result.stderr).toContain('CONFIG_REFERENCES_UNKNOWN_SKILL');
+  });
+
+  it('should error when plugin references non-existent skill selector', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.writePackageJson(tempDir, ['skill-a']);
+    suite.writeMarketplaceConfig(tempDir, 'skills:\n            - "skill-a"\n            - "nonexistent-skill"');
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('nonexistent-skill');
+    expect(result.stderr).toContain('PLUGIN_REFERENCES_UNKNOWN_SKILL');
+  });
+
+  it('should skip package.json checks when no package.json exists', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.writeSkillsOnlyConfig(tempDir);
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(0);
+  });
+
+  it('should skip plugin assignment checks when no claude.marketplaces configured', () => {
+    const tempDir = suite.createTempDir();
+    suite.createSkillSource(tempDir, 'skill-a');
+    suite.writePackageJson(tempDir, ['skill-a']);
+    suite.writeSkillsOnlyConfig(tempDir);
+
+    const result = suite.runVerify(tempDir);
+    expect(result.status).toBe(0);
+  });
+});

--- a/packages/cli/test/system/skills-list.system.test.ts
+++ b/packages/cli/test/system/skills-list.system.test.ts
@@ -1,44 +1,59 @@
 /**
  * System tests for skills list command
+ *
+ * These tests dogfood the real project scan (scanning the monorepo from cwd).
+ * To avoid redundant ~15s scans, the default and verbose commands are each run
+ * once in beforeAll and shared across assertions.
+ *
+ * For fast, deterministic, fixture-based tests see skills-list-fixture.system.test.ts.
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
 
 import { safePath } from '@vibe-agent-toolkit/utils';
 import * as yaml from 'js-yaml';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { getBinPath } from './test-common.js';
 
-/**
- * Helper to run skills list command and parse YAML output
- */
-function runListCommand(args: string[] = []): {
-  result: ReturnType<typeof spawnSync>;
-  parsed: Record<string, unknown>;
-} {
-  const binPath = getBinPath(import.meta.url);
-  // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
-  const result = spawnSync('node', [binPath, 'skills', 'list', ...args], {
-    encoding: 'utf-8',
-    cwd: process.cwd(),
-  });
+interface SkillEntry {
+  name: string;
+  path: string;
+  valid: boolean;
+  warning?: string;
+}
 
-  let parsed: Record<string, unknown>;
-  try {
-    parsed = yaml.load(result.stdout) as Record<string, unknown>;
-  } catch (error) {
-    // If parsing fails, log the error and return empty object
-    console.error('Failed to parse YAML:', error);
-    console.error('stdout:', result.stdout);
-    console.error('stderr:', result.stderr);
-    parsed = {};
-  }
-  return { result, parsed };
+interface SkillsListOutput {
+  status: string;
+  context: string;
+  skillsFound: number;
+  skills: SkillEntry[];
 }
 
 describe('skills list command (system test)', () => {
   const binPath = getBinPath(import.meta.url);
+
+  // Shared results from beforeAll — avoids 4 redundant full-project scans
+  let defaultResult: SpawnSyncReturns<string>;
+  let defaultParsed: SkillsListOutput;
+  let verboseResult: SpawnSyncReturns<string>;
+
+  beforeAll(() => {
+    // Run the default scan once (~15-20s) and share across tests
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
+    defaultResult = spawnSync('node', [binPath, 'skills', 'list'], {
+      encoding: 'utf-8',
+      cwd: process.cwd(),
+    });
+    defaultParsed = yaml.load(defaultResult.stdout) as SkillsListOutput;
+
+    // Run the verbose scan once
+    // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
+    verboseResult = spawnSync('node', [binPath, 'skills', 'list', '--verbose'], {
+      encoding: 'utf-8',
+      cwd: process.cwd(),
+    });
+  }, 60_000); // Two full-project scans (~15-20s each)
 
   it('should show help text', () => {
     // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
@@ -56,38 +71,19 @@ describe('skills list command (system test)', () => {
   });
 
   it('should list project skills by default', () => {
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
-    const result = spawnSync('node', [binPath, 'skills', 'list'], {
-      encoding: 'utf-8',
-      cwd: process.cwd(),
-    });
-
-    // Parse YAML output
-    const parsed = yaml.load(result.stdout) as {
-      status: string;
-      context: string;
-      skillsFound: number;
-      skills: Array<{
-        name: string;
-        path: string;
-        valid: boolean;
-        warning?: string;
-      }>;
-    };
-
-    expect(result.status).toBe(0);
-    expect(parsed).toHaveProperty('status', 'success');
-    expect(parsed).toHaveProperty('context', 'project');
-    expect(parsed).toHaveProperty('skillsFound');
-    expect(parsed).toHaveProperty('skills');
-    expect(Array.isArray(parsed.skills)).toBe(true);
+    expect(defaultResult.status).toBe(0);
+    expect(defaultParsed).toHaveProperty('status', 'success');
+    expect(defaultParsed).toHaveProperty('context', 'project');
+    expect(defaultParsed).toHaveProperty('skillsFound');
+    expect(defaultParsed).toHaveProperty('skills');
+    expect(Array.isArray(defaultParsed.skills)).toBe(true);
 
     // Should find at least the cat-agents skill
-    expect(parsed.skillsFound).toBeGreaterThan(0);
+    expect(defaultParsed.skillsFound).toBeGreaterThan(0);
 
     // Verify result structure
-    if (parsed.skills.length > 0) {
-      const firstSkill = parsed.skills[0];
+    if (defaultParsed.skills.length > 0) {
+      const firstSkill = defaultParsed.skills[0];
       expect(firstSkill).toHaveProperty('name');
       expect(firstSkill).toHaveProperty('path');
       expect(firstSkill).toHaveProperty('valid');
@@ -96,31 +92,14 @@ describe('skills list command (system test)', () => {
   });
 
   it('should output YAML format', () => {
-    const { result, parsed } = runListCommand();
-
-    // Should be parseable as YAML (runListCommand already does this)
-    expect(result.status).toBe(0);
-    expect(parsed.status).toBe('success');
-    expect(['project', 'user']).toContain(parsed.context);
+    expect(defaultResult.status).toBe(0);
+    expect(defaultParsed.status).toBe('success');
+    expect(['project', 'user']).toContain(defaultParsed.context);
   });
 
   it('should show validation warnings for non-standard filenames', () => {
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
-    const result = spawnSync('node', [binPath, 'skills', 'list'], {
-      encoding: 'utf-8',
-      cwd: process.cwd(),
-    });
-
-    const parsed = yaml.load(result.stdout) as {
-      skills: Array<{
-        name: string;
-        valid: boolean;
-        warning?: string;
-      }>;
-    };
-
     // Check if any skills have warnings (they should all be valid in this repo)
-    for (const skill of parsed.skills) {
+    for (const skill of defaultParsed.skills) {
       if (!skill.valid) {
         expect(skill.warning).toBeDefined();
         expect(typeof skill.warning).toBe('string');
@@ -129,16 +108,10 @@ describe('skills list command (system test)', () => {
   });
 
   it('should show verbose output with --verbose flag', () => {
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
-    const result = spawnSync('node', [binPath, 'skills', 'list', '--verbose'], {
-      encoding: 'utf-8',
-      cwd: process.cwd(),
-    });
-
-    expect(result.status).toBe(0);
+    expect(verboseResult.status).toBe(0);
 
     // Verbose output goes to stderr
-    expect(result.stderr).toContain('Path:');
+    expect(verboseResult.stderr).toContain('Path:');
   });
 
   it('should list skills at specific path', () => {
@@ -149,14 +122,7 @@ describe('skills list command (system test)', () => {
       cwd: process.cwd(),
     });
 
-    const parsed = yaml.load(result.stdout) as {
-      status: string;
-      context: string;
-      skillsFound: number;
-      skills: Array<{
-        name: string;
-      }>;
-    };
+    const parsed = yaml.load(result.stdout) as SkillsListOutput;
 
     // Debug output if test fails
     if (result.status !== 0) {
@@ -176,15 +142,7 @@ describe('skills list command (system test)', () => {
 
   it('should exit with code 0 even with warnings', () => {
     // List command should always succeed (warnings don't fail)
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- Testing CLI command
-    const result = spawnSync('node', [binPath, 'skills', 'list'], {
-      encoding: 'utf-8',
-      cwd: process.cwd(),
-    });
-
-    expect(result.status).toBe(0);
-
-    const parsed = yaml.load(result.stdout) as { status: string };
-    expect(parsed.status).toBe('success');
+    expect(defaultResult.status).toBe(0);
+    expect(defaultParsed.status).toBe('success');
   });
 });

--- a/packages/dev-tools/knip.config.ts
+++ b/packages/dev-tools/knip.config.ts
@@ -37,6 +37,11 @@ const config: KnipConfig = {
       project: ['src/**/*.ts'],
     },
 
+    // agent-schema: scripts/ uses utils for JSON Schema generation
+    'packages/agent-schema': {
+      entry: ['src/**/*.ts', 'scripts/**/*.ts'],
+    },
+
     // CLI: Commander.js wires commands from bin.ts, not index.ts
     'packages/cli': {
       entry: ['src/bin.ts'],

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/discovery/src/scanners/local-scanner.ts
+++ b/packages/discovery/src/scanners/local-scanner.ts
@@ -12,10 +12,12 @@ import type { DetectedFormat, ScanOptions, ScanResult, ScanSummary } from '../ty
  * These contain tens of thousands of files and are never useful for discovery.
  */
 const PERFORMANCE_POISON = [
-  '**/.git/**',          // Git objects (1000s of files), never useful for discovery
-  '**/node_modules/**',  // Dependencies (40K+ files), never user content
-  '**/coverage/**',      // Test coverage reports, never useful for discovery
-  '**/.test-output/**',  // Test artifacts, never useful for discovery
+  '**/.git/**',              // Git objects (1000s of files), never useful for discovery
+  '**/node_modules/**',      // Dependencies (40K+ files), never user content
+  '**/coverage/**',          // Test coverage reports, never useful for discovery
+  '**/.test-output/**',      // Test artifacts, never useful for discovery
+  '**/.worktrees/**',        // Git worktrees (full repo copies), must not traverse into
+  '**/.claude/worktrees/**', // Claude Code worktrees, same reason
 ];
 
 /**

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/src/schemas/project-config.ts
+++ b/packages/resources/src/schemas/project-config.ts
@@ -127,6 +127,8 @@ export type SkillFileEntry = z.infer<typeof SkillFileEntrySchema>;
  * reference exclusion rules, and validation overrides.
  */
 export const SkillPackagingConfigSchema = z.object({
+  publish: z.boolean().optional()
+    .describe('Whether this skill is published for distribution (default: true). Set to false for in-development skills.'),
   linkFollowDepth: z.union([z.number().int().min(0), z.literal('full')]).optional(),
   resourceNaming: z.enum(['basename', 'resource-id', 'preserve-path']).optional(),
   stripPrefix: z.string().optional(),

--- a/packages/resources/test/schemas/project-config-publish.test.ts
+++ b/packages/resources/test/schemas/project-config-publish.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { SkillPackagingConfigSchema, SkillsConfigSchema } from '../../src/schemas/project-config.js';
+
+describe('SkillPackagingConfigSchema publish field', () => {
+  it('should accept publish: false', () => {
+    const result = SkillPackagingConfigSchema.safeParse({ publish: false });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.publish).toBe(false);
+    }
+  });
+
+  it('should accept publish: true', () => {
+    const result = SkillPackagingConfigSchema.safeParse({ publish: true });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.publish).toBe(true);
+    }
+  });
+
+  it('should default publish to undefined (treated as true by consumers)', () => {
+    const result = SkillPackagingConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.publish).toBeUndefined();
+    }
+  });
+
+  it('should reject non-boolean publish values', () => {
+    const result = SkillPackagingConfigSchema.safeParse({ publish: 'false' });
+    expect(result.success).toBe(false);
+  });
+
+  it('should work in full skills config context', () => {
+    const result = SkillsConfigSchema.safeParse({
+      include: ['skills/**/SKILL.md'],
+      config: {
+        'my-skill': { publish: false },
+        'other-skill': { publish: true },
+        'default-skill': {},
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -18,7 +18,8 @@
       "authoring",
       "audit",
       "debugging",
-      "install"
+      "install",
+      "org-admin"
     ],
     "replaces": {
       "plugins": ["vat-development-agents"],

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.28",
+  "version": "0.1.29-rc.1",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **`vat verify` consistency phase** — new phase that validates skill distribution config in `vibe-agent-toolkit.config.yaml` and `package.json` are consistent. Detects skills missing from `package.json`, orphaned entries, and publish opt-out mismatches. Runs automatically as phase 4 of `vat verify`, isolatable via `--only consistency`.
- **Fix flaky system tests** — discovery scanner now excludes `.worktrees/` and `.claude/worktrees/` from `PERFORMANCE_POISON`, preventing physical traversal into worktree repo copies. Refactored `skills-list.system.test.ts` to share CLI spawns via `beforeAll` instead of 5 redundant full-project scans (90s → 27s, eliminates vitest `onTaskUpdate` timeout).

## Validated against

- Current `avonrisk-sdlc` — all phases pass including consistency
- `avonrisk-sdlc` @ v0.1.20 — correctly detects 2 missing skills (`halo`, `process-automation-design`) that were not in `package.json`

## Test plan

- [ ] `vv validate` passes (all phases green, no vitest worker timeouts)
- [ ] `vat verify --only consistency` passes on a clean project
- [ ] `vat verify --only consistency` detects missing skills on a project with known issues
- [ ] System test suite completes in <100s (was 133s)
- [ ] CI passes on Ubuntu and Windows matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)