### PR TITLE
feat(audit): recognize skill-claude-plugin shape + docs shift-left (0.1.34-rc.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Skill-claude-plugin recognition in `vat audit`.** Introduces the **skill-claude-plugin** artifact shape — a skill that self-publishes as a Claude plugin by co-locating `.claude-plugin/plugin.json` alongside its root `SKILL.md`. Audit now emits independent `ValidationResult` entries for each surface (one `agent-skill`, one `claude-plugin`) instead of reporting only the plugin and silently ignoring the skill. The skill remains platform-agnostic; the graduation to skill-claude-plugin adds Claude-specific packaging only. See [`docs/architecture/skill-packaging.md`](docs/architecture/skill-packaging.md) for the full packaging-shape terminology (standalone skill / skill-claude-plugin / claude-plugin / claude-marketplace).
+- **`SKILL_CLAUDE_PLUGIN_NAME_MISMATCH`** validation code (default `warning`). Fires on the plugin result when a skill-claude-plugin's `plugin.json.name` disagrees with the co-located `SKILL.md` frontmatter `name`. The skill is authoritative; the plugin manifest is a distribution wrapper and should match unless the plugin is intentionally namespaced (in which case use `validation.severity` or `validation.allow`).
+
+### Changed
+- `vat audit` directory-entry detection uses a new `enumerateSurfaces()` helper that returns every manifest present at the directory root, replacing single-result detection in the multi-surface case. Single-surface directories retain their legacy single-validator dispatch, including the marketplace-with-co-located-plugin collapse.
+- `packages/cli/src/commands/audit/hierarchical-output.ts` comments standardized on the new terminology: the pattern previously documented as "standalone plugin skill (no skills subdir)" is now called **skill-claude-plugin**.
+- Upgraded `vibe-validate` and `@vibe-validate/cli` dev dependencies from `^0.19.1` to `^0.19.4`.
+
+### Documentation
+- New reference doc `docs/architecture/skill-packaging.md` enumerates the four packaging shapes with layouts and applicable validation.
+- `docs/README.md` gains a "Validation & Quality Framework" section indexing the three stance docs (`skill-quality-and-compatibility.md`, `validation-codes.md`, `skill-smell-philosophy.md`).
+- New `docs/CLAUDE.md` and `docs/architecture/CLAUDE.md` agent navigators pull in each directory's README via `@README.md` and add agent-only guidance for audit/validation work.
+- Root `/CLAUDE.md` "Questions?" section now links to directories rather than README files — child CLAUDE.md files auto-trigger and pull in their README once, avoiding the previous double-read pattern.
+- `packages/cli/CLAUDE.md` gains a "Validation Framework References" section.
+
 ## [0.1.33] - 2026-04-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -761,9 +761,9 @@ Cached copies of external guidance (e.g., Anthropic's skill-authoring best-pract
 
 ## Questions?
 
-- [Architecture](./docs/architecture/README.md) - Package structure and evolution plan
+- [Architecture](./docs/architecture/) - Package structure, evolution plan, and cross-cutting architectural concerns (the directory's CLAUDE.md pulls in its README)
 - [Getting Started](./docs/getting-started.md) - Detailed setup guide
-- [Documentation](./docs/README.md) - Full documentation index
+- [Documentation](./docs/) - Full documentation index (the directory's CLAUDE.md pulls in its README)
 - [Build System](./docs/build-system.md) - TypeScript monorepo build configuration
 - [Publishing](./docs/publishing.md) - Version management and publishing workflow
 - [Best Practices](./docs/best-practices.md) - Enterprise development standards

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@types/semver": "^7.7.1",
         "@typescript-eslint/eslint-plugin": "^8.50.1",
         "@typescript-eslint/parser": "^8.50.1",
-        "@vibe-validate/cli": "^0.19.1",
+        "@vibe-validate/cli": "^0.19.4",
         "@vitest/coverage-v8": "^3.2.4",
         "adm-zip": "^0.5.16",
         "eslint": "^9.39.2",
@@ -36,14 +36,14 @@
         "tsx": "^4.21.0",
         "turbo": "^2.8.3",
         "typescript": "^5.9.3",
-        "vibe-validate": "^0.19.1",
+        "vibe-validate": "^0.19.4",
         "vitest": "^3.2.4",
         "yaml": "^2.8.2",
       },
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -127,7 +127,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -165,7 +165,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -184,7 +184,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -195,7 +195,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -232,7 +232,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -249,7 +249,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -270,7 +270,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -298,7 +298,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -317,7 +317,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -335,7 +335,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -353,7 +353,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -374,7 +374,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -387,7 +387,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -401,7 +401,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -422,7 +422,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -437,7 +437,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -463,7 +463,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.33",
+      "version": "0.1.34-rc.1",
       "bin": {
         "vat": "./bin/vat",
       },
@@ -1008,19 +1008,19 @@
 
     "@vibe-agent-toolkit/vat-example-cat-agents": ["@vibe-agent-toolkit/vat-example-cat-agents@workspace:packages/vat-example-cat-agents"],
 
-    "@vibe-validate/cli": ["@vibe-validate/cli@0.19.1", "", { "dependencies": { "@vibe-validate/config": "0.19.1", "@vibe-validate/core": "0.19.1", "@vibe-validate/extractors": "0.19.1", "@vibe-validate/git": "0.19.1", "@vibe-validate/history": "0.19.1", "chalk": "^5.6.2", "commander": "^12.1.0", "prompts": "^2.4.2", "proper-lockfile": "^4.1.2", "semver": "^7.7.3", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" }, "bin": { "vv": "dist/bin/vv", "vibe-validate": "dist/bin/vibe-validate" } }, "sha512-UFOGICFkWu/0xfTqiT0/c7YRzaV38c9zb33BxLG4lIoBQvi/21aNnrW76uDUJgId7fbXeicRE6aMMeqMmWA9Mg=="],
+    "@vibe-validate/cli": ["@vibe-validate/cli@0.19.4", "", { "dependencies": { "@vibe-validate/config": "0.19.4", "@vibe-validate/core": "0.19.4", "@vibe-validate/extractors": "0.19.4", "@vibe-validate/git": "0.19.4", "@vibe-validate/history": "0.19.4", "chalk": "^5.6.2", "commander": "^12.1.0", "prompts": "^2.4.2", "proper-lockfile": "^4.1.2", "semver": "^7.7.3", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" }, "bin": { "vv": "dist/bin/vv", "vibe-validate": "dist/bin/vibe-validate" } }, "sha512-1tWb/8hhuewnm1D7E1EwpmFZAmq7yIU0Grk4/Y8+LrCAr6K6OQgmvFvWpSQQhXfi47C6bUNRwxbJriHbm2ltBw=="],
 
-    "@vibe-validate/config": ["@vibe-validate/config@0.19.1", "", { "dependencies": { "@vibe-validate/utils": "0.19.1", "tsx": "^4.21.0", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-jANQosi7JbwDgUqqJOd7tuUAQQFAthfqhyFYmAgIhzCNtrygTlrf6je+ZSRUaGtPdi6JKhGOSXAh2dy+DPq8Qg=="],
+    "@vibe-validate/config": ["@vibe-validate/config@0.19.4", "", { "dependencies": { "@vibe-validate/utils": "0.19.4", "tsx": "^4.21.0", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-NalDjEBot/JbbCrcU7p1qDS/gSI/8xX+Bt8R7emJgILa7C4G5VAxx8nk9ZM0AGtx5RuGjI84qvN51RR3DSwC+A=="],
 
-    "@vibe-validate/core": ["@vibe-validate/core@0.19.1", "", { "dependencies": { "@vibe-validate/config": "0.19.1", "@vibe-validate/extractors": "0.19.1", "@vibe-validate/git": "0.19.1", "@vibe-validate/utils": "0.19.1", "strip-ansi": "^7.1.2", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-bOqquRA/XNSFVhvNvBbXHZ4qp3YksPH9qg8YzzSqJy0lq8U//c7mWGX1sAzXMpYi+XkK/J+8UsQHN6/hbhc9aA=="],
+    "@vibe-validate/core": ["@vibe-validate/core@0.19.4", "", { "dependencies": { "@vibe-validate/config": "0.19.4", "@vibe-validate/extractors": "0.19.4", "@vibe-validate/git": "0.19.4", "@vibe-validate/utils": "0.19.4", "strip-ansi": "^7.1.2", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-o/q41BlqMd/3tmI/Eaki+3JtiCBuo9bnWBDu5dz7z8FDCAydXZ2essp4z9GQlRUvO7/qvhBqK0D2wrHkrjwOBQ=="],
 
-    "@vibe-validate/extractors": ["@vibe-validate/extractors@0.19.1", "", { "dependencies": { "@vibe-validate/config": "0.19.1", "@vibe-validate/utils": "0.19.1", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-gF92o1TAtQLqjqGRU/feZSSHdZPegCvhxVKpEwkcZqIz6SGTAh7BCHG+ZKwtMi4CP5V1xZpF4zTWotxLirFhVg=="],
+    "@vibe-validate/extractors": ["@vibe-validate/extractors@0.19.4", "", { "dependencies": { "@vibe-validate/config": "0.19.4", "@vibe-validate/utils": "0.19.4", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-/Q08HCTJy0IEfMMucXULJE+5NPQTkODMbt2+Lol7il2IwY857kiIQQUfpRsuF/wNVdp4fY0hf1AgH9HutNIffQ=="],
 
-    "@vibe-validate/git": ["@vibe-validate/git@0.19.1", "", { "dependencies": { "@vibe-validate/utils": "0.19.1", "yaml": "^2.8.2" } }, "sha512-J2Zw+CPN2LXp7wDHAgJbJxR/XhDk++D3T5z95RZKYZGTagv6WbX/wpd8lIL8j3PpyrEP2kP7ho4NiQ5M8i5/oQ=="],
+    "@vibe-validate/git": ["@vibe-validate/git@0.19.4", "", { "dependencies": { "@vibe-validate/utils": "0.19.4", "yaml": "^2.8.2" } }, "sha512-J3dPNx5U0Se8Z4SBTV7H7tcbvq6aAL8stJ9ZEq0sDqxsyteukG24AsWNa705NpJtrzQcpbW4M+IjDJsk6Qypdw=="],
 
-    "@vibe-validate/history": ["@vibe-validate/history@0.19.1", "", { "dependencies": { "@vibe-validate/core": "0.19.1", "@vibe-validate/git": "0.19.1", "yaml": "^2.8.2", "zod": "^3.25.76" } }, "sha512-vnGb4i4DEZFBF7dQlQ+VuNxbDS6IDh576HJ1DPYz9HwkjuwONVFkYcQy9duTYQcHREY3sCM40jqTiZb9Unox5Q=="],
+    "@vibe-validate/history": ["@vibe-validate/history@0.19.4", "", { "dependencies": { "@vibe-validate/core": "0.19.4", "@vibe-validate/git": "0.19.4", "yaml": "^2.8.2", "zod": "^3.25.76" } }, "sha512-t5gjXkV0Li/0rK/BGWUgKTsgKysz6w0argYye5Q3gnG7yGwcE5RMGNY2LmH84xm47Y+vZ20fYH1owcP/BOvN0w=="],
 
-    "@vibe-validate/utils": ["@vibe-validate/utils@0.19.1", "", { "dependencies": { "which": "^5.0.0" } }, "sha512-VuhynwrEb1IL5Y3RXV+bjegum8XHF9imR1Fyngsz/arlDQTcnuexjuhZ3YzEESylOi5Q6tgSUHmxw3TZWWEcdw=="],
+    "@vibe-validate/utils": ["@vibe-validate/utils@0.19.4", "", { "dependencies": { "which": "^5.0.0" } }, "sha512-Hv5fcJ2IDdS/lnOXGGaXDx89zHw9spe+tW8DdB67GcbFCXJs5S81u79fgouR+OTqzw0/dgcz2mb/65vSILH+Ow=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
@@ -2372,7 +2372,7 @@
 
     "vibe-agent-toolkit": ["vibe-agent-toolkit@workspace:packages/vibe-agent-toolkit"],
 
-    "vibe-validate": ["vibe-validate@0.19.1", "", { "dependencies": { "@vibe-validate/cli": "0.19.1", "@vibe-validate/utils": "0.19.1", "vibe-agent-toolkit": "^0.1.22" }, "bin": { "vv": "bin/vv", "vibe-validate": "bin/vibe-validate" } }, "sha512-EimIeJRDX3j4/2w76D7DD3KTv2fl7EbFwqYYl74YjRFL0HxIy5aXYAG/MRJshf2dFX2vODR3Er3l2NPNDj2wfg=="],
+    "vibe-validate": ["vibe-validate@0.19.4", "", { "dependencies": { "@vibe-validate/cli": "0.19.4", "@vibe-validate/utils": "0.19.4", "vibe-agent-toolkit": "^0.1.33" }, "bin": { "vv": "bin/vv", "vibe-validate": "bin/vibe-validate" } }, "sha512-i4n7JztfSqglc90ids08n27jj00AgwlgBtfrhM62Cths4pxORZwYvKleqF2cNK272jfzrFpCbIRYuJcQrrkyPQ=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
@@ -2694,7 +2694,7 @@
 
     "ts-patch/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
-    "vibe-validate/vibe-agent-toolkit": ["vibe-agent-toolkit@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/cli": "0.1.22", "@vibe-agent-toolkit/vat-development-agents": "0.1.22" }, "bin": { "vat": "bin/vat" } }, "sha512-uiN9x02HG+C1yqtk/IMQFwc9OVakMPZaBstxSL7maJffNHV49KI5tYZcpbou6zjdVLDeE/GIUvv6GVHb70UL2w=="],
+    "vibe-validate/vibe-agent-toolkit": ["vibe-agent-toolkit@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/cli": "0.1.33", "@vibe-agent-toolkit/vat-development-agents": "0.1.33" }, "bin": { "vat": "bin/vat" } }, "sha512-lZAiYw+eszG2MGPsMbYT16gl0cdRHV+0qjah04YmQ6iYFNE7lHehq90tvpk8Qqix/c7ryoURxbAUgTUmpf1D8g=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -3086,9 +3086,9 @@
 
     "ts-patch/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli": ["@vibe-agent-toolkit/cli@0.1.22", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.2", "@vibe-agent-toolkit/agent-config": "0.1.22", "@vibe-agent-toolkit/agent-schema": "0.1.22", "@vibe-agent-toolkit/agent-skills": "0.1.22", "@vibe-agent-toolkit/claude-marketplace": "0.1.22", "@vibe-agent-toolkit/discovery": "0.1.22", "@vibe-agent-toolkit/gateway-mcp": "0.1.22", "@vibe-agent-toolkit/rag": "0.1.22", "@vibe-agent-toolkit/rag-lancedb": "0.1.22", "@vibe-agent-toolkit/resources": "0.1.22", "@vibe-agent-toolkit/utils": "0.1.22", "adm-zip": "^0.5.16", "commander": "^12.1.0", "js-yaml": "^4.1.0", "picomatch": "^4.0.3", "semver": "^7.7.3", "tar": "^7.5.7", "zod": "^3.24.1" }, "bin": { "vat": "dist/bin/vat.js" } }, "sha512-u+tNcrINruabK7igv+dEfCy9Hxc13G+dsJm6BgW2s3zUBEs+5y6oRWUWusjiRjZdYVPWe9LuKTKWYupsYaxG2A=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli": ["@vibe-agent-toolkit/cli@0.1.33", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.2", "@vibe-agent-toolkit/agent-config": "0.1.33", "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/agent-skills": "0.1.33", "@vibe-agent-toolkit/claude-marketplace": "0.1.33", "@vibe-agent-toolkit/discovery": "0.1.33", "@vibe-agent-toolkit/gateway-mcp": "0.1.33", "@vibe-agent-toolkit/rag": "0.1.33", "@vibe-agent-toolkit/rag-lancedb": "0.1.33", "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "adm-zip": "^0.5.16", "commander": "^12.1.0", "js-yaml": "^4.1.0", "picomatch": "^4.0.3", "semver": "^7.7.3", "tar": "^7.5.7", "zod": "^3.24.1" }, "bin": { "vat": "dist/bin/vat.js" } }, "sha512-0RQukKa5LhJKqqIMW+aC3YsIH6TOzZV2q3O1nPO8xCDjT6fGm0yCvPiaIIuSUgOiJtkh9b9U4/of4q0Mv9NRwg=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/vat-development-agents": ["@vibe-agent-toolkit/vat-development-agents@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.22", "@vibe-agent-toolkit/cli": "0.1.22", "yaml": "^2.8.2" } }, "sha512-6IHn8rC0XnTWYORZr0w5EnIMMnIcm0jCHbCxZX4aP7zIZcIxtHdVy/alIY2zKLU/oef7IvUNAFvJt/7ECldaMQ=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/vat-development-agents": ["@vibe-agent-toolkit/vat-development-agents@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/cli": "0.1.33", "yaml": "^2.8.2" } }, "sha512-xw/TlyrYYHJnCG2XXDEODua0ZTpFdb4Sk5vpUMzu5AVU/D2gjxlBd+IDP9Aw3GGLIJVt8MV/bmBlUFu4dd/phw=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -3176,27 +3176,27 @@
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-config": ["@vibe-agent-toolkit/agent-config@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.22", "@vibe-agent-toolkit/utils": "0.1.22", "yaml": "^2.3.4" } }, "sha512-Gs2pDYzltdx/srAF+0Pvl7QvzW+F8x2OvqcjJPznW+Z73dWZPHkDyK7I+qWNVMeOffujX+UTszp56YVm80oRnQ=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-config": ["@vibe-agent-toolkit/agent-config@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "yaml": "^2.3.4" } }, "sha512-ZHgWsft4J3mDuw0yC7AhfmuaX9skXK+hoNqn+b+TF6yZTs5glgnwdCEn4hXoMp0FhgbEU42PBVY7Tn8go+Ejjg=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-schema": ["@vibe-agent-toolkit/agent-schema@0.1.22", "", { "dependencies": { "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5" } }, "sha512-vh/LyamYn/WwPgZvP6YK0Od4ZJyiW4mcSnTJ9sEUm9wCfi3IkLPmoHHhWOcx6oepXwKGMkmAmOhYI45rtntbzA=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-schema": ["@vibe-agent-toolkit/agent-schema@0.1.33", "", { "dependencies": { "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5" } }, "sha512-24pInktOPgbiji6g5j00iUuenFlcz5L9taCcQ4aGNQILkOmcvVFz7y93swEMxi87KuGUiGz4sJ6LBrwiecqFWg=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-skills": ["@vibe-agent-toolkit/agent-skills@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/agent-config": "0.1.22", "@vibe-agent-toolkit/agent-schema": "0.1.22", "@vibe-agent-toolkit/resources": "0.1.22", "@vibe-agent-toolkit/utils": "0.1.22", "adm-zip": "^0.5.16", "picomatch": "^4.0.3", "yaml": "^2.6.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.23.5" } }, "sha512-+aLSXE6aq2gzHd0FSnmzFkEPWB1sF+jYjfwqqaOvRKrVhb7pNdFtS21PJD0Y7WYvJgcfixTqedP/WWLjVXcRwA=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-skills": ["@vibe-agent-toolkit/agent-skills@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-config": "0.1.33", "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "adm-zip": "^0.5.16", "picomatch": "^4.0.3", "yaml": "^2.6.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.23.5" } }, "sha512-oBHVEVtyRZ8nKR3mvrtbXSn29aWlvwDnN5yLXjdkUUbuNtcCMFi2IV19t5A24pjO6/Fum0uZV83KKh6vFml4Bw=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/claude-marketplace": ["@vibe-agent-toolkit/claude-marketplace@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/utils": "0.1.22", "ignore": "^6.0.0", "yaml": "^2.6.1", "zod": "^3.24.1" } }, "sha512-uHOPSJ2m8NEJcUDJw1Ve7SHfhFHjCkVP8DNKeJHF37b73IeSZokZ0gEaJR+1W7hC816O8WJen6kM4kd6v2jxFA=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/claude-marketplace": ["@vibe-agent-toolkit/claude-marketplace@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-skills": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "ignore": "^6.0.0", "zod": "^3.24.1" } }, "sha512-UqtWfOOFF+zBoIKTjl4Nv6Koe7067bEzlghk6UKJa8gdMyt8HzpZxriQxZZgrKYWfBculPnGOp2ntvljXOOXVw=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/discovery": ["@vibe-agent-toolkit/discovery@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/utils": "0.1.22", "picomatch": "^4.0.2" } }, "sha512-DrjFJfqfWl9pTttvxE0p/9zZlcC/tpAQTOVFK6MmBBU/CGGaokRtl04wd8Pq7UIz8w/Dl8Fe0IbmmOwL1P+Vqg=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/discovery": ["@vibe-agent-toolkit/discovery@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/utils": "0.1.33", "picomatch": "^4.0.2" } }, "sha512-xvkYl3tDxD/ShXiHGf+9lG4n6Tho+ToUQm0FLCcMSiTpn8tldgMbhwbnyQqw9ZZI4tKx5n9KbF5D6vU0nh+5+g=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/gateway-mcp": ["@vibe-agent-toolkit/gateway-mcp@0.1.22", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.4", "@vibe-agent-toolkit/agent-schema": "0.1.22", "zod": "^3.24.1" } }, "sha512-BNUrNyueNzvSbZfEZVCKOVji60Pa2beNZo501HZgGk+c7y7SgtkX6ZInFHpf5ws9uwCXozshzrQSVnNHkPBvpg=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/gateway-mcp": ["@vibe-agent-toolkit/gateway-mcp@0.1.33", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.4", "@vibe-agent-toolkit/agent-schema": "0.1.33", "zod": "^3.24.1" } }, "sha512-XuY8nZakA1m/A7283zmBKHLG/p8E9Yu+XKO4hm1/cJRF8JVJirj4YDV0GseKCT4Cb51dCtxjlRRXEIiZBkI/Hw=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag": ["@vibe-agent-toolkit/rag@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/resources": "0.1.22", "@vibe-agent-toolkit/utils": "0.1.22", "gpt-tokenizer": "^2.6.0", "zod": "^3.22.0", "zod-to-json-schema": "^3.22.0" }, "optionalDependencies": { "@xenova/transformers": "^2.17.0", "onnxruntime-node": "^1.24.0", "openai": "^6.16.0" } }, "sha512-EStRqDWwSjD9PnXOdwzEAfo3vUdCorVngV+AzFKreQUw85Vxl/axEfGFUayLewlJs28nAvF0YRhiHBk/TTcBIg=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag": ["@vibe-agent-toolkit/rag@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "gpt-tokenizer": "^2.6.0", "zod": "^3.22.0", "zod-to-json-schema": "^3.22.0" }, "optionalDependencies": { "@xenova/transformers": "^2.17.0", "onnxruntime-node": "^1.24.0", "openai": "^6.16.0" } }, "sha512-oSqwT+vz+Wprgp2O1stan/ABX2mCkpC7vfxCToLoBUEfyiIunJkW9ydW8XTEcA8LX0slzNn4X7fp5sG1LVbw8w=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb": ["@vibe-agent-toolkit/rag-lancedb@0.1.22", "", { "dependencies": { "@lancedb/lancedb": "^0.23.0", "@vibe-agent-toolkit/rag": "0.1.22", "@vibe-agent-toolkit/resources": "0.1.22", "@vibe-agent-toolkit/utils": "0.1.22", "apache-arrow": "^18.1.0", "zod": "^3.24.1" } }, "sha512-YysdDymbNlA0q6uR9BJ+a/yA2MsULAKZM9+5GkwXkiLPDddOxPhID8ERYQqUiLK5OZY9ifBNs4RVKuKDhqi3OQ=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb": ["@vibe-agent-toolkit/rag-lancedb@0.1.33", "", { "dependencies": { "@lancedb/lancedb": "^0.23.0", "@vibe-agent-toolkit/rag": "0.1.33", "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "apache-arrow": "^18.1.0", "zod": "^3.24.1" } }, "sha512-VvB0tLJm0Yw/Vr/yLNsqOTZ7aD0uBL5+d5kUZhbg7MpBzfhc7HAXidAnUpQGqz5w1ALVwSJt5wN37yvCVCaecQ=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/resources": ["@vibe-agent-toolkit/resources@0.1.22", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.22", "@vibe-agent-toolkit/utils": "0.1.22", "ajv": "^8.17.1", "github-slugger": "^2.0.0", "js-yaml": "^4.1.1", "markdown-link-check": "^3.14.2", "picomatch": "^4.0.3", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "zod": "^3.24.1" } }, "sha512-83YkeaLideUm1+Ggj06jP+MMmYaH69VKeHYQX8ZfnjLMhXbo5ewv8nWYE44IPgfY4sWwhz+RyE3R2AwUMcVmzQ=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/resources": ["@vibe-agent-toolkit/resources@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "ajv": "^8.17.1", "github-slugger": "^2.0.0", "js-yaml": "^4.1.1", "markdown-link-check": "^3.14.2", "picomatch": "^4.0.3", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "zod": "^3.24.1" } }, "sha512-yHI79/0Yg0dRZqQgJkz2/4niT8GqZW9UTMnIBlEWcUgkDVAhwd26gL5h1IcnU2apLQvMDt1Ib/WGAn2Bu5cDIA=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/utils": ["@vibe-agent-toolkit/utils@0.1.22", "", { "dependencies": { "handlebars": "^4.7.8", "ignore": "^7.0.5", "picomatch": "^4.0.3", "which": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-8NGIAetVpMeihAa5B8rx9ZlbQLLD/K7FZ9cItIaJ5+Sii7HP0BO18xF0FhWGAJXhkZj5GXeMeX7www89C+aVeA=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/utils": ["@vibe-agent-toolkit/utils@0.1.33", "", { "dependencies": { "handlebars": "^4.7.8", "ignore": "^7.0.5", "picomatch": "^4.0.3", "which": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ce9vwqQ96wSTz3UM9TV0fTmG8xucV3+Lz1qwUrcobGuv8aZAs/BPI6Cv3FmvzQ2Gaw8n7RktFDvX6b3qeyNCqw=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/vat-development-agents/@vibe-agent-toolkit/agent-schema": ["@vibe-agent-toolkit/agent-schema@0.1.22", "", { "dependencies": { "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5" } }, "sha512-vh/LyamYn/WwPgZvP6YK0Od4ZJyiW4mcSnTJ9sEUm9wCfi3IkLPmoHHhWOcx6oepXwKGMkmAmOhYI45rtntbzA=="],
+    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/vat-development-agents/@vibe-agent-toolkit/agent-schema": ["@vibe-agent-toolkit/agent-schema@0.1.33", "", { "dependencies": { "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5" } }, "sha512-24pInktOPgbiji6g5j00iUuenFlcz5L9taCcQ4aGNQILkOmcvVFz7y93swEMxi87KuGUiGz4sJ6LBrwiecqFWg=="],
 
     "@vibe-agent-toolkit/cli/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -1,0 +1,13 @@
+# Documentation — Agent Navigator
+
+@README.md
+
+## Agent guidance
+
+When working on anything validation-related, start with the stance docs linked above, not the code:
+
+- **Audit/validation logic changes** → read `skill-quality-and-compatibility.md` first to understand the stance, then `validation-codes.md` for code semantics.
+- **Adding/modifying a validation code** → consult `skill-smell-philosophy.md` for the severity-default posture and rule-addition bar. Do not add `error`-severity codes without corpus evidence.
+- **Understanding plugin vs skill vs marketplace artifacts** → `architecture/skill-packaging.md`.
+
+The `validation-codes.md` index is the code-level reference; the stance doc is the reasoning behind every default.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,16 @@ Welcome to the Vibe Agent Toolkit documentation.
 - **[Adding Runtime Adapters](./adding-runtime-adapters.md)** - Best practices for creating new runtime adapters
 - **[Publishing Guide](./publishing.md)** - How to prepare and publish packages to npm
 
+## Validation & Quality Framework
+
+VAT is opinionated about skill and plugin quality. Three docs articulate what we believe, what we flag, and how we decide:
+
+- **[Skill Quality & Compatibility — VAT's Stance](./skill-quality-and-compatibility.md)** — What VAT believes about skill structure, packaging, and runtime compatibility. Foundation for every `defaultSeverity`.
+- **[Validation Codes](./validation-codes.md)** — Every code VAT emits, default severities, and configuration syntax (`validation.severity` / `validation.allow`).
+- **[Skill-Smell Philosophy](./skill-smell-philosophy.md)** — How VAT decides what to flag; rule-addition and severity-default policy.
+
+See also: [Skill Packaging Shapes](./architecture/skill-packaging.md) for the artifact shape terminology.
+
 ## Guides
 
 - **[Collection Validation](./guides/collection-validation.md)** - Per-collection frontmatter validation with JSON Schemas

--- a/docs/architecture/CLAUDE.md
+++ b/docs/architecture/CLAUDE.md
@@ -1,0 +1,13 @@
+# Architecture — Agent Navigator
+
+@README.md
+
+## Agent guidance
+
+Cross-cutting architectural concerns worth knowing before editing any validator or audit code:
+
+- **Validation framework** — VAT uses a three-layer model: **Evidence** (neutral pattern matches), **Observation** (derived capability claims), **Verdict** (context-aware outcomes against declared targets). See [`../skill-quality-and-compatibility.md`](../skill-quality-and-compatibility.md#the-evidence-substrate). This is load-bearing — don't emit a validation issue without knowing which layer you're operating at.
+
+- **Skill packaging shapes** — Four recognized artifact types (standalone skill, skill-claude-plugin, claude-plugin, claude-marketplace). See [`skill-packaging.md`](./skill-packaging.md). Audit's surface enumeration returns all present; never assume a single shape.
+
+- **Validation codes reference** — [`../validation-codes.md`](../validation-codes.md) enumerates every emittable code by name, default severity, and when it fires.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -444,3 +444,9 @@ When using `--user` flag:
    - Is CLI intuitive?
    - What's missing?
    - Then build RAG or agent-skills based on priority
+
+---
+
+## Related references
+
+- [Skill Packaging Shapes](./skill-packaging.md) — the four recognized artifact shapes (standalone skill, skill-claude-plugin, claude-plugin, claude-marketplace) with layouts and applicable validation.

--- a/docs/architecture/skill-packaging.md
+++ b/docs/architecture/skill-packaging.md
@@ -1,0 +1,79 @@
+# Skill Packaging Shapes
+
+VAT recognizes four skill/plugin packaging shapes. Each has a distinct directory layout, a distinct set of applicable validation codes, and (in the case of skill-claude-plugin) a distinct graduation path from a simpler shape.
+
+## Shapes
+
+### Standalone skill
+
+A bare skill with no plugin packaging. Multi-AI-platform: the same `SKILL.md` works across Claude Code, Claude Chat, and any other runtime that understands the agent-skills contract.
+
+```
+my-skill/
+└── SKILL.md
+```
+
+**Canonical location for Claude Code:** `~/.claude/skills/<name>/SKILL.md`.
+
+Applicable validation: all skill-level codes (`SKILL_NAME_*`, `SKILL_DESCRIPTION_*`, `LINK_*`, capability observations, etc.). No plugin-level codes apply.
+
+### Skill-claude-plugin
+
+A skill that self-publishes as a Claude plugin by co-locating `.claude-plugin/plugin.json` at the same root as `SKILL.md`. The skill is authoritative; the plugin manifest is a Claude-specific distribution wrapper.
+
+```
+my-skill/
+├── SKILL.md
+└── .claude-plugin/
+    └── plugin.json
+```
+
+**Graduation:** a standalone skill becomes a skill-claude-plugin by adding `.claude-plugin/plugin.json`. The skill itself remains platform-agnostic; the graduation adds Claude-specific packaging that makes the skill installable via `claude plugin install`.
+
+Applicable validation: all skill-level codes (on the skill surface) PLUS all plugin-level codes (on the plugin surface), PLUS `SKILL_CLAUDE_PLUGIN_NAME_MISMATCH` when the two manifests declare different `name` values.
+
+### Claude-plugin (canonical Anthropic layout)
+
+A Claude plugin that packages one or more skills under a `skills/` subdirectory. This is the canonical Anthropic layout documented at [code.claude.com/docs/en/plugins-reference](https://code.claude.com/docs/en/plugins-reference).
+
+```
+my-plugin/
+├── .claude-plugin/
+│   └── plugin.json
+├── skills/
+│   ├── skill-a/
+│   │   └── SKILL.md
+│   └── skill-b/
+│       └── SKILL.md
+└── commands/           # optional
+```
+
+Applicable validation: plugin-level codes on the plugin manifest; skill-level codes on each nested skill; no cross-check between plugin name and individual skill names (they are independent by design — plugins can ship any number of skills under namespaced names).
+
+### Claude-marketplace
+
+A marketplace manifest that lists one or more plugins available for installation.
+
+```
+my-marketplace/
+└── .claude-plugin/
+    └── marketplace.json
+```
+
+A marketplace may **co-locate a single plugin** via `source: "./"` — see `format-detection.ts` co-located pattern detection. When co-located, the directory is treated as a single marketplace surface, not two surfaces, to preserve the historical contract.
+
+Applicable validation: marketplace-level codes.
+
+## Detection
+
+`vat audit` uses `enumerateSurfaces(dir)` (in `packages/agent-skills/src/validators/format-detection.ts`) to find every manifest at a directory's root layer. A directory can contain:
+
+- Zero surfaces (audit falls through to recursive scan)
+- One surface (single-validator dispatch; legacy behavior preserved)
+- Two surfaces (typically a skill-claude-plugin — skill + plugin emit independently)
+- Three surfaces (rare: skill + plugin + marketplace in one directory — allowed but unusual)
+
+## See also
+
+- [`docs/validation-codes.md`](../validation-codes.md) — every validation code by name, default severity, and applicable shapes.
+- [`docs/skill-quality-and-compatibility.md`](../skill-quality-and-compatibility.md) — VAT's stance on structure, packaging, and compatibility.

--- a/docs/skill-quality-and-compatibility.md
+++ b/docs/skill-quality-and-compatibility.md
@@ -95,6 +95,8 @@ The parser is a regex-based heuristic; it will be wrong. Known gaps:
 
 ## Structure
 
+See [Skill Packaging Shapes](./architecture/skill-packaging.md) for the terminology reference — the four recognized artifact shapes (standalone skill, skill-claude-plugin, claude-plugin, claude-marketplace) and how their validation applies.
+
 VAT believes skills should be **self-contained** and **progressively disclosed**: all linked resources live inside the skill directory, and long content is split into linked resources rather than loaded into a monolithic SKILL.md. Skills that reach outside their directory couple silently to project layout; skills that bundle everything into SKILL.md crowd the agent's context. See `LINK_OUTSIDE_PROJECT`, `LINK_TARGETS_DIRECTORY`, `LINK_TO_NAVIGATION_FILE`, `LINK_TO_GITIGNORED_FILE`, `LINK_TO_SKILL_DEFINITION`, `NO_PROGRESSIVE_DISCLOSURE`, and `REFERENCE_TOO_DEEP` in [`docs/validation-codes.md`](./validation-codes.md) for the code-level enforcement.
 
 ## Packaging

--- a/docs/validation-codes.md
+++ b/docs/validation-codes.md
@@ -190,6 +190,13 @@ Best-practice checks about skill shape and content.
 - **Why it matters:** Anthropic's guidance is unambiguous: "Always write in third person. The description is injected into the system prompt, and inconsistent point-of-view can cause discovery problems." Their bad examples are literally `I can help you process Excel files` and `You can use this to process Excel files`.
 - **Fix:** Rewrite in third person. `I can extract PDFs` → `Extracts text from PDFs`. `You can use this to...` → the action itself (`Processes...`, `Generates...`).
 
+### `SKILL_CLAUDE_PLUGIN_NAME_MISMATCH`
+
+- **Default:** `warning`
+- **What:** For a [skill-claude-plugin](./architecture/skill-packaging.md) (a directory with both root `SKILL.md` and `.claude-plugin/plugin.json`), the plugin manifest's `name` does not match the skill's frontmatter `name`.
+- **Why it matters:** In a skill-claude-plugin, the skill is the authoritative artifact and the plugin is a Claude-specific distribution wrapper. Name drift between the two confuses users (which name shows up in their installed-plugins list? which is referenced in config?) and usually indicates a packaging oversight. For canonical plugins (skills under `skills/<name>/`), this code does not apply — plugin names and individual skill names are independent by design.
+- **Fix:** Align the names — update `plugin.json` `name` to match the skill's frontmatter `name` (the skill is authoritative). If the plugin is intentionally namespaced differently (e.g., `com.author.foo-plugin`), configure `validation.severity: { SKILL_CLAUDE_PLUGIN_NAME_MISMATCH: ignore }` or add a `validation.allow` entry with a reason.
+
 ### `SKILL_NAME_MISMATCHES_DIR`
 
 - **Default:** `warning`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",
@@ -77,7 +77,7 @@
     "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.50.1",
     "@typescript-eslint/parser": "^8.50.1",
-    "@vibe-validate/cli": "^0.19.1",
+    "@vibe-validate/cli": "^0.19.4",
     "@vitest/coverage-v8": "^3.2.4",
     "adm-zip": "^0.5.16",
     "eslint": "^9.39.2",
@@ -96,7 +96,7 @@
     "tsx": "^4.21.0",
     "turbo": "^2.8.3",
     "typescript": "^5.9.3",
-    "vibe-validate": "^0.19.1",
+    "vibe-validate": "^0.19.4",
     "vitest": "^3.2.4",
     "yaml": "^2.8.2"
   },

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/src/index.ts
+++ b/packages/agent-skills/src/index.ts
@@ -68,7 +68,7 @@ export { validateMarketplace } from './validators/marketplace-validator.js';
 export { validatePlugin } from './validators/plugin-validator.js';
 export { validateSkill } from './validators/skill-validator.js';
 export { validate } from './validators/unified-validator.js';
-export { detectResourceFormat } from './validators/format-detection.js';
+export { detectResourceFormat, enumerateSurfaces } from './validators/format-detection.js';
 export {
   validateSkillForPackaging,
   type ExcludedReferenceDetail,
@@ -91,6 +91,7 @@ export type {
   ValidationIssue,
   ValidateOptions,
   ResourceFormat,
+  Surface,
 } from './validators/types.js';
 
 export {

--- a/packages/agent-skills/src/validators/code-registry.ts
+++ b/packages/agent-skills/src/validators/code-registry.ts
@@ -36,6 +36,7 @@ export type IssueCode =
   | 'SKILL_DESCRIPTION_OVER_CLAUDE_CODE_LIMIT'
   | 'SKILL_DESCRIPTION_FILLER_OPENER'
   | 'SKILL_DESCRIPTION_WRONG_PERSON'
+  | 'SKILL_CLAUDE_PLUGIN_NAME_MISMATCH'
   | 'SKILL_NAME_MISMATCHES_DIR'
   | 'RESERVED_WORD_IN_NAME'
   | 'SKILL_TIME_SENSITIVE_CONTENT'
@@ -177,6 +178,12 @@ export const CODE_REGISTRY: Record<IssueCode, CodeRegistryEntry> = {
     'SKILL.md description uses first-person or conversational second-person voice.',
     'Rewrite in third person. "I can extract PDFs" → "Extracts text from PDFs". "You can use this to..." → the action itself.',
     'skill_description_wrong_person',
+  ),
+  SKILL_CLAUDE_PLUGIN_NAME_MISMATCH: entry(
+    'warning',
+    'plugin.json name does not match the co-located root SKILL.md frontmatter name.',
+    'Align the names: update plugin.json `name` to match SKILL.md `name` (the skill is authoritative), or intentionally namespace the plugin (configure `validation.severity` or `validation.allow` with a reason).',
+    'skill_claude_plugin_name_mismatch',
   ),
   SKILL_NAME_MISMATCHES_DIR: entry(
     'warning',

--- a/packages/agent-skills/src/validators/format-detection.ts
+++ b/packages/agent-skills/src/validators/format-detection.ts
@@ -4,7 +4,9 @@ import * as path from 'node:path';
 
 import { safePath } from '@vibe-agent-toolkit/utils';
 
-import type { ResourceFormat } from './types.js';
+import type { ResourceFormat, Surface } from './types.js';
+
+const CLAUDE_PLUGIN_DIR_NAME = '.claude-plugin';
 
 /**
  * Detects the format of a resource at the given path
@@ -77,7 +79,7 @@ export async function detectResourceFormat(
  * Detects format for directory resources
  */
 function detectDirectoryFormat(dirPath: string): ResourceFormat {
-	const claudePluginDir = safePath.join(dirPath, '.claude-plugin');
+	const claudePluginDir = safePath.join(dirPath, CLAUDE_PLUGIN_DIR_NAME);
 
 	// Check if .claude-plugin directory exists
 	if (!fs.existsSync(claudePluginDir)) {
@@ -204,4 +206,92 @@ function detectFileFormat(filePath: string): ResourceFormat {
 		path: filePath,
 		reason: 'JSON file but not a recognized registry',
 	};
+}
+
+/**
+ * Enumerate all manifest surfaces present at a directory's root layer.
+ *
+ * Unlike {@link detectResourceFormat} (single-answer), this returns every
+ * recognized manifest found in the same directory. A skill-claude-plugin
+ * (root SKILL.md + .claude-plugin/plugin.json) returns two surfaces; a
+ * canonical plugin layout returns one (SKILL.md lives under skills/<name>/,
+ * not at the plugin root, so no agent-skill surface at this level).
+ *
+ * Detection rules (independent, all applied):
+ * - `<dir>/SKILL.md` exists → { type: 'agent-skill', path: <dir>/SKILL.md }
+ * - `<dir>/.claude-plugin/plugin.json` exists → { type: 'claude-plugin', path: <dir> }
+ * - `<dir>/.claude-plugin/marketplace.json` exists → { type: 'marketplace', path: <dir> }
+ *
+ * Returns `[]` for nonexistent paths, files, or directories with no recognized manifests.
+ *
+ * @param dirPath - Absolute path to a directory
+ * @returns Array of surfaces in enumerator-stable order (skill, plugin, marketplace)
+ */
+export async function enumerateSurfaces(dirPath: string): Promise<Surface[]> {
+	try {
+		if (!fs.existsSync(dirPath)) {
+			return [];
+		}
+		const stats = fs.statSync(dirPath);
+		if (!stats.isDirectory()) {
+			return [];
+		}
+	} catch {
+		return [];
+	}
+
+	const surfaces: Surface[] = [];
+
+	const skillPath = safePath.join(dirPath, 'SKILL.md');
+	if (fs.existsSync(skillPath)) {
+		surfaces.push({ type: 'agent-skill', path: skillPath });
+	}
+
+	const pluginJsonPath = safePath.join(dirPath, CLAUDE_PLUGIN_DIR_NAME, 'plugin.json');
+	const marketplaceJsonPath = safePath.join(dirPath, CLAUDE_PLUGIN_DIR_NAME, 'marketplace.json');
+	const hasPlugin = fs.existsSync(pluginJsonPath);
+	const hasMarketplace = fs.existsSync(marketplaceJsonPath);
+
+	// Co-located plugin/marketplace pattern: when both plugin.json and
+	// marketplace.json are present AND the marketplace references the current
+	// directory via `source: "./"`, detectResourceFormat collapses to a single
+	// `marketplace` surface. Preserve that collapse here so a co-located
+	// marketplace does not produce two parallel results (marketplace AND plugin).
+	const isColocated = hasPlugin && hasMarketplace && hasColocatedPluginInMarketplace(marketplaceJsonPath);
+
+	if (hasPlugin && !isColocated) {
+		surfaces.push({ type: 'claude-plugin', path: dirPath });
+	}
+
+	if (hasMarketplace) {
+		surfaces.push({ type: 'marketplace', path: dirPath });
+	}
+
+	return surfaces;
+}
+
+/**
+ * Returns true when marketplace.json declares a plugin with `source` pointing
+ * at the current directory (`./`, `.`, etc.), indicating a single-directory
+ * marketplace that owns the co-located plugin.
+ *
+ * Best-effort: swallows read/parse errors (caller treats as "not co-located").
+ */
+function hasColocatedPluginInMarketplace(marketplaceJsonPath: string): boolean {
+	try {
+		const content = fs.readFileSync(marketplaceJsonPath, 'utf-8');
+		const data = JSON.parse(content) as Record<string, unknown>;
+		const plugins = data['plugins'];
+		if (!Array.isArray(plugins)) {
+			return false;
+		}
+		return plugins.some((plugin: unknown) => {
+			if (typeof plugin !== 'object' || plugin === null) return false;
+			const source = (plugin as Record<string, unknown>)['source'];
+			if (typeof source !== 'string') return false;
+			return source === './' || source === '.' || source === '.\\' || source === '';
+		});
+	} catch {
+		return false;
+	}
 }

--- a/packages/agent-skills/src/validators/index.ts
+++ b/packages/agent-skills/src/validators/index.ts
@@ -1,4 +1,4 @@
-export { detectResourceFormat } from './format-detection.js';
+export { detectResourceFormat, enumerateSurfaces } from './format-detection.js';
 export { validatePlugin } from './plugin-validator.js';
 export {
 	validateInstalledPluginsRegistry,
@@ -11,6 +11,7 @@ export type {
 	IssueSeverity,
 	LinkedFileValidationResult,
 	ResourceFormat,
+	Surface,
 	ValidateOptions,
 	ValidationIssue,
 	ValidationResult,

--- a/packages/agent-skills/src/validators/plugin-validator.ts
+++ b/packages/agent-skills/src/validators/plugin-validator.ts
@@ -13,6 +13,155 @@ import {
 
 const PLUGIN_TYPE = 'claude-plugin' as const;
 
+interface FrontmatterNameReadResult {
+	skillFrontmatterName?: string;
+}
+
+/**
+ * Best-effort read of a co-located SKILL.md's frontmatter `name` field.
+ *
+ * Returns `{ skillFrontmatterName: undefined }` when SKILL.md is absent,
+ * unreadable, has no frontmatter, or the frontmatter has no `name`. Silent
+ * failure is intentional — the skill validator handles its own errors, and
+ * this helper only exists to enable the plugin-side cross-check.
+ *
+ * Accepts a minimal YAML subset: only extracts `name: <value>` from the first
+ * frontmatter block. Full YAML parsing is not needed here because the skill
+ * validator already reports every frontmatter-parse failure separately.
+ */
+/**
+ * Extract the YAML frontmatter block from file content, or undefined when
+ * the content does not begin with a `---` fence.
+ *
+ * Uses indexOf instead of regex to avoid slow-regex lint errors.
+ */
+function extractFrontmatterBlock(content: string): string | undefined {
+	// Normalize CRLF to LF so Windows-authored SKILL.md files parse identically.
+	// Matches the convention in parsers/frontmatter-parser.ts.
+	const normalized = content.replaceAll('\r\n', '\n');
+	const FENCE = '---';
+	if (!normalized.startsWith(`${FENCE}\n`)) {
+		return undefined;
+	}
+	const openerEnd = FENCE.length + 1;
+	const closerStart = normalized.indexOf(`\n${FENCE}`, openerEnd);
+	return closerStart === -1 ? undefined : normalized.slice(openerEnd, closerStart);
+}
+
+/** Strip optional surrounding single or double quotes from a YAML scalar. */
+function stripYamlQuotes(raw: string): string {
+	if (raw.length >= 2) {
+		const first = raw.at(0);
+		const last = raw.at(-1);
+		if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+			return raw.slice(1, -1);
+		}
+	}
+	return raw;
+}
+
+function readColocatedSkillFrontmatterName(pluginDir: string): FrontmatterNameReadResult {
+	const skillPath = safePath.join(pluginDir, 'SKILL.md');
+	if (!existsSync(skillPath)) {
+		return {};
+	}
+
+	let content: string;
+	try {
+		content = readFileSync(skillPath, 'utf-8');
+	} catch {
+		return {};
+	}
+
+	const frontmatter = extractFrontmatterBlock(content);
+	if (frontmatter === undefined) {
+		return {};
+	}
+
+	// Find the `name:` line using a non-backtracking line scan.
+	const nameLine = frontmatter.split('\n').find((line) => line.startsWith('name:'));
+	if (nameLine === undefined) {
+		return {};
+	}
+
+	const raw = nameLine.slice('name:'.length).trim();
+	if (raw.length === 0) {
+		return {};
+	}
+
+	return { skillFrontmatterName: stripYamlQuotes(raw) };
+}
+
+/**
+ * Return a SKILL_CLAUDE_PLUGIN_NAME_MISMATCH issue when the plugin's co-located
+ * root SKILL.md has a `name` frontmatter field that disagrees with `pluginName`,
+ * or undefined when the names agree or SKILL.md is absent / unreadable.
+ */
+function checkPluginSkillNameMismatch(
+	pluginPath: string,
+	pluginJsonPath: string,
+	pluginName: string,
+): ValidationIssue | undefined {
+	const { skillFrontmatterName } = readColocatedSkillFrontmatterName(pluginPath);
+	if (skillFrontmatterName === undefined || skillFrontmatterName === pluginName) {
+		return undefined;
+	}
+	return {
+		severity: 'warning',
+		code: 'SKILL_CLAUDE_PLUGIN_NAME_MISMATCH',
+		message: `plugin.json name "${pluginName}" does not match co-located SKILL.md frontmatter name "${skillFrontmatterName}"`,
+		location: pluginJsonPath,
+		fix: 'Align the names: update plugin.json `name` to match SKILL.md `name` (the skill is authoritative), or intentionally namespace the plugin (configure `validation.severity` or `validation.allow` with a reason).',
+	};
+}
+
+/**
+ * Apply schema-success post-checks: set metadata, warn on missing version,
+ * and cross-check skill-claude-plugin name agreement. Mutates `issues` and
+ * `validationResult` in place; callers re-use the computed status/summary.
+ *
+ * Extracted from `validatePlugin` to keep cognitive complexity under the
+ * project threshold.
+ */
+function applyPostSchemaChecks(args: {
+	pluginPath: string;
+	pluginJsonPath: string;
+	data: { name: string; version?: string | undefined };
+	strict: boolean;
+	issues: ValidationIssue[];
+	validationResult: ValidationResult;
+}): void {
+	const { pluginPath, pluginJsonPath, data, strict, issues, validationResult } = args;
+
+	validationResult.metadata = {
+		name: data.name,
+		...(data.version !== undefined && { version: data.version }),
+	};
+
+	// Warn when version is missing — Claude Code caches plugins by version,
+	// and without it the cache directory becomes "unknown/", causing stale
+	// skill resolution across upgrades.
+	if (data.version === undefined) {
+		issues.push({
+			severity: strict ? 'error' : 'warning',
+			code: 'PLUGIN_MISSING_VERSION',
+			message: 'plugin.json missing version field — Claude Code will cache as "unknown/", causing stale skill resolution across upgrades',
+			location: pluginJsonPath,
+			fix: 'Add a "version" field to plugin.json (semver format, e.g. "1.0.0")',
+		});
+	}
+
+	const mismatchIssue = checkPluginSkillNameMismatch(pluginPath, pluginJsonPath, data.name);
+	if (mismatchIssue !== undefined) {
+		issues.push(mismatchIssue);
+	}
+
+	if (issues.length > 0) {
+		validationResult.status = calculateValidationStatus(issues);
+		validationResult.summary = `Found ${issues.length} issue(s)`;
+	}
+}
+
 /**
  * Validate a plugin directory structure against the ClaudePluginSchema.
  *
@@ -95,25 +244,14 @@ export async function validatePlugin(
 	};
 
 	if (result.success) {
-		validationResult.metadata = {
-			name: result.data.name,
-			...(result.data.version !== undefined && { version: result.data.version }),
-		};
-
-		// Warn when version is missing — Claude Code caches plugins by version,
-		// and without it the cache directory becomes "unknown/", causing stale
-		// skill resolution across upgrades.
-		if (result.data.version === undefined) {
-			issues.push({
-				severity: options?.strict ? 'error' : 'warning',
-				code: 'PLUGIN_MISSING_VERSION',
-				message: 'plugin.json missing version field — Claude Code will cache as "unknown/", causing stale skill resolution across upgrades',
-				location: pluginJsonPath,
-				fix: 'Add a "version" field to plugin.json (semver format, e.g. "1.0.0")',
-			});
-			validationResult.status = calculateValidationStatus(issues);
-			validationResult.summary = `Found ${issues.length} issue(s)`;
-		}
+		applyPostSchemaChecks({
+			pluginPath,
+			pluginJsonPath,
+			data: result.data,
+			strict: options?.strict === true,
+			issues,
+			validationResult,
+		});
 	}
 
 	return validationResult;

--- a/packages/agent-skills/src/validators/types.ts
+++ b/packages/agent-skills/src/validators/types.ts
@@ -122,3 +122,21 @@ export type ResourceFormat =
   | { type: 'installed-plugins-registry'; path: string; filename: string }
   | { type: 'known-marketplaces-registry'; path: string; filename: string }
   | { type: 'unknown'; path: string; reason?: string };
+
+/**
+ * One recognized manifest surface at a directory's root layer.
+ *
+ * Unlike {@link ResourceFormat} — which is the single-answer API used by
+ * `detectResourceFormat()` — `Surface` is emitted by `enumerateSurfaces()`
+ * which returns *every* manifest found in the same directory. A directory can
+ * contain multiple surfaces: e.g., a skill-claude-plugin has both `agent-skill`
+ * (root SKILL.md) and `claude-plugin` (.claude-plugin/plugin.json) surfaces.
+ *
+ * The `path` field points to the file to hand the validator: the SKILL.md path
+ * for skills, the directory path for plugin/marketplace (those validators resolve
+ * `<dir>/.claude-plugin/<manifest>.json` themselves).
+ */
+export type Surface =
+  | { type: 'agent-skill'; path: string }
+  | { type: 'claude-plugin'; path: string }
+  | { type: 'marketplace'; path: string };

--- a/packages/agent-skills/test/fixtures/packaging-shapes/canonical-plugin/.claude-plugin/plugin.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/canonical-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "canonical-plugin",
+  "version": "1.0.0",
+  "description": "Canonical plugin layout with skills under skills/<name>/."
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/canonical-plugin/skills/example/SKILL.md
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/canonical-plugin/skills/example/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: example
+description: A skill inside a canonical plugin layout, nested under skills/example/. Should not trigger skill-claude-plugin detection at the plugin root.
+---
+
+# Example Skill

--- a/packages/agent-skills/test/fixtures/packaging-shapes/colocated-plugin-marketplace/.claude-plugin/marketplace.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/colocated-plugin-marketplace/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "colocated-marketplace",
+  "version": "1.0.0",
+  "description": "Marketplace that co-locates a single plugin via source: './'.",
+  "plugins": [
+    {
+      "name": "colocated-plugin",
+      "source": "./"
+    }
+  ]
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/colocated-plugin-marketplace/.claude-plugin/plugin.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/colocated-plugin-marketplace/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "colocated-plugin",
+  "version": "1.0.0",
+  "description": "Plugin whose marketplace sibling points back at this directory via source: './'."
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/marketplace-only/.claude-plugin/marketplace.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/marketplace-only/.claude-plugin/marketplace.json
@@ -1,0 +1,6 @@
+{
+  "name": "marketplace-only",
+  "version": "1.0.0",
+  "description": "Marketplace with no co-located plugin.",
+  "plugins": []
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-matching/.claude-plugin/plugin.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-matching/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "matching-skill",
+  "version": "1.0.0",
+  "description": "Matching skill-claude-plugin fixture."
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-matching/SKILL.md
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-matching/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: matching-skill
+description: A skill-claude-plugin fixture whose SKILL.md frontmatter name matches plugin.json name. Used to exercise the matching branch of the name cross-check.
+---
+
+# Matching Skill

--- a/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-mismatch/.claude-plugin/plugin.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-mismatch/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "different-name",
+  "version": "1.0.0",
+  "description": "Plugin manifest with a name that differs from the co-located skill."
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-mismatch/SKILL.md
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/skill-claude-plugin-mismatch/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: mismatch-skill
+description: A skill-claude-plugin fixture whose SKILL.md frontmatter name deliberately differs from plugin.json name. Used to exercise the SKILL_CLAUDE_PLUGIN_NAME_MISMATCH detection.
+---
+
+# Mismatch Skill

--- a/packages/agent-skills/test/fixtures/packaging-shapes/standalone-skill/SKILL.md
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/standalone-skill/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: standalone-skill
+description: A bare skill fixture used to test that enumerateSurfaces returns a single agent-skill entry when no plugin manifest is present.
+---
+
+# Standalone Skill
+
+Body content for the fixture.

--- a/packages/agent-skills/test/fixtures/packaging-shapes/three-surface/.claude-plugin/marketplace.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/three-surface/.claude-plugin/marketplace.json
@@ -1,0 +1,11 @@
+{
+  "name": "three-surface-marketplace",
+  "version": "1.0.0",
+  "description": "Marketplace that does NOT point at the current directory, so the co-located collapse does not apply.",
+  "plugins": [
+    {
+      "name": "some-other-plugin",
+      "source": "./subdir/"
+    }
+  ]
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/three-surface/.claude-plugin/plugin.json
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/three-surface/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "three-surface",
+  "version": "1.0.0",
+  "description": "Plugin manifest co-located with a non-co-located marketplace."
+}

--- a/packages/agent-skills/test/fixtures/packaging-shapes/three-surface/SKILL.md
+++ b/packages/agent-skills/test/fixtures/packaging-shapes/three-surface/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: three-surface
+description: A deliberately unusual directory that holds SKILL.md plus both plugin.json and marketplace.json (non-co-located). Used to exercise the three-surface ordering contract from enumerateSurfaces.
+---
+
+# Three-Surface Fixture

--- a/packages/agent-skills/test/validators/format-detection.test.ts
+++ b/packages/agent-skills/test/validators/format-detection.test.ts
@@ -5,12 +5,15 @@ import * as fs from 'node:fs';
 import { mkdirSyncReal, safePath } from '@vibe-agent-toolkit/utils';
 import { describe, expect, it } from 'vitest';
 
-import { detectResourceFormat } from '../../src/validators/format-detection.js';
+import { detectResourceFormat, enumerateSurfaces } from '../../src/validators/format-detection.js';
 import {
 	createAmbiguousDirectory,
 	createTestPlugin,
 	setupTempDir,
 } from '../test-helpers.js';
+
+const SURFACE_TYPE_CLAUDE_PLUGIN = 'claude-plugin';
+const SURFACE_TYPE_AGENT_SKILL = 'agent-skill';
 
 describe('detectResourceFormat', () => {
 	const { getTempDir } = setupTempDir('format-detection-test-');
@@ -32,7 +35,7 @@ describe('detectResourceFormat', () => {
 
 			const result = await detectResourceFormat(pluginDir);
 
-			expect(result.type).toBe('claude-plugin');
+			expect(result.type).toBe(SURFACE_TYPE_CLAUDE_PLUGIN);
 			expect(result.path).toBe(pluginDir);
 		});
 
@@ -238,5 +241,91 @@ describe('detectResourceFormat', () => {
 				fs.chmodSync(restrictedDir, 0o755);
 			}
 		});
+	});
+});
+
+describe('enumerateSurfaces', () => {
+	const fixturesBase = safePath.join(
+		import.meta.dirname,
+		'..',
+		'fixtures',
+		'packaging-shapes',
+	);
+
+	it('returns a single agent-skill surface for a standalone skill', async () => {
+		const dir = safePath.join(fixturesBase, 'standalone-skill');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toHaveLength(1);
+		expect(surfaces[0]).toEqual({
+			type: SURFACE_TYPE_AGENT_SKILL,
+			path: safePath.join(dir, 'SKILL.md'),
+		});
+	});
+
+	it('returns both agent-skill and claude-plugin for a skill-claude-plugin', async () => {
+		const dir = safePath.join(fixturesBase, 'skill-claude-plugin-matching');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toHaveLength(2);
+		expect(surfaces).toContainEqual({
+			type: SURFACE_TYPE_AGENT_SKILL,
+			path: safePath.join(dir, 'SKILL.md'),
+		});
+		expect(surfaces).toContainEqual({ type: SURFACE_TYPE_CLAUDE_PLUGIN, path: dir });
+	});
+
+	it('returns only claude-plugin for a canonical plugin layout (no root SKILL.md)', async () => {
+		const dir = safePath.join(fixturesBase, 'canonical-plugin');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toHaveLength(1);
+		expect(surfaces[0]).toEqual({ type: SURFACE_TYPE_CLAUDE_PLUGIN, path: dir });
+	});
+
+	it('returns only marketplace when only marketplace.json is present', async () => {
+		const dir = safePath.join(fixturesBase, 'marketplace-only');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toHaveLength(1);
+		expect(surfaces[0]).toEqual({ type: 'marketplace', path: dir });
+	});
+
+	it('returns an empty array for an empty directory', async () => {
+		const dir = safePath.join(fixturesBase, 'empty-dir');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toEqual([]);
+	});
+
+	it('returns an empty array for a nonexistent path', async () => {
+		const dir = safePath.join(fixturesBase, 'does-not-exist');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toEqual([]);
+	});
+
+	it('returns an empty array for a file (not a directory)', async () => {
+		const file = safePath.join(fixturesBase, 'standalone-skill', 'SKILL.md');
+		const surfaces = await enumerateSurfaces(file);
+		expect(surfaces).toEqual([]);
+	});
+
+	it('collapses co-located plugin+marketplace to a single marketplace surface', async () => {
+		// Mirrors detectResourceFormat's co-located collapse — a marketplace that
+		// declares `source: "./"` for its plugin SHOULD NOT produce a parallel
+		// claude-plugin surface.
+		const dir = safePath.join(fixturesBase, 'colocated-plugin-marketplace');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toHaveLength(1);
+		expect(surfaces[0]).toEqual({ type: 'marketplace', path: dir });
+	});
+
+	it('returns all three surfaces in enumerator-stable order when none collapse', async () => {
+		// Non-co-located marketplace + plugin + SKILL.md: audit is expected to
+		// emit three independent results; this test documents the ordering
+		// contract (skill, plugin, marketplace).
+		const dir = safePath.join(fixturesBase, 'three-surface');
+		const surfaces = await enumerateSurfaces(dir);
+		expect(surfaces).toHaveLength(3);
+		expect(surfaces.map((s) => s.type)).toEqual([
+			SURFACE_TYPE_AGENT_SKILL,
+			SURFACE_TYPE_CLAUDE_PLUGIN,
+			'marketplace',
+		]);
 	});
 });

--- a/packages/agent-skills/test/validators/plugin-validator.test.ts
+++ b/packages/agent-skills/test/validators/plugin-validator.test.ts
@@ -1,5 +1,8 @@
+/* eslint-disable security/detect-non-literal-fs-filename -- test uses controlled temp dirs */
 
-import { safePath } from '@vibe-agent-toolkit/utils';
+import { writeFileSync } from 'node:fs';
+
+import { mkdirSyncReal, safePath } from '@vibe-agent-toolkit/utils';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { validatePlugin } from '../../src/validators/plugin-validator.js';
@@ -10,6 +13,8 @@ import {
 	createTestPlugin,
 	setupTempDir,
 } from '../test-helpers.js';
+
+const CLAUDE_PLUGIN_DIR = '.claude-plugin';
 
 describe('validatePlugin', () => {
 	const { getTempDir } = setupTempDir('plugin-validator-test-');
@@ -47,7 +52,7 @@ describe('validatePlugin', () => {
 		// Overwrite with invalid JSON
 		const fs = await import('node:fs');
 		fs.writeFileSync(
-			safePath.join(pluginPath, '.claude-plugin', 'plugin.json'),
+			safePath.join(pluginPath, CLAUDE_PLUGIN_DIR, 'plugin.json'),
 			'{ invalid json }',
 		);
 
@@ -155,5 +160,68 @@ describe('validatePlugin', () => {
 					issue.message.includes('semver'),
 			),
 		).toBe(true);
+	});
+
+	describe('SKILL_CLAUDE_PLUGIN_NAME_MISMATCH', () => {
+		const MISMATCH_CODE = 'SKILL_CLAUDE_PLUGIN_NAME_MISMATCH';
+		const fixturesBase = safePath.resolve(
+			__dirname,
+			'../fixtures/packaging-shapes',
+		);
+
+		it('does not emit when skill-claude-plugin names match', async () => {
+			const dir = safePath.join(fixturesBase, 'skill-claude-plugin-matching');
+			const result = await validatePlugin(dir);
+			expect(
+				result.issues.find((i) => i.code === MISMATCH_CODE),
+			).toBeUndefined();
+		});
+
+		it('emits a warning when skill-claude-plugin names disagree', async () => {
+			const dir = safePath.join(fixturesBase, 'skill-claude-plugin-mismatch');
+			const result = await validatePlugin(dir);
+			const issue = result.issues.find(
+				(i) => i.code === MISMATCH_CODE,
+			);
+			expect(issue).toBeDefined();
+			expect(issue?.severity).toBe('warning');
+			expect(issue?.message).toContain('different-name');
+			expect(issue?.message).toContain('mismatch-skill');
+		});
+
+		it('does not emit for canonical plugin layout (no root SKILL.md)', async () => {
+			const dir = safePath.join(fixturesBase, 'canonical-plugin');
+			const result = await validatePlugin(dir);
+			expect(
+				result.issues.find((i) => i.code === MISMATCH_CODE),
+			).toBeUndefined();
+		});
+
+		it('detects mismatch even when SKILL.md has CRLF line endings', async () => {
+			// Windows-authored SKILL.md without a .gitattributes normalization
+			// ships with CRLF. The frontmatter cross-check must still fire.
+			const tempDir = getTempDir();
+			const pluginDir = safePath.join(tempDir, 'crlf-skill-plugin');
+			mkdirSyncReal(safePath.join(pluginDir, CLAUDE_PLUGIN_DIR), { recursive: true });
+
+			const skillContentCrlf =
+				'---\r\nname: crlf-skill-name\r\ndescription: Skill with CRLF endings used to verify the plugin cross-check normalizes line endings before parsing frontmatter.\r\n---\r\n\r\n# CRLF Skill\r\n';
+			writeFileSync(safePath.join(pluginDir, 'SKILL.md'), skillContentCrlf);
+
+			writeFileSync(
+				safePath.join(pluginDir, CLAUDE_PLUGIN_DIR, 'plugin.json'),
+				JSON.stringify({
+					name: 'different-plugin-name',
+					version: '1.0.0',
+					description: 'Plugin with a name that deliberately differs from the CRLF SKILL.md.',
+				}),
+			);
+
+			const result = await validatePlugin(pluginDir);
+			const issue = result.issues.find((i) => i.code === MISMATCH_CODE);
+			expect(issue).toBeDefined();
+			expect(issue?.message).toContain('crlf-skill-name');
+			expect(issue?.message).toContain('different-plugin-name');
+		});
 	});
 });

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -2,6 +2,15 @@
 
 This document provides guidance specific to developing the vat CLI tool.
 
+## Validation Framework References
+
+Audit and related commands (`vat audit`, `vat skills validate`, `vat resources validate`) rely on VAT's unified validation framework. Before changing validator logic, read:
+
+- [`../../docs/skill-quality-and-compatibility.md`](../../docs/skill-quality-and-compatibility.md) — VAT's stance; the three-layer evidence/observation/verdict model.
+- [`../../docs/validation-codes.md`](../../docs/validation-codes.md) — Every code by name, default severity, and what triggers it.
+- [`../../docs/skill-smell-philosophy.md`](../../docs/skill-smell-philosophy.md) — Rule-addition discipline; never ship an `error`-severity code without corpus evidence.
+- [`../../docs/architecture/skill-packaging.md`](../../docs/architecture/skill-packaging.md) — The four recognized artifact shapes and which codes apply to each.
+
 ## Running vat Commands in Development
 
 **In this monorepo during development**, use one of these approaches to run vat commands:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/audit.ts
+++ b/packages/cli/src/commands/audit.ts
@@ -8,7 +8,10 @@ import { existsSync as fsExistsSync } from 'node:fs';
 
 import {
   detectResourceFormat,
+  enumerateSurfaces,
   validate,
+  validateMarketplace,
+  validatePlugin,
   validateSkill,
   validateSkillForPackaging,
   type EvidenceRecord,
@@ -746,6 +749,29 @@ export async function getValidationResults(
     const skillPath = safePath.join(scanPath, 'SKILL.md');
     logger.debug('Detected VAT agent, validating SKILL.md');
     return [await validateSingleSkill(skillPath, options, logger, true)];
+  }
+
+  // Enumerate all manifest surfaces at the directory root. If multiple are
+  // present (e.g., skill-claude-plugin: SKILL.md + .claude-plugin/plugin.json),
+  // validate each independently. This intentionally bypasses
+  // detectResourceFormat's single-answer collapse so the skill surface is not
+  // swallowed by the plugin surface.
+  const surfaces = await enumerateSurfaces(scanPath);
+  if (surfaces.length > 1) {
+    logger.debug(
+      `Detected ${surfaces.length.toString()} surfaces at ${scanPath}: ${surfaces.map((s) => s.type).join(', ')}`
+    );
+    const results: ValidationResult[] = [];
+    for (const surface of surfaces) {
+      if (surface.type === 'agent-skill') {
+        results.push(await validateSingleSkill(surface.path, options, logger));
+      } else if (surface.type === 'claude-plugin') {
+        results.push(await validatePlugin(surface.path));
+      } else {
+        results.push(await validateMarketplace(surface.path));
+      }
+    }
+    return results;
   }
 
   // For plugin/marketplace directories or registry files, use unified validator

--- a/packages/cli/src/commands/audit/hierarchical-output.ts
+++ b/packages/cli/src/commands/audit/hierarchical-output.ts
@@ -54,7 +54,7 @@ function replaceHomeDir(filePath: string): string {
  * Expected patterns:
  * - Marketplace plugin skill: .../marketplaces/{marketplace}/{plugin}/skills/{skill}/SKILL.md
  * - Standalone plugin skill (in plugins dir): .../plugins/{plugin}/skills/{skill}/SKILL.md (no marketplaces/)
- * - Standalone plugin skill (no skills subdir): .../plugins/{skill}/SKILL.md (no skills/)
+ * - Skill-claude-plugin: .../plugins/{skill}/SKILL.md (root SKILL.md + .claude-plugin/plugin.json, no skills/ subdir)
  * - Standalone skill (in skills dir): ~/.claude/skills/{skill}/SKILL.md
  */
 function parsePathStructure(filePath: string): {
@@ -123,7 +123,7 @@ function parsePluginPath(
     }
   }
 
-  // Standalone skill in plugins dir: .../plugins/{skill}/SKILL.md (no /skills/ subdir)
+  // Skill-claude-plugin: .../plugins/{skill}/SKILL.md (root SKILL.md + .claude-plugin/plugin.json, no /skills/ subdir)
   const skill = parts[pluginsIdx + 1];
   if (skill !== undefined) {
     return { skill, isCached };

--- a/packages/cli/test/integration/audit-packaging-shapes.integration.test.ts
+++ b/packages/cli/test/integration/audit-packaging-shapes.integration.test.ts
@@ -1,0 +1,86 @@
+import type { ValidationResult } from '@vibe-agent-toolkit/agent-skills';
+import { safePath } from '@vibe-agent-toolkit/utils';
+import { describe, expect, it } from 'vitest';
+
+import type { AuditCommandOptions } from '../../src/commands/audit.js';
+import { getValidationResults, resetAuditCaches } from '../../src/commands/audit.js';
+
+const MISMATCH_CODE = 'SKILL_CLAUDE_PLUGIN_NAME_MISMATCH';
+const SURFACE_TYPE_CLAUDE_PLUGIN = 'claude-plugin';
+
+const silentLogger = {
+  info: (_msg: string) => {},
+  error: (_msg: string) => {},
+  debug: (_msg: string) => {},
+};
+
+async function runAudit(targetPath: string, options: AuditCommandOptions = {}) {
+  resetAuditCaches();
+  return getValidationResults(targetPath, options.recursive !== false, options, silentLogger);
+}
+
+function expectNoMismatchOnPlugin(results: ValidationResult[]): void {
+  const pluginResult = results.find((r) => r.type === SURFACE_TYPE_CLAUDE_PLUGIN);
+  expect(pluginResult).toBeDefined();
+  expect(
+    pluginResult?.issues.find((i) => i.code === MISMATCH_CODE),
+  ).toBeUndefined();
+}
+
+describe('audit: packaging shapes (integration)', () => {
+  const fixturesBase = safePath.join(
+    import.meta.dirname,
+    '..',
+    '..',
+    '..',
+    'agent-skills',
+    'test',
+    'fixtures',
+    'packaging-shapes',
+  );
+
+  it('standalone-skill fixture produces one agent-skill result', async () => {
+    const dir = safePath.join(fixturesBase, 'standalone-skill');
+    const results = await runAudit(dir, { recursive: false });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.type).toBe('agent-skill');
+  });
+
+  it('skill-claude-plugin-matching fixture produces two results (skill + plugin), no mismatch issue', async () => {
+    const dir = safePath.join(fixturesBase, 'skill-claude-plugin-matching');
+    const results = await runAudit(dir, { recursive: false });
+    expect(results).toHaveLength(2);
+    const types = results.map((r) => r.type).sort((a, b) => a.localeCompare(b));
+    expect(types).toEqual(['agent-skill', SURFACE_TYPE_CLAUDE_PLUGIN]);
+    expectNoMismatchOnPlugin(results);
+  });
+
+  it('skill-claude-plugin-mismatch fixture produces two results with SKILL_CLAUDE_PLUGIN_NAME_MISMATCH on the plugin', async () => {
+    const dir = safePath.join(fixturesBase, 'skill-claude-plugin-mismatch');
+    const results = await runAudit(dir, { recursive: false });
+    expect(results).toHaveLength(2);
+    const pluginResult = results.find((r) => r.type === SURFACE_TYPE_CLAUDE_PLUGIN);
+    expect(pluginResult).toBeDefined();
+    const issue = pluginResult?.issues.find((i) => i.code === MISMATCH_CODE);
+    expect(issue).toBeDefined();
+    expect(issue?.severity).toBe('warning');
+  });
+
+  it('canonical-plugin fixture produces one claude-plugin result (no skill at root)', async () => {
+    const dir = safePath.join(fixturesBase, 'canonical-plugin');
+    const results = await runAudit(dir, { recursive: false });
+    expect(results.some((r) => r.type === SURFACE_TYPE_CLAUDE_PLUGIN)).toBe(true);
+    expectNoMismatchOnPlugin(results);
+  });
+
+  it('colocated-plugin-marketplace fixture produces one marketplace result (collapse preserved)', async () => {
+    // Regression: enumerateSurfaces must honor detectResourceFormat's
+    // co-located collapse — a marketplace that points at the current
+    // directory via `source: "./"` must not produce a parallel claude-plugin
+    // result even though .claude-plugin/plugin.json also exists.
+    const dir = safePath.join(fixturesBase, 'colocated-plugin-marketplace');
+    const results = await runAudit(dir, { recursive: false });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.type).toBe('marketplace');
+  });
+});

--- a/packages/cli/test/system/audit-skill-claude-plugin.system.test.ts
+++ b/packages/cli/test/system/audit-skill-claude-plugin.system.test.ts
@@ -1,0 +1,72 @@
+/**
+ * System test: `vat audit` recognizes skill-claude-plugin packaging shape.
+ *
+ * Spawns the built CLI against the skill-claude-plugin fixtures in
+ * `packages/agent-skills/test/fixtures/packaging-shapes/` and verifies that
+ * audit emits independent results for each surface.
+ */
+
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { safePath } from '@vibe-agent-toolkit/utils';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { executeCli, executeCliAndParseYaml, getWrapperPath } from './test-common.js';
+
+interface FileEntry {
+  type?: string;
+  path?: string;
+}
+
+interface AuditSummary {
+  filesScanned?: number;
+}
+
+interface ParsedAuditOutput {
+  summary?: AuditSummary;
+  files?: FileEntry[];
+}
+
+const binPath = getWrapperPath(import.meta.url);
+const fixturesBase = safePath.join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  '..',
+  'agent-skills',
+  'test',
+  'fixtures',
+  'packaging-shapes',
+);
+
+describe('vat audit skill-claude-plugin (system)', () => {
+  beforeAll(() => {
+    const check = executeCli(binPath, ['--help']);
+    if (check.status !== 0) {
+      throw new Error('CLI not built. Run `bun run build` before these tests.');
+    }
+  });
+
+  it('emits two entries with expected types for the matching fixture', () => {
+    const dir = safePath.join(fixturesBase, 'skill-claude-plugin-matching');
+    const { result, parsed } = executeCliAndParseYaml(binPath, ['audit', dir]);
+    expect(result.status).toBe(0);
+
+    const audit = parsed as ParsedAuditOutput;
+    expect(audit.summary?.filesScanned).toBe(2);
+    expect(audit.files).toHaveLength(2);
+    const types = (audit.files ?? [])
+      .map((f) => f.type)
+      .filter((t): t is string => typeof t === 'string')
+      .sort((a, b) => a.localeCompare(b));
+    expect(types).toEqual(['agent-skill', 'claude-plugin']);
+  });
+
+  it('emits SKILL_CLAUDE_PLUGIN_NAME_MISMATCH for the mismatch fixture', () => {
+    const dir = safePath.join(fixturesBase, 'skill-claude-plugin-mismatch');
+    const result = executeCli(binPath, ['audit', dir]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('SKILL_CLAUDE_PLUGIN_NAME_MISMATCH');
+  });
+});

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.33",
+  "version": "0.1.34-rc.1",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Introduce the **skill-claude-plugin** artifact shape — a skill with co-located `.claude-plugin/plugin.json`. `vat audit` now emits independent `ValidationResult` entries for each surface via a new `enumerateSurfaces()` helper.
- Add `SKILL_CLAUDE_PLUGIN_NAME_MISMATCH` (default `warning`) that fires when the plugin manifest and SKILL.md frontmatter declare different `name` values.
- Shift-left documentation: new `docs/architecture/skill-packaging.md` terminology reference, new directory-level `CLAUDE.md` navigators, validation framework refs in `packages/cli/CLAUDE.md`.
- Also: `vibe-validate` / `@vibe-validate/cli` upgraded to `^0.19.4`; version bumped to `0.1.34-rc.1`.

## Architecture

`enumerateSurfaces()` returns ALL manifests at a directory root (skill, plugin, marketplace). `detectResourceFormat()` (single-answer) is preserved for legacy callers. Audit's directory-entry path engages the new multi-surface branch only when `>1` surfaces are present, so single-surface directories retain legacy behavior. The co-located marketplace collapse (`source: "./"`) is preserved — verified against Astronomer's real `data-engineering` plugin and against a dedicated fixture.

## Terminology (canonical)

| Shape | Layout |
|---|---|
| Standalone skill | `my-skill/SKILL.md` |
| Skill-claude-plugin | `my-skill/SKILL.md` + `my-skill/.claude-plugin/plugin.json` |
| Claude-plugin (canonical) | `my-plugin/.claude-plugin/plugin.json` + `my-plugin/skills/<name>/SKILL.md` |
| Claude-marketplace | `my-marketplace/.claude-plugin/marketplace.json` |

Full reference: [`docs/architecture/skill-packaging.md`](docs/architecture/skill-packaging.md)

## Test plan

- [x] Unit — `format-detection.test.ts` (21 tests: enumerator shapes incl. co-located collapse and three-surface ordering)
- [x] Unit — `plugin-validator.test.ts` (13 tests: `SKILL_CLAUDE_PLUGIN_NAME_MISMATCH` matching/mismatch/canonical/CRLF)
- [x] Integration — `audit-packaging-shapes.integration.test.ts` (5 tests across all fixtures)
- [x] System — `audit-skill-claude-plugin.system.test.ts` (end-to-end via spawned CLI on matching and mismatch fixtures)
- [x] `bun run validate` — all gates green (fast checks, unit+coverage, integration, system)
- [x] QA sweep against real data: `vat audit --user` (360 files, zero false positives, zero crashes); direct audit on Astronomer `data-engineering` plugin (co-located collapse still single marketplace); canonical plugin unaffected
- [x] Code review dispatched via `pr-review-toolkit:code-reviewer` — two issues raised (co-located marketplace regression, CRLF normalization) both fixed with added tests and fixtures before commit

## Deferred (captured in project memory, not this PR)

- `filesScanned` field name is misleading in audit output (counts surfaces, not files)
- Link-walker doesn't follow bare paths or inline-backtick / code-block references — skills that reference resources via `import` statements or bash commands rather than `[label](path)` markdown syntax get zero traversal coverage
- `scanDirectory` heuristic skips skill directories that also contain large content trees (e.g., `~/.claude-personal/skills/cpto-exec-kb/`)
- `enumerateSurfaces` is only used at the audit entry; recursive children still go through legacy `detectResourceFormat`, causing asymmetry for three-surface directories

All are pre-existing VAT behaviors — none block this PR. Scheduled for a follow-up RC after community-scan calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)