### PR TITLE
feat: multi-plugin marketplace independent versioning (v0.1.35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.35] - 2026-05-09
+
+### Added
+- **Multi-plugin marketplaces with independent versioning.** Each plugin in a marketplace can now declare its own version (in `plugins/<name>/.claude-plugin/plugin.json:version` or via the marketplace config's per-plugin `version` field), get its own per-plugin source-repo tag (`<plugin>-v<version>`) on `vat claude marketplace publish`, and ship its own CHANGELOG (default `<plugin.source>/CHANGELOG.md`, override via the per-plugin `changelog` field) bundled into the published marketplace at `plugins/<name>/CHANGELOG.md`. The published `marketplace.json` includes `version` per plugin entry when defined. Marketplaces with no per-plugin version inherit the root `package.json:version` (backwards compatible — exercised by integration test scenario 3 against the existing avonrisk-sdlc shape). Unblocks the AvonRiskBuilders marketplace where each topical plugin must version and release independently.
+
+### Changed
+- **Version precedence in `mergePluginJson` flipped.** When both a marketplace-config version and a `plugin.json:version` are present, config wins (with a reconciliation warning); when only `plugin.json:version` is present, it now wins over the root `package.json` version. Previously the root version always won. Single-version marketplaces (no per-plugin version anywhere) are unaffected.
+
 ## [0.1.34] - 2026-05-06
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.23.5",
@@ -86,7 +86,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -112,7 +112,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
         "@vibe-agent-toolkit/resources": "workspace:*",
@@ -129,7 +129,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -167,7 +167,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "semver": "^7.7.3",
@@ -186,7 +186,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -197,7 +197,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -213,7 +213,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -234,7 +234,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -251,7 +251,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -272,7 +272,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -284,6 +284,7 @@
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "remark-parse": "^11.0.0",
+        "semver": "^7.7.3",
         "unified": "^11.0.5",
         "unist-util-visit": "^5.0.0",
         "zod": "^3.24.1",
@@ -293,6 +294,7 @@
         "@types/mdast": "^4.0.4",
         "@types/node": "^22.10.5",
         "@types/picomatch": "^4.0.2",
+        "@types/semver": "^7.7.1",
         "rimraf": "^6.0.1",
         "typescript": "^5.7.3",
         "vitest": "^2.1.8",
@@ -300,7 +302,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -319,7 +321,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -337,7 +339,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -355,7 +357,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -376,7 +378,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -389,7 +391,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -403,7 +405,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -424,7 +426,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -439,7 +441,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -465,7 +467,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/src/commands/claude/marketplace/git-publish.ts
+++ b/packages/cli/src/commands/claude/marketplace/git-publish.ts
@@ -13,6 +13,8 @@ import { normalizedTmpdir, safePath } from '@vibe-agent-toolkit/utils';
 import type { Logger } from '../../../utils/logger.js';
 import { redactUrlCredentials } from '../../../utils/url-redact.js';
 
+import { pluginTagName } from './tag-utils.js';
+
 export interface CommitMetadata {
   sourceRepo?: string;
   commitRange?: string;
@@ -26,6 +28,14 @@ export interface PublishGitOptions {
   force: boolean;
   dryRun: boolean;
   noPush: boolean;
+  /**
+   * Plugins (with resolved versions) extracted from the published
+   * marketplace.json. After a successful branch push, each entry is tagged
+   * `<name>-v<version>` on the SOURCE repo (the cwd from which vat was
+   * invoked) and pushed to the remote. Tag-push failures are logged as
+   * warnings — they do NOT roll back the publish.
+   */
+  publishedPlugins: { name: string; version: string }[];
   logger: Logger;
 }
 
@@ -110,15 +120,101 @@ function resolveRemoteUrl(remote: string, cwd: string): string {
 }
 
 /**
+ * Push per-plugin source-repo tags for each entry in `publishedPlugins`.
+ *
+ * Runs against the SOURCE repo (cwd), not the temp publish repo, because the
+ * source commit is the artifact users want to identify. Tag failures are
+ * logged as warnings — the publish itself already succeeded, so we never
+ * throw from this helper.
+ *
+ * Republish-without-bump safety: we never use `git tag -f`. If the tag
+ * already exists locally at HEAD, that's fine — skip the local create and
+ * still attempt the push (a no-op if the remote already has it). If the
+ * tag exists locally pointing at a different SHA than HEAD, the user is
+ * republishing the same `<plugin>@<version>` on new commits without bumping
+ * — emit a clear warning and do NOT move the local tag or push it. This
+ * preserves the user's existing reference to the originally released commit.
+ */
+function pushPluginTags(
+  cwd: string,
+  remoteUrl: string,
+  publishedPlugins: { name: string; version: string }[],
+  logger: Logger,
+): void {
+  if (publishedPlugins.length === 0) return;
+
+  for (const plugin of publishedPlugins) {
+    const tag = pluginTagName(plugin.name, plugin.version);
+
+    // 1. Reconcile local tag state. If the tag exists at a different SHA than
+    //    HEAD, this is the republish-without-bump case — bail with guidance.
+    const headSha = git(['rev-parse', 'HEAD'], { cwd }).stdout.trim();
+    const existingTagSha = git(['rev-list', '-n', '1', tag], {
+      cwd,
+      allowFailure: true,
+    }).stdout.trim();
+
+    let skipPush = false;
+    if (existingTagSha === '') {
+      // Tag does not exist locally — create it (without -f).
+      try {
+        git(['tag', tag], { cwd });
+      } catch (err) {
+        logger.info(
+          `   warning: failed to create local tag ${tag}: ${(err as Error).message}. ` +
+            `Skipping tag push.`,
+        );
+        skipPush = true;
+      }
+    } else if (existingTagSha === headSha) {
+      // Tag is already correct locally — skip create, still try the push so
+      // the remote catches up if it was missing this tag.
+      logger.debug(`   Tag ${tag} already exists locally at HEAD — skipping local tag create.`);
+    } else {
+      // Republish-without-bump: tag exists locally at a different SHA. Do
+      // NOT move the local tag, do NOT push.
+      logger.info(
+        `   warning: tag ${tag} already exists locally at ${existingTagSha} but HEAD is ${headSha}. ` +
+          `This usually means the plugin was republished at the same version on new ` +
+          `commits. Either bump the plugin's version, or (if intentional) delete the ` +
+          `existing tag with \`git tag -d ${tag}\` and force-push, accepting that ` +
+          `consumers may have already cached the old commit at this version.`,
+      );
+      continue;
+    }
+
+    if (skipPush) continue;
+
+    // 2. Push the tag to the remote (non-force). If the remote already has the
+    //    tag at a different commit, this push will fail — surface that as a
+    //    warning explaining the most likely cause.
+    try {
+      git(['push', remoteUrl, tag], { cwd });
+      logger.info(`   Tagged source repo: ${tag}`);
+    } catch (err) {
+      logger.info(
+        `   warning: failed to push tag ${tag}: ${(err as Error).message}. The most likely cause ` +
+          `is that ${tag} already exists on the remote at a different commit. The publish ` +
+          `itself succeeded; if you intended to republish at the same version, the version ` +
+          `should be bumped.`,
+      );
+    }
+  }
+}
+
+/**
  * Deliver the commit: dry-run (show info), no-push (local branch), or push to remote.
  */
 function deliverCommit(
   tmpRepo: string,
   cwd: string,
-  options: Pick<PublishGitOptions, 'branch' | 'remote' | 'force' | 'dryRun' | 'noPush' | 'logger'>,
+  options: Pick<
+    PublishGitOptions,
+    'branch' | 'remote' | 'force' | 'dryRun' | 'noPush' | 'publishedPlugins' | 'logger'
+  >,
   remoteUrl: string,
 ): void {
-  const { branch, remote, force, dryRun, noPush, logger } = options;
+  const { branch, remote, force, dryRun, noPush, publishedPlugins, logger } = options;
 
   if (dryRun) {
     logger.info('   [dry-run] Would push to remote. Commit staged at:');
@@ -146,6 +242,11 @@ function deliverCommit(
   }
   git(pushArgs, { cwd: tmpRepo });
   logger.info(`   Pushed to ${redactUrlCredentials(remoteUrl)} branch ${branch}`);
+
+  // Tag the source repo with per-plugin tags (`<name>-v<version>`) and push
+  // them to the remote. Failures are logged as warnings, never thrown — the
+  // publish already succeeded above.
+  pushPluginTags(cwd, remoteUrl, publishedPlugins, logger);
 }
 
 /**

--- a/packages/cli/src/commands/claude/marketplace/publish-tree.ts
+++ b/packages/cli/src/commands/claude/marketplace/publish-tree.ts
@@ -44,6 +44,18 @@ export interface ComposeResult {
   version: string;
   changelogDelta: string;
   files: string[];
+  /**
+   * Plugins listed in the published marketplace.json with their resolved versions.
+   * Used by the publish flow to push per-plugin source-repo tags after a successful
+   * branch push. Plugins without a `version` field are skipped.
+   */
+  publishedPlugins: { name: string; version: string }[];
+}
+
+/** Shape we read defensively out of the published marketplace.json. */
+interface PublishedPluginInfo {
+  name: string;
+  version?: string;
 }
 
 export async function composePublishTree(options: ComposeOptions): Promise<ComposeResult> {
@@ -64,6 +76,22 @@ export async function composePublishTree(options: ComposeOptions): Promise<Compo
   // Use cpSync instead of async cp() — Node 22 cp() drops files in nested directories
   cpSync(buildDir, outputDir, { recursive: true });
   files.push('.claude-plugin/marketplace.json', 'plugins/');
+
+  // 2b. Read the published marketplace.json so the publish flow knows which
+  //     plugins (and resolved versions) to tag after a successful push. The
+  //     build pipeline writes this file; we just observe it here. Defensive
+  //     parsing because marketplace.json is build output, not validated input
+  //     at this layer.
+  const marketplaceJsonPath = safePath.join(outputDir, '.claude-plugin', 'marketplace.json');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path constructed from validated config
+  const marketplaceJsonRaw = readFileSync(marketplaceJsonPath, 'utf-8');
+  const marketplaceJson = JSON.parse(marketplaceJsonRaw) as { plugins?: PublishedPluginInfo[] };
+  // Plugins without a resolved version are not eligible for tagging — skip them.
+  const publishedPlugins = (marketplaceJson.plugins ?? [])
+    .filter((p): p is { name: string; version: string } =>
+      Boolean(p.name) && typeof p.version === 'string' && p.version.length > 0,
+    )
+    .map((p) => ({ name: p.name, version: p.version }));
 
   // 3. Process changelog — VAT copies the source file byte-for-byte into the publish tree.
   //    We only extract a release-note string for the commit body (changelogDelta).
@@ -118,5 +146,5 @@ export async function composePublishTree(options: ComposeOptions): Promise<Compo
     files.push('LICENSE');
   }
 
-  return { version, changelogDelta, files };
+  return { version, changelogDelta, files, publishedPlugins };
 }

--- a/packages/cli/src/commands/claude/marketplace/publish.ts
+++ b/packages/cli/src/commands/claude/marketplace/publish.ts
@@ -64,10 +64,28 @@ Description:
     [version] section matching package.json, or (as a fallback) a
     non-empty [Unreleased] section. Publish fails if neither is
     present. VAT never mutates CHANGELOG.md.
+  - Per-plugin CHANGELOG.md — when plugins/<name>/CHANGELOG.md exists
+    (or the marketplace plugin entry's changelog field points to one),
+    it is bundled into the published marketplace at
+    plugins/<name>/CHANGELOG.md alongside the marketplace-level
+    CHANGELOG.md.
   - README.md
   - LICENSE (SPDX shortcut or file)
 
   Creates one squashed commit per version on the target branch.
+
+  Per-plugin source-repo tags:
+  After a successful publish, pushes <plugin>-v<version> tags to the
+  source repo for each plugin with a resolved version. Tag-push failures
+  log a warning but do not roll back the publish (publish branch is
+  already pushed at that point). Skipped during --dry-run and --no-push.
+
+Per-plugin versioning:
+  Each plugin can declare its own version via plugins/<name>/.claude-plugin/plugin.json:version
+  or the marketplace config's per-plugin version field. Precedence:
+    marketplace config > plugin.json:version > root package.json:version
+  When neither is set, all plugins inherit the root version (existing
+  single-version model — preserved for backwards compatibility).
 
 Output:
   YAML summary -> stdout
@@ -207,6 +225,7 @@ async function publishOneMarketplace(ctx: PublishOneOptions): Promise<PublishRes
     force: options.force ?? false,
     dryRun: options.dryRun ?? false,
     noPush: options.push === false,
+    publishedPlugins: composeResult.publishedPlugins,
     logger,
   });
 

--- a/packages/cli/src/commands/claude/marketplace/tag-utils.ts
+++ b/packages/cli/src/commands/claude/marketplace/tag-utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Format a per-plugin source-repo tag name for the multi-plugin marketplace
+ * publish flow.
+ *
+ * Plugin-name validation (`/^[a-z0-9][a-z0-9-]*$/`) is enforced upstream by
+ * `ClaudeMarketplacePluginEntrySchema`; semver validation is enforced upstream
+ * by the schema's `version` refine. This formatter only enforces non-empty
+ * inputs.
+ */
+export function pluginTagName(name: string, version: string): string {
+  if (!name) throw new Error('Plugin name is required for tag naming');
+  if (!version) throw new Error('Version is required for tag naming');
+  return `${name}-v${version}`;
+}

--- a/packages/cli/src/commands/claude/plugin/build.ts
+++ b/packages/cli/src/commands/claude/plugin/build.ts
@@ -419,7 +419,7 @@ function matchesSelector(skillName: string, selector: string): boolean {
  */
 function readAuthorPluginJson(
   pluginSourceDir: string,
-): Record<string, unknown> | undefined {
+): (Record<string, unknown> & { version?: string }) | undefined {
   const authorPluginJsonPath = safePath.join(pluginSourceDir, CLAUDE_PLUGIN_DIRNAME, 'plugin.json');
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- controlled path
   if (!existsSync(authorPluginJsonPath)) {
@@ -582,7 +582,7 @@ async function buildPlugin(
   const authorJson = readAuthorPluginJson(pluginSourceDir);
   const pluginVersion = resolveVersion(
     pluginDef,
-    authorJson as { version?: string } | undefined,
+    authorJson,
     rootVersion,
     { warn: (message) => logger.info(`warning: ${message}`) },
   );

--- a/packages/cli/src/commands/claude/plugin/build.ts
+++ b/packages/cli/src/commands/claude/plugin/build.ts
@@ -19,8 +19,9 @@ import { createLogger } from '../../../utils/logger.js';
 import { writeYamlOutput } from '../../../utils/output.js';
 import { loadClaudeProjectConfig } from '../claude-config.js';
 
+import { resolvePluginChangelogPath } from './plugin-changelog.js';
 import { applyPluginFiles } from './plugin-files.js';
-import { mergePluginJson } from './plugin-json-merge.js';
+import { mergePluginJson, resolveVersion } from './plugin-json-merge.js';
 import {
   parsePluginJsonFiles,
   verifyNoCaseCollidingPluginNames,
@@ -38,6 +39,7 @@ const CLAUDE_PLUGIN_DIRNAME = '.claude-plugin';
 interface PluginBuildResult {
   pluginName: string;
   pluginDir: string;
+  pluginVersion: string | undefined;
   skillsCopied: string[];
   commandsCopied: number;
   hooksCopied: number;
@@ -133,15 +135,17 @@ async function pluginBuildCommand(options: PluginBuildCommandOptions): Promise<v
       process.exit(0);
     }
 
-    // Read version from package.json — used in plugin.json so Claude Code
-    // caches by version instead of "unknown/"
-    let packageVersion: string | undefined;
+    // Read version from root package.json — lowest-precedence fallback in the
+    // per-plugin version chain (config > plugin.json > root). Used so Claude
+    // Code caches by version instead of "unknown/" when no per-plugin version
+    // is supplied.
+    let rootVersion: string | undefined;
     try {
       const pkgPath = safePath.join(configDir, 'package.json');
       // eslint-disable-next-line security/detect-non-literal-fs-filename -- configDir from loadClaudeProjectConfig
       const pkgRaw = readFileSync(pkgPath, 'utf-8');
       const pkg = JSON.parse(pkgRaw) as { version?: string };
-      packageVersion = pkg.version;
+      rootVersion = pkg.version;
     } catch {
       // No package.json or unreadable — version will be omitted
     }
@@ -176,7 +180,7 @@ async function pluginBuildCommand(options: PluginBuildCommandOptions): Promise<v
         mpConfig,
         availableSkills,
         configDir,
-        packageVersion,
+        rootVersion,
         logger,
       );
       results.push(result);
@@ -263,7 +267,7 @@ async function buildMarketplace(
   config: ClaudeMarketplaceConfig,
   availableSkills: string[],
   configDir: string,
-  packageVersion: string | undefined,
+  rootVersion: string | undefined,
   logger: ReturnType<typeof createLogger>,
 ): Promise<MarketplaceBuildResult> {
   const plugins: PluginBuildResult[] = [];
@@ -292,7 +296,7 @@ async function buildMarketplace(
       marketplaceAvailable,
       configDir,
       config.owner,
-      packageVersion,
+      rootVersion,
       logger,
     );
     plugins.push(pluginResult);
@@ -317,6 +321,7 @@ async function buildMarketplace(
         name: p.pluginName,
         ...(pluginDesc ? { description: pluginDesc } : {}),
         source: `./plugins/${p.pluginName}`,
+        ...(p.pluginVersion ? { version: p.pluginVersion } : {}),
         author: {
           name: config.owner.name,
           ...(config.owner.email ? { email: config.owner.email } : {}),
@@ -408,38 +413,46 @@ function matchesSelector(skillName: string, selector: string): boolean {
   return regex.test(skillName);
 }
 
+/**
+ * Read the author-supplied .claude-plugin/plugin.json from the plugin source dir,
+ * if present. Returns undefined when the file doesn't exist; throws on invalid JSON.
+ */
+function readAuthorPluginJson(
+  pluginSourceDir: string,
+): Record<string, unknown> | undefined {
+  const authorPluginJsonPath = safePath.join(pluginSourceDir, CLAUDE_PLUGIN_DIRNAME, 'plugin.json');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- controlled path
+  if (!existsSync(authorPluginJsonPath)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- controlled path
+      readFileSync(authorPluginJsonPath, 'utf-8'),
+    ) as Record<string, unknown>;
+  } catch (e) {
+    throw new Error(
+      `Author .claude-plugin/plugin.json is not valid JSON: ${(e as Error).message}`,
+    );
+  }
+}
+
 async function writeMergedPluginJson(
   pluginDef: ClaudeMarketplacePluginEntry,
-  pluginSourceDir: string,
+  authorJson: Record<string, unknown> | undefined,
+  pluginVersion: string | undefined,
   pluginDir: string,
   owner: ClaudeMarketplaceConfig['owner'],
-  packageVersion: string | undefined,
   logger: ReturnType<typeof createLogger>,
 ): Promise<void> {
   const pluginJsonDir = safePath.join(pluginDir, CLAUDE_PLUGIN_DIRNAME);
   // eslint-disable-next-line security/detect-non-literal-fs-filename -- resolved paths
   await mkdir(pluginJsonDir, { recursive: true });
 
-  const authorPluginJsonPath = safePath.join(pluginSourceDir, CLAUDE_PLUGIN_DIRNAME, 'plugin.json');
-  let authorJson: Record<string, unknown> | undefined;
-  // eslint-disable-next-line security/detect-non-literal-fs-filename -- controlled path
-  if (existsSync(authorPluginJsonPath)) {
-    try {
-      authorJson = JSON.parse(
-        // eslint-disable-next-line security/detect-non-literal-fs-filename -- controlled path
-        readFileSync(authorPluginJsonPath, 'utf-8'),
-      ) as Record<string, unknown>;
-    } catch (e) {
-      throw new Error(
-        `Author .claude-plugin/plugin.json is not valid JSON: ${(e as Error).message}`,
-      );
-    }
-  }
-
   const { merged, warnings } = mergePluginJson({
     vat: {
       name: pluginDef.name,
-      version: packageVersion,
+      version: pluginVersion,
       author: { name: owner.name, ...(owner.email ? { email: owner.email } : {}) },
     },
     configDescription: pluginDef.description,
@@ -493,7 +506,7 @@ async function buildPlugin(
   marketplaceAvailable: string[],
   configDir: string,
   owner: ClaudeMarketplaceConfig['owner'],
-  packageVersion: string | undefined,
+  rootVersion: string | undefined,
   logger: ReturnType<typeof createLogger>,
 ): Promise<PluginBuildResult> {
   const pluginDir = safePath.join(
@@ -564,18 +577,39 @@ async function buildPlugin(
   }
 
   // Phase 5: plugin.json merge-write (always last, always wins).
+  // Read author plugin.json once, resolve version once — single source of
+  // truth that flows into both the merged plugin.json and marketplace.json.
+  const authorJson = readAuthorPluginJson(pluginSourceDir);
+  const pluginVersion = resolveVersion(
+    pluginDef,
+    authorJson as { version?: string } | undefined,
+    rootVersion,
+    { warn: (message) => logger.info(`warning: ${message}`) },
+  );
+
   await writeMergedPluginJson(
     pluginDef,
-    pluginSourceDir,
+    authorJson,
+    pluginVersion,
     pluginDir,
     owner,
-    packageVersion,
     logger,
   );
+
+  // Phase 6: per-plugin CHANGELOG copy. Resolves to <pluginSourceDir>/CHANGELOG.md
+  // by default, or `entry.changelog` (relative to plugin source) when configured.
+  // No-op when neither resolves — marketplace-level CHANGELOG (handled in
+  // copyDistributionFiles) is unaffected.
+  const changelogPath = resolvePluginChangelogPath(pluginSourceDir, pluginDef);
+  if (changelogPath) {
+    cpSync(changelogPath, safePath.join(pluginDir, 'CHANGELOG.md'));
+    logger.info(`         CHANGELOG.md`);
+  }
 
   return {
     pluginName: pluginDef.name,
     pluginDir,
+    pluginVersion,
     skillsCopied,
     commandsCopied: treeResult.commandsCopied,
     hooksCopied: treeResult.hooksCopied,

--- a/packages/cli/src/commands/claude/plugin/plugin-changelog.ts
+++ b/packages/cli/src/commands/claude/plugin/plugin-changelog.ts
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs';
+
+import { safePath } from '@vibe-agent-toolkit/utils';
+
+/**
+ * Resolve the per-plugin CHANGELOG file path for a marketplace publish.
+ *
+ * Resolution order:
+ *   1. If `entry.changelog` is provided, treat it as a path relative to the
+ *      plugin source dir. Returns the absolute path if the file exists; else
+ *      `undefined` (a config-supplied path that doesn't resolve is a no-op).
+ *   2. Otherwise, default to `<pluginSourceDir>/CHANGELOG.md` if that file
+ *      exists; else `undefined`.
+ *
+ * The default path is anchored to the plugin's *source* dir (the `source`
+ * field on the marketplace plugin entry, default `plugins/<name>`). Callers
+ * pass the resolved source dir directly — this helper does not assume layout.
+ */
+export function resolvePluginChangelogPath(
+  pluginSourceDir: string,
+  entry: { changelog?: string | undefined },
+): string | undefined {
+  if (entry.changelog) {
+    const configured = safePath.join(pluginSourceDir, entry.changelog);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    return existsSync(configured) ? configured : undefined;
+  }
+  const defaulted = safePath.join(pluginSourceDir, 'CHANGELOG.md');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  return existsSync(defaulted) ? defaulted : undefined;
+}

--- a/packages/cli/src/commands/claude/plugin/plugin-json-merge.ts
+++ b/packages/cli/src/commands/claude/plugin/plugin-json-merge.ts
@@ -6,11 +6,22 @@
  *   - Author wins on: all other keys (keywords, repository, homepage, license, ...)
  *   - description:    config.description ?? author.description ?? `${name} plugin`
  *
+ * Version resolution lives in `resolveVersion` (config > plugin.json > root) and
+ * happens at the caller in `build.ts`. By the time `mergePluginJson` runs, the
+ * value passed in `vat.version` IS the resolved answer — this function does no
+ * additional precedence work for version.
+ *
  * Mismatches on VAT-winning fields produce warnings — never errors.
  */
 
 export interface VatGeneratedFields {
   name: string;
+  /**
+   * The resolved plugin version (already gone through the precedence chain in
+   * `resolveVersion`). `undefined` only when all sources (config, plugin.json,
+   * root package.json) are absent — in which case `version` is omitted from
+   * the merged output entirely.
+   */
   version: string | undefined;
   author: { name: string; email?: string };
 }
@@ -24,6 +35,10 @@ export interface MergePluginJsonArgs {
 export interface MergePluginJsonResult {
   merged: Record<string, unknown>;
   warnings: string[];
+}
+
+export interface ResolveVersionLogger {
+  warn(message: string): void;
 }
 
 const VAT_OWNED_KEYS: ReadonlySet<string> = new Set(['name', 'version', 'author']);
@@ -63,15 +78,6 @@ function collectWarnings(
       `plugin.json "name" mismatch: author value ${JSON.stringify(authorJson['name'])} ignored; using VAT-generated "${vat.name}".`,
     );
   }
-  if (
-    vat.version !== undefined &&
-    'version' in authorJson &&
-    authorJson['version'] !== vat.version
-  ) {
-    warnings.push(
-      `plugin.json "version" mismatch: author value ${JSON.stringify(authorJson['version'])} ignored; using VAT-generated "${vat.version}".`,
-    );
-  }
   if ('author' in authorJson && !deepEqual(authorJson['author'], mergedAuthor)) {
     warnings.push(
       `plugin.json "author" mismatch: author-supplied value discarded; using VAT-generated author object.`,
@@ -80,13 +86,33 @@ function collectWarnings(
   return warnings;
 }
 
-function resolveVersion(
-  vat: VatGeneratedFields,
-  authorJson: Record<string, unknown> | undefined,
+/**
+ * Resolve the effective plugin version using the precedence chain:
+ *   marketplace-config-supplied version > plugin.json:version > root package.json version
+ *
+ * If both the config and plugin.json supply a version and they disagree, a warning is
+ * emitted via the supplied logger (config still wins). When agreement holds — or when
+ * one side is absent — no warning is emitted.
+ *
+ * Returns `undefined` only when all three sources are absent.
+ */
+export function resolveVersion(
+  configEntry: { version?: string | undefined } | undefined,
+  authorJson: { version?: string | undefined } | undefined,
+  rootVersion: string | undefined,
+  logger: ResolveVersionLogger = console,
 ): string | undefined {
-  if (vat.version !== undefined) return vat.version;
-  if (authorJson && typeof authorJson['version'] === 'string') return authorJson['version'];
-  return undefined;
+  const config = configEntry?.version;
+  const author = authorJson?.version;
+
+  if (config && author && config !== author) {
+    logger.warn(
+      `Plugin version mismatch: marketplace config declares ${config}, ` +
+        `plugin.json declares ${author}. Using config (${config}). ` +
+        `Reconcile by removing one or the other.`,
+    );
+  }
+  return config ?? author ?? rootVersion;
 }
 
 function resolveDescription(
@@ -107,9 +133,10 @@ export function mergePluginJson(args: MergePluginJsonArgs): MergePluginJsonResul
   const merged: Record<string, unknown> = collectAuthorPassthrough(authorJson);
   merged['name'] = vat.name;
 
-  const version = resolveVersion(vat, authorJson);
-  if (version !== undefined) {
-    merged['version'] = version;
+  // Version is already resolved by the caller via resolveVersion.
+  // Omit entirely when no source supplied a value.
+  if (vat.version !== undefined) {
+    merged['version'] = vat.version;
   }
 
   merged['author'] = buildAuthorObject(vat);

--- a/packages/cli/test/commands/claude/marketplace/tag-utils.test.ts
+++ b/packages/cli/test/commands/claude/marketplace/tag-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { pluginTagName } from '../../../../src/commands/claude/marketplace/tag-utils.js';
+
+describe('pluginTagName', () => {
+  it('formats <plugin>-v<version> for normal inputs', () => {
+    expect(pluginTagName('ai-digest', '0.2.0')).toBe('ai-digest-v0.2.0');
+  });
+
+  it('passes through prerelease version strings', () => {
+    expect(pluginTagName('foo', '1.0.0-rc.1')).toBe('foo-v1.0.0-rc.1');
+  });
+
+  it('throws on empty plugin name', () => {
+    expect(() => pluginTagName('', '0.1.0')).toThrow(/name/i);
+  });
+
+  it('throws on empty version', () => {
+    expect(() => pluginTagName('foo', '')).toThrow(/version/i);
+  });
+});

--- a/packages/cli/test/commands/claude/plugin/plugin-changelog.test.ts
+++ b/packages/cli/test/commands/claude/plugin/plugin-changelog.test.ts
@@ -1,0 +1,56 @@
+/* eslint-disable security/detect-non-literal-fs-filename */
+import { writeFileSync } from 'node:fs';
+
+import { mkdirSyncReal, safePath } from '@vibe-agent-toolkit/utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolvePluginChangelogPath } from '../../../../src/commands/claude/plugin/plugin-changelog.js';
+import { createTempDirTracker } from '../../../system/test-common.js';
+
+const { createTempDir, cleanupTempDirs } = createTempDirTracker('vat-plugin-changelog-');
+
+describe('resolvePluginChangelogPath', () => {
+  afterEach(() => cleanupTempDirs());
+
+  it('resolves config-supplied path when file exists', () => {
+    const sourceDir = createTempDir();
+    const customPath = safePath.join(sourceDir, 'docs', 'CHANGES.md');
+    mkdirSyncReal(safePath.join(sourceDir, 'docs'), { recursive: true });
+    writeFileSync(customPath, '# Changes\n');
+
+    const result = resolvePluginChangelogPath(sourceDir, { changelog: 'docs/CHANGES.md' });
+    expect(result).toBe(customPath);
+  });
+
+  it('returns undefined when config-supplied path does not exist', () => {
+    const sourceDir = createTempDir();
+
+    const result = resolvePluginChangelogPath(sourceDir, { changelog: 'missing/CHANGES.md' });
+    expect(result).toBeUndefined();
+  });
+
+  it('resolves default <source>/CHANGELOG.md when file exists and no config provided', () => {
+    const sourceDir = createTempDir();
+    const defaultPath = safePath.join(sourceDir, 'CHANGELOG.md');
+    writeFileSync(defaultPath, '# Changelog\n');
+
+    const result = resolvePluginChangelogPath(sourceDir, {});
+    expect(result).toBe(defaultPath);
+  });
+
+  it('returns undefined when no CHANGELOG.md exists and no config provided', () => {
+    const sourceDir = createTempDir();
+
+    const result = resolvePluginChangelogPath(sourceDir, {});
+    expect(result).toBeUndefined();
+  });
+
+  it('treats empty changelog string as not provided and falls through to default', () => {
+    const sourceDir = createTempDir();
+    const defaultPath = safePath.join(sourceDir, 'CHANGELOG.md');
+    writeFileSync(defaultPath, '# Changelog\n');
+
+    const result = resolvePluginChangelogPath(sourceDir, { changelog: '' });
+    expect(result).toBe(defaultPath);
+  });
+});

--- a/packages/cli/test/commands/claude/plugin/plugin-json-merge.test.ts
+++ b/packages/cli/test/commands/claude/plugin/plugin-json-merge.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable sonarjs/no-duplicate-string */
 import { describe, expect, it } from 'vitest';
 
-import { mergePluginJson } from '../../../../src/commands/claude/plugin/plugin-json-merge.js';
+import {
+  mergePluginJson,
+  resolveVersion,
+} from '../../../../src/commands/claude/plugin/plugin-json-merge.js';
 
 describe('mergePluginJson', () => {
   const vatFields = {
@@ -61,13 +64,17 @@ describe('mergePluginJson', () => {
     expect(merged['license']).toBe('Apache-2.0');
   });
 
-  it('VAT wins on name/version/author (shallow wholesale replace)', () => {
+  it('VAT wins on name/author/version (caller pre-resolves version)', () => {
+    // Per the multi-plugin marketplace versioning design, version precedence
+    // (config > plugin.json > root) is resolved by the caller via
+    // resolveVersion BEFORE invoking mergePluginJson. By the time we get here,
+    // vat.version IS the resolved answer — author-supplied versions are
+    // discarded. Name and author follow the same VAT-wins pattern.
     const { merged, warnings } = mergePluginJson({
       vat: vatFields,
       configDescription: undefined,
       authorJson: {
         name: 'author-picked-name',
-        version: '9.9.9',
         author: 'author-picked-author-string',
       },
     });
@@ -77,7 +84,6 @@ describe('mergePluginJson', () => {
     expect(warnings).toEqual(
       expect.arrayContaining([
         expect.stringContaining('name'),
-        expect.stringContaining('version'),
         expect.stringContaining('author'),
       ]),
     );
@@ -105,14 +111,20 @@ describe('mergePluginJson', () => {
     expect(merged['author']).toEqual({ name: 'Org', email: 'ops@org.example' });
   });
 
-  it('preserves author version when VAT has no version (no package.json)', () => {
+  it('omits version when caller-resolved vat.version is undefined (even if authorJson has one)', () => {
+    // Under Option A semantics, the caller pre-resolves version via resolveVersion.
+    // If vat.version is undefined here, all three sources (config, plugin.json,
+    // root) were absent — the author-supplied value would already have been
+    // picked up upstream. Reaching this with vat.version=undefined plus an
+    // authorJson.version means the upstream resolution explicitly chose
+    // undefined; mergePluginJson must respect that.
     const vatNoVersion = { name: 'my-plugin', version: undefined, author: { name: 'Org' } };
     const { merged, warnings } = mergePluginJson({
       vat: vatNoVersion,
       configDescription: undefined,
       authorJson: { version: '7.8.9' },
     });
-    expect(merged['version']).toBe('7.8.9');
+    expect('version' in merged).toBe(false);
     expect(warnings.filter((w) => w.includes('version'))).toEqual([]);
   });
 
@@ -124,5 +136,89 @@ describe('mergePluginJson', () => {
       authorJson: {},
     });
     expect('version' in merged).toBe(false);
+  });
+});
+
+function makeSink(): { warnings: string[]; warn: (m: string) => void } {
+  const warnings: string[] = [];
+  return {
+    warnings,
+    warn(m: string) {
+      warnings.push(m);
+    },
+  };
+}
+
+describe('resolveVersion', () => {
+  it('config wins over plugin.json over root', () => {
+    const sink = makeSink();
+    const result = resolveVersion(
+      { version: '3.0.0' },
+      { version: '2.0.0' },
+      '1.0.0',
+      sink,
+    );
+    expect(result).toBe('3.0.0');
+  });
+
+  it('plugin.json wins over root when no config', () => {
+    const sink = makeSink();
+    const result = resolveVersion(undefined, { version: '2.0.0' }, '1.0.0', sink);
+    expect(result).toBe('2.0.0');
+    expect(sink.warnings).toEqual([]);
+  });
+
+  it('root is fallback when neither config nor plugin.json supplied', () => {
+    const sink = makeSink();
+    const result = resolveVersion(undefined, undefined, '1.0.0', sink);
+    expect(result).toBe('1.0.0');
+    expect(sink.warnings).toEqual([]);
+  });
+
+  it('returns undefined when all three are undefined', () => {
+    const sink = makeSink();
+    const result = resolveVersion(undefined, undefined, undefined, sink);
+    expect(result).toBeUndefined();
+    expect(sink.warnings).toEqual([]);
+  });
+
+  it('warns when config and plugin.json disagree (config still wins)', () => {
+    const sink = makeSink();
+    const result = resolveVersion(
+      { version: '3.0.0' },
+      { version: '2.0.0' },
+      '1.0.0',
+      sink,
+    );
+    expect(result).toBe('3.0.0');
+    expect(sink.warnings).toHaveLength(1);
+    expect(sink.warnings[0]).toContain('3.0.0');
+    expect(sink.warnings[0]).toContain('2.0.0');
+    expect(sink.warnings[0]).toMatch(/mismatch/i);
+  });
+
+  it('does NOT warn when config and plugin.json agree', () => {
+    const sink = makeSink();
+    const result = resolveVersion(
+      { version: '2.0.0' },
+      { version: '2.0.0' },
+      '1.0.0',
+      sink,
+    );
+    expect(result).toBe('2.0.0');
+    expect(sink.warnings).toEqual([]);
+  });
+
+  it('handles empty configEntry object (no version field)', () => {
+    const sink = makeSink();
+    const result = resolveVersion({}, { version: '2.0.0' }, '1.0.0', sink);
+    expect(result).toBe('2.0.0');
+    expect(sink.warnings).toEqual([]);
+  });
+
+  it('defaults logger to console when not provided', () => {
+    // Just ensure no throw with default logger; agreement case so no warn fires.
+    const result = resolveVersion({ version: '2.0.0' }, { version: '2.0.0' }, '1.0.0');
+    expect(result).toBe('2.0.0');
   });
 });

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/package.json
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "multi-plugin-marketplace-fixture",
+  "version": "9.9.9",
+  "private": true
+}

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-a/.claude-plugin/plugin.json
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-a/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugin-a",
+  "version": "0.1.0",
+  "description": "Plugin A — first plugin in the multi-plugin fixture",
+  "license": "MIT"
+}

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-a/CHANGELOG.md
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-a/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to plugin-a will be documented in this file.
+
+## [0.1.0] - 2026-05-09
+
+### Added
+
+- Initial release of plugin-a

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-a/skills/example/SKILL.md
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-a/skills/example/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: plugin-a-example
+description: Example skill bundled with plugin-a to provide minimum content for the build pipeline.
+---
+
+# plugin-a Example Skill
+
+A minimal skill so the plugin has content to package.

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-b/.claude-plugin/plugin.json
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "plugin-b",
+  "version": "0.2.5",
+  "description": "Plugin B — second plugin in the multi-plugin fixture",
+  "license": "MIT"
+}

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-b/CHANGELOG.md
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to plugin-b will be documented in this file.
+
+## [0.2.5] - 2026-05-09
+
+### Added
+
+- Initial release of plugin-b at version 0.2.5

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-b/skills/example/SKILL.md
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/plugins/plugin-b/skills/example/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: plugin-b-example
+description: Example skill bundled with plugin-b to provide minimum content for the build pipeline.
+---
+
+# plugin-b Example Skill
+
+A minimal skill so the plugin has content to package.

--- a/packages/cli/test/fixtures/multi-plugin-marketplace/vibe-agent-toolkit.config.yaml
+++ b/packages/cli/test/fixtures/multi-plugin-marketplace/vibe-agent-toolkit.config.yaml
@@ -1,0 +1,19 @@
+version: 1
+
+claude:
+  marketplaces:
+    multi-plugin:
+      owner:
+        name: Multi Plugin Test
+      plugins:
+        - name: plugin-a
+          description: First plugin in the multi-plugin fixture
+          source: plugins/plugin-a
+          skills: []
+        - name: plugin-b
+          description: Second plugin in the multi-plugin fixture
+          source: plugins/plugin-b
+          skills: []
+      publish:
+        branch: claude-marketplace
+        remote: origin

--- a/packages/cli/test/fixtures/single-version-marketplace/package.json
+++ b/packages/cli/test/fixtures/single-version-marketplace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "single-version-marketplace-fixture",
+  "version": "1.0.0",
+  "private": true
+}

--- a/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-a/.claude-plugin/plugin.json
+++ b/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-a/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-a",
+  "description": "Plugin A — no per-plugin version, falls back to root package.json",
+  "license": "MIT"
+}

--- a/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-a/skills/example/SKILL.md
+++ b/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-a/skills/example/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: plugin-a-example
+description: Example skill bundled with plugin-a to provide minimum content for the single-version build pipeline.
+---
+
+# plugin-a Example Skill
+
+A minimal skill so the plugin has content to package.

--- a/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-b/.claude-plugin/plugin.json
+++ b/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-b/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-b",
+  "description": "Plugin B — no per-plugin version, falls back to root package.json",
+  "license": "MIT"
+}

--- a/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-b/skills/example/SKILL.md
+++ b/packages/cli/test/fixtures/single-version-marketplace/plugins/plugin-b/skills/example/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: plugin-b-example
+description: Example skill bundled with plugin-b to provide minimum content for the single-version build pipeline.
+---
+
+# plugin-b Example Skill
+
+A minimal skill so the plugin has content to package.

--- a/packages/cli/test/fixtures/single-version-marketplace/vibe-agent-toolkit.config.yaml
+++ b/packages/cli/test/fixtures/single-version-marketplace/vibe-agent-toolkit.config.yaml
@@ -1,0 +1,19 @@
+version: 1
+
+claude:
+  marketplaces:
+    single-version:
+      owner:
+        name: Single Version Test
+      plugins:
+        - name: plugin-a
+          description: First plugin (no per-plugin version)
+          source: plugins/plugin-a
+          skills: []
+        - name: plugin-b
+          description: Second plugin (no per-plugin version)
+          source: plugins/plugin-b
+          skills: []
+      publish:
+        branch: claude-marketplace
+        remote: origin

--- a/packages/cli/test/integration/multi-plugin-marketplace.integration.test.ts
+++ b/packages/cli/test/integration/multi-plugin-marketplace.integration.test.ts
@@ -1,0 +1,288 @@
+/* eslint-disable security/detect-non-literal-fs-filename, sonarjs/no-duplicate-string */
+// Test file — file ops happen in temp dirs; duplicated literals (plugin/branch
+// names, paths) are expected and acceptable in fixture-driven tests.
+
+/**
+ * End-to-end sufficiency test for the multi-plugin marketplace versioning flow.
+ *
+ * Runs the actual VAT CLI (`vat claude plugin build` + `vat claude marketplace
+ * publish`) against on-disk fixtures backed by a real local bare git remote.
+ * Asserts on the published artifacts (marketplace.json, per-plugin
+ * CHANGELOG.md, plugin.json:version) and on the per-plugin source-repo tags
+ * (`<plugin>-v<version>`) pushed after a successful publish.
+ *
+ * Three scenarios:
+ *   1. Initial publish — distinct per-plugin versions and CHANGELOGs
+ *   2. Republish after one plugin version bump — tags accumulate, other plugin untouched
+ *   3. Backwards-compat fallback — no per-plugin versions, both inherit root package.json:version
+ */
+import { cpSync, readFileSync, writeFileSync } from 'node:fs';
+
+import { mkdirSyncReal, safeExecSync, safePath } from '@vibe-agent-toolkit/utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  commitAllAndPushMain,
+  createTempDirTracker,
+  executeCli,
+  fs,
+  getBinPath,
+  getFixturePath,
+  initGitRepoWithRemote,
+  listRemoteTagNames,
+} from '../system/test-common.js';
+
+const binPath = getBinPath(import.meta.url);
+const { createTempDir, cleanupTempDirs } = createTempDirTracker(
+  'vat-multi-plugin-mp-',
+);
+
+const PUBLISH_BRANCH = 'claude-marketplace';
+
+interface FixtureRepos {
+  /** Source repo where the fixture lives + vat is invoked. */
+  sourceRepo: string;
+  /** Bare git remote that the publish branch is pushed to. */
+  bareRemote: string;
+}
+
+/**
+ * Copy a fixture into a temp source repo, init it as a real git repo, and set
+ * up a bare remote at `origin`. Mirrors the structure publish-tags.integration.test.ts
+ * uses, but copies the on-disk fixture tree instead of hand-building it.
+ */
+function setupFixtureRepo(fixtureName: string): FixtureRepos {
+  const root = createTempDir();
+  const bareRemote = safePath.join(root, 'remote.git');
+  const sourceRepo = safePath.join(root, 'src');
+
+  mkdirSyncReal(bareRemote, { recursive: true });
+  mkdirSyncReal(sourceRepo, { recursive: true });
+
+  // Bare remote
+  safeExecSync('git', ['init', '--bare', '-q'], { cwd: bareRemote });
+
+  // Copy fixture tree into source repo
+  const fixturePath = getFixturePath(import.meta.url, fixtureName);
+  cpSync(fixturePath, sourceRepo, { recursive: true });
+
+  // Init source repo with remote, then initial commit so refs exist for tag operations
+  initGitRepoWithRemote(sourceRepo, bareRemote);
+  commitAllAndPushMain(sourceRepo);
+
+  return { sourceRepo, bareRemote };
+}
+
+/**
+ * Spawn the VAT CLI against `cwd` and assert it exits 0. Returns combined
+ * stdout+stderr for diagnostic logging if assertions later fail.
+ */
+async function runVatExpectSuccess(cwd: string, args: string[]): Promise<string> {
+  const result = await executeCli(binPath, args, { cwd });
+  if (result.status !== 0) {
+    throw new Error(
+      `vat ${args.join(' ')} failed (status=${String(result.status)}):\n` +
+        `STDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}`,
+    );
+  }
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+/**
+ * Clone the publish branch out of the bare remote into a temp dir so we can
+ * inspect the published files. Returns the working tree root.
+ */
+function cloneBranchToInspect(bareRemote: string, branch: string): string {
+  const inspectDir = createTempDir();
+  safeExecSync(
+    'git',
+    ['clone', '-q', '--branch', branch, '--single-branch', bareRemote, inspectDir],
+    { cwd: bareRemote },
+  );
+  return inspectDir;
+}
+
+/** List local tags in a working repo. */
+function listLocalTags(sourceRepo: string): string[] {
+  const out = safeExecSync('git', ['tag', '--list'], {
+    cwd: sourceRepo,
+    encoding: 'utf-8',
+  });
+  return String(out).split('\n').map((s) => s.trim()).filter(Boolean);
+}
+
+/** Read+parse the published `.claude-plugin/marketplace.json` from an inspect clone. */
+function readPublishedMarketplaceJson(inspectDir: string): {
+  plugins: Array<Record<string, unknown>>;
+} {
+  const path = safePath.join(inspectDir, '.claude-plugin', 'marketplace.json');
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as { plugins: Array<Record<string, unknown>> };
+}
+
+/** Read a published plugin's plugin.json from an inspect clone. */
+function readPublishedPluginJson(
+  inspectDir: string,
+  pluginName: string,
+): Record<string, unknown> {
+  const path = safePath.join(
+    inspectDir,
+    'plugins',
+    pluginName,
+    '.claude-plugin',
+    'plugin.json',
+  );
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** Find a plugin entry by name in the marketplace.json plugins array. */
+function findPluginEntry(
+  plugins: Array<Record<string, unknown>>,
+  name: string,
+): Record<string, unknown> {
+  const entry = plugins.find((p) => p['name'] === name);
+  if (!entry) {
+    throw new Error(
+      `Plugin "${name}" not found in marketplace.json plugins (got: ` +
+        `${plugins.map((p) => String(p['name'])).join(', ')})`,
+    );
+  }
+  return entry;
+}
+
+describe('multi-plugin marketplace — end-to-end build + publish (integration)', () => {
+  afterEach(() => cleanupTempDirs());
+
+  it('scenario 1: initial publish — both plugins ship with their own version, CHANGELOG, and tag', async () => {
+    const { sourceRepo, bareRemote } = setupFixtureRepo('multi-plugin-marketplace');
+
+    await runVatExpectSuccess(sourceRepo, ['claude', 'plugin', 'build']);
+    await runVatExpectSuccess(sourceRepo, ['claude', 'marketplace', 'publish']);
+
+    // Inspect published branch
+    const inspectDir = cloneBranchToInspect(bareRemote, PUBLISH_BRANCH);
+    const { plugins } = readPublishedMarketplaceJson(inspectDir);
+
+    // Both plugins listed with their per-plugin versions
+    expect(plugins).toHaveLength(2);
+    expect(findPluginEntry(plugins, 'plugin-a')['version']).toBe('0.1.0');
+    expect(findPluginEntry(plugins, 'plugin-b')['version']).toBe('0.2.5');
+
+    // Per-plugin CHANGELOGs ship inside each plugin dir
+    expect(
+      fs.existsSync(safePath.join(inspectDir, 'plugins', 'plugin-a', 'CHANGELOG.md')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(safePath.join(inspectDir, 'plugins', 'plugin-b', 'CHANGELOG.md')),
+    ).toBe(true);
+
+    // Per-plugin plugin.json has correct version
+    expect(readPublishedPluginJson(inspectDir, 'plugin-a')['version']).toBe('0.1.0');
+    expect(readPublishedPluginJson(inspectDir, 'plugin-b')['version']).toBe('0.2.5');
+
+    // Source repo has the per-plugin tags, both pushed to remote
+    const localTags = listLocalTags(sourceRepo);
+    expect(localTags).toContain('plugin-a-v0.1.0');
+    expect(localTags).toContain('plugin-b-v0.2.5');
+
+    const remoteTags = listRemoteTagNames(sourceRepo, bareRemote);
+    expect(remoteTags).toContain('plugin-a-v0.1.0');
+    expect(remoteTags).toContain('plugin-b-v0.2.5');
+  });
+
+  it('scenario 2: republish after one plugin bump — only that plugin advances; tags accumulate', async () => {
+    const { sourceRepo, bareRemote } = setupFixtureRepo('multi-plugin-marketplace');
+
+    // First publish: plugin-a@0.1.0, plugin-b@0.2.5
+    await runVatExpectSuccess(sourceRepo, ['claude', 'plugin', 'build']);
+    await runVatExpectSuccess(sourceRepo, ['claude', 'marketplace', 'publish']);
+
+    // Bump plugin-a to 0.2.0; update its CHANGELOG; commit.
+    const pluginAJsonPath = safePath.join(
+      sourceRepo,
+      'plugins',
+      'plugin-a',
+      '.claude-plugin',
+      'plugin.json',
+    );
+    const pluginAJson = JSON.parse(readFileSync(pluginAJsonPath, 'utf-8')) as Record<
+      string,
+      unknown
+    >;
+    pluginAJson['version'] = '0.2.0';
+    writeFileSync(pluginAJsonPath, JSON.stringify(pluginAJson, null, 2));
+
+    const pluginAChangelogPath = safePath.join(
+      sourceRepo,
+      'plugins',
+      'plugin-a',
+      'CHANGELOG.md',
+    );
+    writeFileSync(
+      pluginAChangelogPath,
+      '# Changelog\n\n' +
+        'All notable changes to plugin-a will be documented in this file.\n\n' +
+        '## [0.2.0] - 2026-05-09\n\n### Changed\n- Bumped plugin-a to 0.2.0 for republish test\n\n' +
+        '## [0.1.0] - 2026-05-09\n\n### Added\n- Initial release of plugin-a\n',
+    );
+
+    safeExecSync('git', ['add', '-A'], { cwd: sourceRepo });
+    safeExecSync('git', ['commit', '-q', '-m', 'bump plugin-a to 0.2.0'], {
+      cwd: sourceRepo,
+    });
+
+    // Second publish (no --plugin flag — selective publish was dropped)
+    await runVatExpectSuccess(sourceRepo, ['claude', 'plugin', 'build']);
+    await runVatExpectSuccess(sourceRepo, ['claude', 'marketplace', 'publish']);
+
+    // Inspect
+    const inspectDir = cloneBranchToInspect(bareRemote, PUBLISH_BRANCH);
+    const { plugins } = readPublishedMarketplaceJson(inspectDir);
+
+    expect(findPluginEntry(plugins, 'plugin-a')['version']).toBe('0.2.0');
+    expect(findPluginEntry(plugins, 'plugin-b')['version']).toBe('0.2.5');
+
+    // plugin-a's published CHANGELOG includes the new entry
+    const publishedAChangelog = readFileSync(
+      safePath.join(inspectDir, 'plugins', 'plugin-a', 'CHANGELOG.md'),
+      'utf-8',
+    );
+    expect(publishedAChangelog).toContain('## [0.2.0]');
+    expect(publishedAChangelog).toContain('## [0.1.0]');
+
+    // Tags accumulate: old plugin-a tag still on remote, new one added, plugin-b unchanged
+    const remoteTags = listRemoteTagNames(sourceRepo, bareRemote);
+    expect(remoteTags).toContain('plugin-a-v0.1.0');
+    expect(remoteTags).toContain('plugin-a-v0.2.0');
+    expect(remoteTags).toContain('plugin-b-v0.2.5');
+  });
+
+  it('scenario 3: backwards-compat — no per-plugin versions, both plugins inherit root package.json:version', async () => {
+    const { sourceRepo, bareRemote } = setupFixtureRepo('single-version-marketplace');
+
+    await runVatExpectSuccess(sourceRepo, ['claude', 'plugin', 'build']);
+    await runVatExpectSuccess(sourceRepo, ['claude', 'marketplace', 'publish']);
+
+    const inspectDir = cloneBranchToInspect(bareRemote, PUBLISH_BRANCH);
+    const { plugins } = readPublishedMarketplaceJson(inspectDir);
+
+    // Both plugins inherit root package.json:version (1.0.0)
+    expect(plugins).toHaveLength(2);
+    expect(findPluginEntry(plugins, 'plugin-a')['version']).toBe('1.0.0');
+    expect(findPluginEntry(plugins, 'plugin-b')['version']).toBe('1.0.0');
+
+    // No per-plugin CHANGELOG.md ships (fixture has none)
+    expect(
+      fs.existsSync(safePath.join(inspectDir, 'plugins', 'plugin-a', 'CHANGELOG.md')),
+    ).toBe(false);
+    expect(
+      fs.existsSync(safePath.join(inspectDir, 'plugins', 'plugin-b', 'CHANGELOG.md')),
+    ).toBe(false);
+
+    // Per-plugin tags use the inherited root version
+    const remoteTags = listRemoteTagNames(sourceRepo, bareRemote);
+    expect(remoteTags).toContain('plugin-a-v1.0.0');
+    expect(remoteTags).toContain('plugin-b-v1.0.0');
+  });
+});

--- a/packages/cli/test/integration/multi-plugin-marketplace.integration.test.ts
+++ b/packages/cli/test/integration/multi-plugin-marketplace.integration.test.ts
@@ -145,7 +145,7 @@ function findPluginEntry(
   if (!entry) {
     throw new Error(
       `Plugin "${name}" not found in marketplace.json plugins (got: ` +
-        `${plugins.map((p) => String(p['name'])).join(', ')})`,
+        `${plugins.map((p) => JSON.stringify(p['name'])).join(', ')})`,
     );
   }
   return entry;

--- a/packages/cli/test/integration/per-plugin-changelog-and-version.integration.test.ts
+++ b/packages/cli/test/integration/per-plugin-changelog-and-version.integration.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable security/detect-non-literal-fs-filename, sonarjs/no-duplicate-string */
+// Test file — all file operations are in temp directories; duplicated strings acceptable.
+import { existsSync, readFileSync } from 'node:fs';
+
+import { mkdirSyncReal, safePath } from '@vibe-agent-toolkit/utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  createTempDirTracker,
+  executeCliAndParseYaml,
+  getBinPath,
+  writeTestFile,
+} from '../system/test-common.js';
+
+const binPath = getBinPath(import.meta.url);
+const { createTempDir, cleanupTempDirs } = createTempDirTracker(
+  'vat-plugin-changelog-version-',
+);
+
+interface FixtureOptions {
+  /** Whether to write a per-plugin CHANGELOG.md inside the plugin source dir. */
+  withChangelog?: boolean;
+  /** Optional custom plugin.json:version. Pass `null` to omit the version field. */
+  pluginJsonVersion?: string | null;
+  /** Whether to write a root package.json (and its version). Defaults to false (no root version). */
+  rootPackageVersion?: string | null;
+}
+
+/**
+ * Build a minimal single-plugin marketplace fixture under tempDir.
+ * Returns the plugin source dir and plugin name for assertions.
+ */
+function buildFixture(
+  tempDir: string,
+  opts: FixtureOptions = {},
+): { pluginName: string; pluginSourceDir: string; outDir: string } {
+  const pluginName = 'demo-plugin';
+  const marketplaceName = 'mp1';
+
+  // Optional root package.json (lowest-precedence version source).
+  if (opts.rootPackageVersion !== null && opts.rootPackageVersion !== undefined) {
+    writeTestFile(
+      safePath.join(tempDir, 'package.json'),
+      JSON.stringify({ name: 'fixture', version: opts.rootPackageVersion }),
+    );
+  }
+
+  const config = `version: 1
+skills:
+  include: ["plugins/*/skills/**/SKILL.md"]
+claude:
+  marketplaces:
+    ${marketplaceName}:
+      owner:
+        name: Test Org
+        email: ops@test.example
+      plugins:
+        - name: ${pluginName}
+          description: Demo plugin
+          skills: []
+`;
+  writeTestFile(safePath.join(tempDir, 'vibe-agent-toolkit.config.yaml'), config);
+
+  const pluginSourceDir = safePath.join(tempDir, 'plugins', pluginName);
+  mkdirSyncReal(safePath.join(pluginSourceDir, 'commands'), { recursive: true });
+  // Plugin needs at least one piece of content so the build doesn't error.
+  writeTestFile(
+    safePath.join(pluginSourceDir, 'commands', 'hello.md'),
+    '---\n---\n# hello',
+  );
+
+  // Author plugin.json with optional version.
+  mkdirSyncReal(safePath.join(pluginSourceDir, '.claude-plugin'), { recursive: true });
+  const pluginJson: Record<string, unknown> = {
+    license: 'MIT',
+  };
+  if (opts.pluginJsonVersion !== null && opts.pluginJsonVersion !== undefined) {
+    pluginJson['version'] = opts.pluginJsonVersion;
+  }
+  writeTestFile(
+    safePath.join(pluginSourceDir, '.claude-plugin', 'plugin.json'),
+    JSON.stringify(pluginJson),
+  );
+
+  if (opts.withChangelog) {
+    writeTestFile(
+      safePath.join(pluginSourceDir, 'CHANGELOG.md'),
+      '# Changelog\n\n## 0.5.0\n- initial release\n',
+    );
+  }
+
+  const outDir = safePath.join(
+    tempDir,
+    'dist',
+    '.claude',
+    'plugins',
+    'marketplaces',
+    marketplaceName,
+    'plugins',
+    pluginName,
+  );
+
+  return { pluginName, pluginSourceDir, outDir };
+}
+
+function readMarketplaceJson(tempDir: string): Record<string, unknown> {
+  const path = safePath.join(
+    tempDir,
+    'dist',
+    '.claude',
+    'plugins',
+    'marketplaces',
+    'mp1',
+    '.claude-plugin',
+    'marketplace.json',
+  );
+  return JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+}
+
+/**
+ * Build a fixture, run the plugin build, and return the parsed marketplace.json
+ * plugins array — shared helper for the version-in-marketplace.json scenarios.
+ */
+async function buildAndReadMarketplacePlugins(
+  opts: FixtureOptions,
+): Promise<Array<Record<string, unknown>>> {
+  const tempDir = createTempDir();
+  buildFixture(tempDir, opts);
+  const pb = await executeCliAndParseYaml(binPath, ['claude', 'plugin', 'build'], {
+    cwd: tempDir,
+  });
+  expect(pb.result.status).toBe(0);
+  const mp = readMarketplaceJson(tempDir);
+  const plugins = mp['plugins'] as Array<Record<string, unknown>>;
+  expect(plugins).toHaveLength(1);
+  return plugins;
+}
+
+describe('vat claude plugin build — per-plugin CHANGELOG and marketplace version', () => {
+  afterEach(() => cleanupTempDirs());
+
+  it('copies per-plugin CHANGELOG.md into the plugin output directory when present', async () => {
+    const tempDir = createTempDir();
+    const { pluginSourceDir, outDir } = buildFixture(tempDir, { withChangelog: true });
+
+    const pb = await executeCliAndParseYaml(binPath, ['claude', 'plugin', 'build'], {
+      cwd: tempDir,
+    });
+    expect(pb.result.status).toBe(0);
+
+    const destChangelog = safePath.join(outDir, 'CHANGELOG.md');
+    expect(existsSync(destChangelog)).toBe(true);
+
+    const sourceContent = readFileSync(
+      safePath.join(pluginSourceDir, 'CHANGELOG.md'),
+      'utf-8',
+    );
+    const destContent = readFileSync(destChangelog, 'utf-8');
+    expect(destContent).toBe(sourceContent);
+  });
+
+  it('does not produce CHANGELOG.md in plugin output when source has none', async () => {
+    const tempDir = createTempDir();
+    const { outDir } = buildFixture(tempDir, { withChangelog: false });
+
+    const pb = await executeCliAndParseYaml(binPath, ['claude', 'plugin', 'build'], {
+      cwd: tempDir,
+    });
+    expect(pb.result.status).toBe(0);
+
+    expect(existsSync(safePath.join(outDir, 'CHANGELOG.md'))).toBe(false);
+  });
+
+  it('includes the per-plugin version in marketplace.json when a version is resolved', async () => {
+    const plugins = await buildAndReadMarketplacePlugins({ pluginJsonVersion: '0.5.0' });
+    expect(plugins[0]?.['version']).toBe('0.5.0');
+    expect(plugins[0]?.['name']).toBe('demo-plugin');
+  });
+
+  it('omits the version field in marketplace.json when no version source is available', async () => {
+    // Explicitly omit pluginJsonVersion (null) and rootPackageVersion (null) so
+    // none of the precedence sources supply a version.
+    const plugins = await buildAndReadMarketplacePlugins({
+      pluginJsonVersion: null,
+      rootPackageVersion: null,
+    });
+    expect(plugins[0]).not.toHaveProperty('version');
+  });
+});

--- a/packages/cli/test/integration/publish-tags.integration.test.ts
+++ b/packages/cli/test/integration/publish-tags.integration.test.ts
@@ -1,0 +1,315 @@
+/* eslint-disable security/detect-non-literal-fs-filename, sonarjs/no-duplicate-string */
+// Test file — all file operations are in temp directories; duplicated strings acceptable.
+import { writeFileSync } from 'node:fs';
+
+import { mkdirSyncReal, safeExecSync, safePath } from '@vibe-agent-toolkit/utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  publishToGitBranch,
+  type PublishGitOptions,
+} from '../../src/commands/claude/marketplace/git-publish.js';
+import {
+  commitAllAndPushMain,
+  createTempDirTracker,
+  initGitRepoWithRemote,
+  listRemoteTagNames,
+} from '../system/test-common.js';
+
+interface TestLogger {
+  info: (msg: string) => void;
+  error: (msg: string) => void;
+  debug: (msg: string) => void;
+  messages: string[];
+}
+
+function createTestLogger(): TestLogger {
+  const messages: string[] = [];
+  return {
+    info: (msg: string) => messages.push(msg),
+    error: (msg: string) => messages.push(msg),
+    debug: () => { /* swallow debug noise */ },
+    messages,
+  };
+}
+
+interface PublishFixture {
+  /** Source repo where vat is "invoked" — tag pushes target this repo. */
+  sourceRepo: string;
+  /** Bare remote that source/publish branches push to. */
+  bareRemote: string;
+  /** Directory containing the composed publish tree (publishDir input). */
+  publishTree: string;
+}
+
+/**
+ * Set up a triple of dirs:
+ *   - bareRemote: a `git init --bare` remote
+ *   - sourceRepo: a working repo with bareRemote as `origin`, plus an initial
+ *     commit on `main` so refs exist for tag operations
+ *   - publishTree: a hand-built composed-tree dir holding a minimal
+ *     marketplace.json — feeds publishToGitBranch.publishDir directly
+ */
+function setupPublishFixture(createTempDir: () => string): PublishFixture {
+  const root = createTempDir();
+  const bareRemote = safePath.join(root, 'remote.git');
+  const sourceRepo = safePath.join(root, 'src');
+  const publishTree = safePath.join(root, 'tree');
+
+  mkdirSyncReal(bareRemote, { recursive: true });
+  mkdirSyncReal(sourceRepo, { recursive: true });
+  mkdirSyncReal(publishTree, { recursive: true });
+
+  // Bare remote
+  safeExecSync('git', ['init', '--bare', '-q'], { cwd: bareRemote });
+
+  // Source repo with bareRemote as origin
+  initGitRepoWithRemote(sourceRepo, bareRemote);
+  writeFileSync(safePath.join(sourceRepo, 'README.md'), '# src\n');
+  commitAllAndPushMain(sourceRepo);
+
+  // Hand-built publish tree (skip composePublishTree — we're testing git-publish only)
+  mkdirSyncReal(safePath.join(publishTree, '.claude-plugin'), { recursive: true });
+  writeFileSync(
+    safePath.join(publishTree, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({ name: 'test-mp', plugins: [{ name: 'foo', version: '1.0.0' }] }, null, 2),
+  );
+
+  return { sourceRepo, bareRemote, publishTree };
+}
+
+/**
+ * publishToGitBranch reads `process.cwd()` as the source-repo cwd. Tests
+ * temporarily chdir into the fixture's source repo so tag pushes target the
+ * right repo.
+ */
+async function withCwd<T>(cwd: string, fn: () => Promise<T>): Promise<T> {
+  const prev = process.cwd();
+  process.chdir(cwd);
+  try {
+    return await fn();
+  } finally {
+    process.chdir(prev);
+  }
+}
+
+/**
+ * Build PublishGitOptions for a fixture. Centralizes the shared "publish foo
+ * v1.0.0" shape so individual tests only declare what differs (dryRun, noPush,
+ * publishedPlugins).
+ */
+function buildPublishOptions(
+  fx: PublishFixture,
+  logger: TestLogger,
+  overrides: Partial<PublishGitOptions> = {},
+): PublishGitOptions {
+  return {
+    publishDir: fx.publishTree,
+    branch: 'claude-marketplace',
+    remote: fx.bareRemote,
+    commitMessage: 'publish v1.0.0',
+    force: false,
+    dryRun: false,
+    noPush: false,
+    publishedPlugins: [{ name: 'foo', version: '1.0.0' }],
+    logger,
+    ...overrides,
+  };
+}
+
+/** Run publishToGitBranch from inside the source repo with the standard option set. */
+async function runPublish(
+  fx: PublishFixture,
+  logger: TestLogger,
+  overrides: Partial<PublishGitOptions> = {},
+): Promise<void> {
+  await withCwd(fx.sourceRepo, () =>
+    publishToGitBranch(buildPublishOptions(fx, logger, overrides)),
+  );
+}
+
+describe('publishToGitBranch — per-plugin tag push', () => {
+  const { createTempDir, cleanupTempDirs } = createTempDirTracker('vat-publish-tags-');
+  let originalCwd = '';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanupTempDirs();
+  });
+
+  it('pushes per-plugin tag on successful publish', async () => {
+    const fx = setupPublishFixture(createTempDir);
+    const logger = createTestLogger();
+
+    await runPublish(fx, logger);
+
+    const tags = listRemoteTagNames(fx.sourceRepo, fx.bareRemote);
+    expect(tags).toContain('foo-v1.0.0');
+  });
+
+  it('does not throw when tag push fails — branch publish still succeeds', async () => {
+    const fx = setupPublishFixture(createTempDir);
+    const logger = createTestLogger();
+
+    // Pre-create the tag on the bare remote pointing to the existing main commit.
+    // The publish flow uses non-force `git push <remote> <tag>`, so re-pushing
+    // a different commit-id under the same tag will be rejected by the remote.
+    safeExecSync('git', ['tag', 'foo-v1.0.0'], { cwd: fx.sourceRepo });
+    safeExecSync('git', ['push', fx.bareRemote, 'foo-v1.0.0'], { cwd: fx.sourceRepo });
+    safeExecSync('git', ['tag', '-d', 'foo-v1.0.0'], { cwd: fx.sourceRepo });
+    // Make a second commit so the local tag will point to a different SHA than
+    // the one published to the remote.
+    writeFileSync(safePath.join(fx.sourceRepo, 'CHANGED.md'), 'x\n');
+    safeExecSync('git', ['add', '-A'], { cwd: fx.sourceRepo });
+    safeExecSync('git', ['commit', '-q', '-m', 'change'], { cwd: fx.sourceRepo });
+
+    let threw = false;
+    try {
+      await runPublish(fx, logger);
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(false);
+
+    // Branch push should have succeeded — verify on the bare remote.
+    const remoteBranches = String(
+      safeExecSync('git', ['ls-remote', '--heads', fx.bareRemote], {
+        cwd: fx.sourceRepo,
+        encoding: 'utf-8',
+      }),
+    );
+    expect(remoteBranches).toContain('refs/heads/claude-marketplace');
+
+    // A warning about the failed tag push must be present in logger output.
+    const warnLine = logger.messages.find(
+      (m) => m.includes('failed to push tag foo-v1.0.0'),
+    );
+    expect(warnLine).toBeDefined();
+  });
+
+  it('republish-without-bump: does not move local tag or push when HEAD differs', async () => {
+    const fx = setupPublishFixture(createTempDir);
+    const logger1 = createTestLogger();
+
+    // First publish — creates tag locally and pushes it to the remote.
+    await runPublish(fx, logger1);
+
+    const tagsAfterFirst = listRemoteTagNames(fx.sourceRepo, fx.bareRemote);
+    expect(tagsAfterFirst).toContain('foo-v1.0.0');
+
+    // Capture the SHA the local tag points at after the first publish.
+    const originalTagSha = String(
+      safeExecSync('git', ['rev-list', '-n', '1', 'foo-v1.0.0'], {
+        cwd: fx.sourceRepo,
+        encoding: 'utf-8',
+      }),
+    ).trim();
+
+    // Add a NEW commit to the source repo without bumping the plugin version.
+    // HEAD now differs from the existing tag's commit.
+    writeFileSync(safePath.join(fx.sourceRepo, 'CHANGED.md'), 'docs tweak\n');
+    safeExecSync('git', ['add', '-A'], { cwd: fx.sourceRepo });
+    safeExecSync('git', ['commit', '-q', '-m', 'docs tweak'], { cwd: fx.sourceRepo });
+
+    // Make the publish tree differ from the previous publish so the second
+    // publishToGitBranch run actually creates a new commit on the publish
+    // branch (and thus reaches the tag step). In a real docs-tweak scenario
+    // the marketplace.json may differ even at the same plugin version (e.g.
+    // marketplace-level metadata changed); we simulate that here.
+    writeFileSync(
+      safePath.join(fx.publishTree, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify(
+        { name: 'test-mp', plugins: [{ name: 'foo', version: '1.0.0' }], note: 'rev2' },
+        null,
+        2,
+      ),
+    );
+
+    const newHeadSha = String(
+      safeExecSync('git', ['rev-parse', 'HEAD'], {
+        cwd: fx.sourceRepo,
+        encoding: 'utf-8',
+      }),
+    ).trim();
+    expect(newHeadSha).not.toBe(originalTagSha);
+
+    // Republish at the same version. The publish itself should succeed (a new
+    // commit on the publish branch), but the tag-handling step must:
+    //   - Leave the local tag pointing at the original commit (not move it)
+    //   - Not attempt to push the tag (since SHA differs)
+    //   - Log a warning explaining the republish-without-bump case
+    const logger2 = createTestLogger();
+    await runPublish(fx, logger2);
+
+    // Local tag must still point at the original commit.
+    const tagShaAfterRepublish = String(
+      safeExecSync('git', ['rev-list', '-n', '1', 'foo-v1.0.0'], {
+        cwd: fx.sourceRepo,
+        encoding: 'utf-8',
+      }),
+    ).trim();
+    expect(tagShaAfterRepublish).toBe(originalTagSha);
+
+    // Remote tag must still point at the original commit.
+    const remoteTagSha = String(
+      safeExecSync('git', ['ls-remote', fx.bareRemote, 'refs/tags/foo-v1.0.0'], {
+        cwd: fx.sourceRepo,
+        encoding: 'utf-8',
+      }),
+    ).trim().split(/\s+/)[0];
+    expect(remoteTagSha).toBe(originalTagSha);
+
+    // Warning must explain the republish-without-bump case.
+    const warnLine = logger2.messages.find(
+      (m) =>
+        m.includes('foo-v1.0.0') &&
+        m.includes('already exists locally') &&
+        m.includes('republished'),
+    );
+    expect(warnLine).toBeDefined();
+
+    // Branch publish itself must have succeeded — verify on the bare remote.
+    const remoteBranches = String(
+      safeExecSync('git', ['ls-remote', '--heads', fx.bareRemote], {
+        cwd: fx.sourceRepo,
+        encoding: 'utf-8',
+      }),
+    );
+    expect(remoteBranches).toContain('refs/heads/claude-marketplace');
+  });
+
+  it('does not push tags in dry-run mode', async () => {
+    const fx = setupPublishFixture(createTempDir);
+    const logger = createTestLogger();
+
+    await runPublish(fx, logger, { dryRun: true });
+
+    const tags = listRemoteTagNames(fx.sourceRepo, fx.bareRemote);
+    expect(tags).not.toContain('foo-v1.0.0');
+  });
+
+  it('does not push tags in no-push mode', async () => {
+    const fx = setupPublishFixture(createTempDir);
+    const logger = createTestLogger();
+
+    await runPublish(fx, logger, { noPush: true });
+
+    const tags = listRemoteTagNames(fx.sourceRepo, fx.bareRemote);
+    expect(tags).not.toContain('foo-v1.0.0');
+  });
+
+  it('is a no-op when publishedPlugins is empty', async () => {
+    const fx = setupPublishFixture(createTempDir);
+    const logger = createTestLogger();
+
+    await runPublish(fx, logger, { publishedPlugins: [] });
+
+    const tags = listRemoteTagNames(fx.sourceRepo, fx.bareRemote);
+    expect(tags.length).toBe(0);
+  });
+});

--- a/packages/cli/test/system/test-common.ts
+++ b/packages/cli/test/system/test-common.ts
@@ -9,7 +9,7 @@ import * as fs from 'node:fs';
 import { dirname as pathDirname, join as pathJoin, resolve as pathResolve } from 'node:path';
 import { fileURLToPath as urlFileURLToPath } from 'node:url';
 
-import { mkdirSyncReal, normalizedTmpdir, safePath } from '@vibe-agent-toolkit/utils';
+import { mkdirSyncReal, normalizedTmpdir, safeExecSync, safePath } from '@vibe-agent-toolkit/utils';
 import * as yaml from 'js-yaml';
 
 // Re-export commonly used functions
@@ -350,6 +350,51 @@ export function fakeHomeEnv(fakeHome: string): Record<string, string> {
     // not any shell-level CLAUDE_CONFIG_DIR that may be set in the test runner's env.
     CLAUDE_CONFIG_DIR: pathJoin(fakeHome, '.claude'),
   };
+}
+
+/**
+ * Initialize a git working repo at `sourceRepo` with `bareRemote` configured as
+ * `origin`, set test identity, and create a single initial commit on `main`
+ * pushed to the remote so refs exist for subsequent tag operations.
+ *
+ * Caller must have already created both directories and run `git init --bare`
+ * on `bareRemote`. This helper is shared by integration tests that need a real
+ * git fixture (publish-tags, multi-plugin marketplace).
+ */
+export function initGitRepoWithRemote(sourceRepo: string, bareRemote: string): void {
+  safeExecSync('git', ['init', '-q', '-b', 'main'], { cwd: sourceRepo });
+  safeExecSync('git', ['config', 'user.email', 'test@test'], { cwd: sourceRepo });
+  safeExecSync('git', ['config', 'user.name', 'test'], { cwd: sourceRepo });
+  safeExecSync('git', ['remote', 'add', 'origin', bareRemote], { cwd: sourceRepo });
+}
+
+/**
+ * Stage all files in `sourceRepo`, create an initial commit, and push `main`
+ * to `origin`. Pairs with `initGitRepoWithRemote`.
+ */
+export function commitAllAndPushMain(sourceRepo: string): void {
+  safeExecSync('git', ['add', '-A'], { cwd: sourceRepo });
+  safeExecSync('git', ['commit', '-q', '-m', 'init'], { cwd: sourceRepo });
+  safeExecSync('git', ['push', '-q', 'origin', 'main'], { cwd: sourceRepo });
+}
+
+/**
+ * List tags on a remote via `git ls-remote --tags`. Returns just the short tag
+ * names (without `refs/tags/` prefix). Used by integration tests to assert on
+ * pushed-tag state after a publish.
+ */
+export function listRemoteTagNames(cwd: string, remoteUrl: string): string[] {
+  const out = safeExecSync('git', ['ls-remote', '--tags', remoteUrl], {
+    cwd,
+    encoding: 'utf-8',
+  });
+  return String(out)
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .map((l) => l.split(/\s+/)[1] ?? '')
+    .filter((ref) => ref.startsWith('refs/tags/'))
+    .map((ref) => ref.replace(/^refs\/tags\//, ''));
 }
 
 /**

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",
@@ -43,6 +43,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "remark-parse": "^11.0.0",
+    "semver": "^7.7.3",
     "unified": "^11.0.5",
     "unist-util-visit": "^5.0.0",
     "zod": "^3.24.1"
@@ -52,6 +53,7 @@
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.10.5",
     "@types/picomatch": "^4.0.2",
+    "@types/semver": "^7.7.1",
     "rimraf": "^6.0.1",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/packages/resources/src/schemas/project-config.ts
+++ b/packages/resources/src/schemas/project-config.ts
@@ -1,6 +1,18 @@
 import { ValidationConfigSchema } from '@vibe-agent-toolkit/agent-schema';
 import { z } from 'zod';
 
+/**
+ * Official semver regex from https://semver.org/ (anchored).
+ *
+ * Used as the JSON-Schema-friendly source of truth for plugin version
+ * validation. A `.refine()` over `semver.valid()` would not survive
+ * `zod-to-json-schema` export — external consumers validating against the
+ * exported JSON Schema would silently accept invalid versions. A `.regex()`
+ * round-trips into JSON Schema as `pattern`, preserving the constraint.
+ */
+// eslint-disable-next-line security/detect-unsafe-regex, sonarjs/regex-complexity -- Official semver regex from https://semver.org/; not user-controlled input.
+const SEMVER_REGEX = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
 // Re-export for downstream consumers (unicorn/prefer-export-from satisfied by the import above)
 export { ValidationConfigSchema } from '@vibe-agent-toolkit/agent-schema';
 
@@ -182,6 +194,12 @@ export const ClaudeMarketplacePluginEntrySchema = z.object({
     .describe('Path to plugin directory (default: plugins/<name>)'),
   files: z.array(SkillFileEntrySchema).optional()
     .describe('Explicit source→dest file mappings for compiled artifacts outside the plugin directory'),
+  version: z.string().regex(SEMVER_REGEX, {
+    message: 'version must be a valid semver string (e.g., "1.2.3" or "1.0.0-rc.1")',
+  }).optional()
+    .describe('Per-plugin semver version (overrides root package.json:version for this plugin)'),
+  changelog: z.string().optional()
+    .describe('Path to per-plugin CHANGELOG (relative to plugin source dir; default: <source>/CHANGELOG.md if it exists)'),
 }).strict().describe('Plugin entry within a marketplace configuration');
 
 export type ClaudeMarketplacePluginEntry = z.infer<typeof ClaudeMarketplacePluginEntrySchema>;

--- a/packages/resources/test/schemas/project-config.test.ts
+++ b/packages/resources/test/schemas/project-config.test.ts
@@ -190,6 +190,79 @@ describe('ClaudeMarketplacePluginEntrySchema (full plugin support)', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  describe('version field', () => {
+    it('accepts a valid semver version', () => {
+      const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+        name: 'p',
+        skills: '*',
+        version: '0.2.0',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a prerelease semver version', () => {
+      const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+        name: 'p',
+        skills: '*',
+        version: '1.0.0-rc.1',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts an entry without version (backwards compat)', () => {
+      const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+        name: 'p',
+        skills: '*',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.version).toBeUndefined();
+      }
+    });
+
+    it('rejects a non-semver version string', () => {
+      for (const version of ['not-a-version', '1.2', '1', 'latest', '']) {
+        const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+          name: 'p',
+          skills: '*',
+          version,
+        });
+        expect(result.success).toBe(false);
+      }
+    });
+  });
+
+  describe('changelog field', () => {
+    it('accepts a relative changelog path', () => {
+      const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+        name: 'p',
+        skills: '*',
+        changelog: 'CHANGELOG.md',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a nested relative changelog path', () => {
+      const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+        name: 'p',
+        skills: '*',
+        changelog: 'docs/CHANGELOG.md',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('leaves changelog undefined when not declared', () => {
+      const result = ClaudeMarketplacePluginEntrySchema.safeParse({
+        name: 'p',
+        skills: '*',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.changelog).toBeUndefined();
+      }
+    });
+  });
 });
 
 describe('ClaudeMarketplaceSchema (pool filter)', () => {

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "type": "module",
   "description": "Core utility functions with no external dependencies",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/resources/skills/vat-skill-distribution.md
+++ b/packages/vat-development-agents/resources/skills/vat-skill-distribution.md
@@ -300,6 +300,63 @@ Start a new Claude Code session to confirm skills load. See the [Marketplace Dis
 
 **Note (Claude Code v2.1.81):** If re-adding a marketplace with the same name as an existing one (e.g., switching from npm to GitHub source), remove the old marketplace first: `claude plugin marketplace remove <name>` then re-add. Otherwise the old source is silently reused.
 
+### Per-plugin versioning (multi-plugin marketplaces)
+
+VAT supports two versioning models for a marketplace:
+
+**Single-version (default for skills-only marketplaces).** No `version` is declared on individual plugins. All plugins inherit the root `package.json:version`. This is the model used by `vibe-agent-toolkit` and `avonrisk-sdlc` — the marketplace is treated as one release artifact.
+
+**Per-plugin versioning** (multi-plugin marketplaces with independent release cadences). Each plugin declares its own `version`. Recommended when topical plugins under one marketplace evolve on independent timelines (e.g., AvonRiskBuilders' `ai-digest`, `bank-reconciliation`).
+
+#### Where to declare a per-plugin version
+
+Two options, in precedence order:
+
+1. **Marketplace config** (`vibe-agent-toolkit.config.yaml`) — most explicit:
+   ```yaml
+   claude:
+     marketplaces:
+       my-marketplace:
+         plugins:
+           - name: ai-digest
+             version: 0.2.0
+             skills: '*'
+   ```
+2. **Plugin source** (`plugins/<name>/.claude-plugin/plugin.json:version`) — most ergonomic for plugin authors:
+   ```json
+   { "name": "ai-digest", "version": "0.2.0", "description": "..." }
+   ```
+
+If both declare a version, marketplace config wins and VAT logs a reconciliation warning. If neither is declared, VAT falls back to the root `package.json:version` (single-version model).
+
+#### What `vat claude marketplace publish` does for multi-plugin marketplaces
+
+For each plugin with a resolved version:
+
+- The published `.claude-plugin/marketplace.json` includes the per-plugin `version` field on each plugin entry.
+- After the publish-branch push succeeds, VAT pushes a `<plugin>-v<version>` tag to the **source repo** (not the marketplace branch) — e.g., `ai-digest-v0.2.0`. "Source repo" means the working directory where you invoke `vat claude marketplace publish` (i.e., `process.cwd()`); if you invoke from a subdirectory of a worktree, tags land in the containing repo, not the subdirectory. Tag-push failures log a warning but do not roll back the publish.
+- If `<plugin.source>/CHANGELOG.md` exists in source (or the marketplace plugin entry's `changelog` field points to a file), it is bundled into the published marketplace at `plugins/<name>/CHANGELOG.md`, alongside the marketplace-level CHANGELOG.
+
+The marketplace-level CHANGELOG (under `publish.changelog` in the config) continues to work unchanged.
+
+#### Default CHANGELOG location
+
+The default per-plugin CHANGELOG path is `<plugin.source>/CHANGELOG.md`, anchored to the entry's `source` field (default `plugins/<name>`). It is NOT assumed to be `plugins/<name>/CHANGELOG.md` — if you override `source`, the default CHANGELOG path follows.
+
+To use a non-default path, set the `changelog` field on the marketplace plugin entry (relative to the plugin source dir):
+
+```yaml
+plugins:
+  - name: ai-digest
+    source: plugins/ai-digest
+    changelog: docs/RELEASES.md
+    skills: '*'
+```
+
+#### Backwards compatibility
+
+Marketplaces with no per-plugin version anywhere are unaffected. The root `package.json` version flows through to every plugin, the published `marketplace.json` either omits per-plugin `version` or includes the same value for all plugins, and tag pushes use the inherited version (e.g., both plugins tagged `<plugin>-v1.0.0`).
+
 ## Step 5: User Install
 
 ### Recommended: npm global install (postinstall runs automatically)

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Adds per-plugin independent versioning, tagging, and CHANGELOG bundling to VAT marketplaces. Each plugin can declare its own `version` (in `<plugin>/.claude-plugin/plugin.json` or via marketplace config), gets its own per-plugin source-repo tag (`<plugin>-v<version>`) on `vat claude marketplace publish`, and ships its own `CHANGELOG.md` bundled into the published marketplace at `plugins/<name>/CHANGELOG.md`.

| Phase | Scope |
|---|---|
| 1 | Schema: optional `version` (semver-validated via official regex from semver.org so JSON Schema export carries the constraint) and `changelog` fields on `ClaudeMarketplacePluginEntrySchema`. |
| 2 | `resolveVersion` precedence: `marketplace config > plugin.json:version > root package.json`. Reconciliation warning on disagreement. `mergePluginJson` simplified — caller pre-resolves. |
| 3 | `buildPlugin` propagates `pluginVersion` per-plugin; `buildMarketplace` writes `version` into `marketplace.json` plugin entries when defined. Per-plugin `CHANGELOG.md` resolved via `resolvePluginChangelogPath` (anchored to `<plugin.source>/CHANGELOG.md`, NOT assumed `plugins/<name>`) and copied to the publish output. |
| 4 | Per-plugin source-repo tags pushed to `process.cwd()` after successful branch push. SHA-aware: republish-without-bump emits a clear warning and does NOT silently move the local tag. Skipped during `--dry-run` / `--no-push`. |
| 5 | End-to-end integration test with `multi-plugin-marketplace` (per-plugin versions + CHANGELOGs) and `single-version-marketplace` (avonrisk-sdlc shape) fixtures; three scenarios + a republish-without-bump scenario locking in tag semantics. |

## Driver

Unblocks the AvonRiskBuilders marketplace where each topical plugin (`ai-digest`, `bank-reconciliation`, …) must version and release independently. Source spec: AvonRiskBuilders `docs/superpowers/specs/2026-05-09-builder-marketplace-design.md` §6, §17.

## Backwards compatibility

Marketplaces with no per-plugin `version` field inherit the root `package.json:version` — preserves the existing `avonrisk-sdlc` shape exactly. **Integration scenario 3 explicitly proves this path.**

## What was scoped out (deliberate, not gaps)

- **Selective publish via `--plugin`** — per AvonRiskBuilders §17.2, only needed when adding plugin #2; the AI Digest pilot does not need it. Defer.
- **`claude.publish.tags: false` opt-out** — pre-1.0 policy in this repo's CLAUDE.md disallows BC shims; tagging is additive.

## Adopter testing (`VAT_ROOT_DIR` protocol)

Verified against three targets vs. `main` baseline (counts compared by stash + rebuild + re-run):

- **avonrisk-sdlc**: `vat audit` 1 error / 95 warnings (matches baseline — pre-existing); `vat skills validate` clean. **PASS.**
- **vibe-validate**: 0 errors / 0 warnings; clean. **PASS.**
- **vat self (`--user`)**: 29 skills with errors / 343 scanned (matches baseline). **PASS.**

Zero new findings introduced by this PR.

## Code review

Internal review identified a `git tag -f` foot-gun (silent local tag drift on republish-without-bump) and a `semver` JSON Schema export gap. Both fixed before commit:
- Tag handling is now SHA-aware (no `-f`); republish-without-bump emits a clear warning and skips both local move and remote push.
- Schema `version` uses the official semver regex so the constraint survives `zod-to-json-schema` export.

Plus 4 nits (log emoji → ASCII, comment, simpler logger plumbing, dead test fixture, doc clarification).

## Test plan

- [x] Phase 1-3 unit tests: schema, `resolveVersion` precedence, tag formatter, CHANGELOG resolver
- [x] Phase 2 integration: tag push success, push-failure-doesn't-rollback, dry-run skip, no-push skip, empty plugins no-op, republish-without-bump SHA reconciliation
- [x] Phase 3 integration: per-plugin CHANGELOG bundled, per-plugin version in `marketplace.json`, no-version omits field
- [x] Phase 4 end-to-end: initial publish (multi-plugin), republish-after-bump, backwards-compat fallback (single-version)
- [x] Adopter testing via `VAT_ROOT_DIR` (avonrisk-sdlc, vibe-validate, vat self) — no regressions
- [x] Local `bun run validate` green (~4 min)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)