### PR TITLE
chore: bump vibe-validate to 0.19.5 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Bumped `vibe-validate` and `@vibe-validate/cli` dev deps from `0.19.5-rc.1` to `0.19.5` (stable). The stable release fixes a git worktree corruption issue.
+
 ## [0.1.35] - 2026-05-09
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@types/semver": "^7.7.1",
         "@typescript-eslint/eslint-plugin": "^8.50.1",
         "@typescript-eslint/parser": "^8.50.1",
-        "@vibe-validate/cli": "0.19.5-rc.1",
+        "@vibe-validate/cli": "0.19.5",
         "@vitest/coverage-v8": "^3.2.4",
         "adm-zip": "^0.5.16",
         "eslint": "^9.39.2",
@@ -36,7 +36,7 @@
         "tsx": "^4.21.0",
         "turbo": "^2.8.3",
         "typescript": "^5.9.3",
-        "vibe-validate": "0.19.5-rc.1",
+        "vibe-validate": "0.19.5",
         "vitest": "^3.2.4",
         "yaml": "^2.8.2",
       },
@@ -1012,19 +1012,19 @@
 
     "@vibe-agent-toolkit/vat-example-cat-agents": ["@vibe-agent-toolkit/vat-example-cat-agents@workspace:packages/vat-example-cat-agents"],
 
-    "@vibe-validate/cli": ["@vibe-validate/cli@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/config": "0.19.5-rc.1", "@vibe-validate/core": "0.19.5-rc.1", "@vibe-validate/extractors": "0.19.5-rc.1", "@vibe-validate/git": "0.19.5-rc.1", "@vibe-validate/history": "0.19.5-rc.1", "chalk": "^5.6.2", "commander": "^12.1.0", "prompts": "^2.4.2", "proper-lockfile": "^4.1.2", "semver": "^7.7.3", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" }, "bin": { "vibe-validate": "dist/bin/vibe-validate", "vv": "dist/bin/vv" } }, "sha512-MBSTzcs3aSzDv2o+j6iZ//gHV2a3Q+GGWEAK48DxuBLs4eG0ChVVsDubuAFBpAiz4ceMMvK1KtievKGtmCsipw=="],
+    "@vibe-validate/cli": ["@vibe-validate/cli@0.19.5", "", { "dependencies": { "@vibe-validate/config": "0.19.5", "@vibe-validate/core": "0.19.5", "@vibe-validate/extractors": "0.19.5", "@vibe-validate/git": "0.19.5", "@vibe-validate/history": "0.19.5", "chalk": "^5.6.2", "commander": "^12.1.0", "prompts": "^2.4.2", "proper-lockfile": "^4.1.2", "semver": "^7.7.3", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" }, "bin": { "vv": "dist/bin/vv", "vibe-validate": "dist/bin/vibe-validate" } }, "sha512-hRx3SE1sGtCZFAZ0GoitJQxcurOlSVJWr70UMiEs7Hr/wnJ1Nszo09Rvq0mKYWQiyBLomsF36NN4j48/TIP2AQ=="],
 
-    "@vibe-validate/config": ["@vibe-validate/config@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/utils": "0.19.5-rc.1", "tsx": "^4.21.0", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-7dA4gR1TiK4PsMsD2F4ZE+hdX2zhoGfLJHeZpXxCXo0td6cR2rkD169j/o6yMwjmGKFg6hbCezGfMFvWfpIKlg=="],
+    "@vibe-validate/config": ["@vibe-validate/config@0.19.5", "", { "dependencies": { "@vibe-validate/utils": "0.19.5", "tsx": "^4.21.0", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-WPDtu7lB7ybuZUkC+gHMK+DhB1FZQzmlG2iiKgwweuF1eGlnRovHG0y4aUu8u58WcwDUq9XUJr/l7vSrLH+Dqw=="],
 
-    "@vibe-validate/core": ["@vibe-validate/core@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/config": "0.19.5-rc.1", "@vibe-validate/extractors": "0.19.5-rc.1", "@vibe-validate/git": "0.19.5-rc.1", "@vibe-validate/utils": "0.19.5-rc.1", "strip-ansi": "^7.1.2", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-RvpHD5tnTIENV0h5aLspNDB0/OxH7T7BtsM1fGOd/UQFbKxUF3Y0YU6Y35JP9Ol/60wvUskZQgDlqqf+rEBM2g=="],
+    "@vibe-validate/core": ["@vibe-validate/core@0.19.5", "", { "dependencies": { "@vibe-validate/config": "0.19.5", "@vibe-validate/extractors": "0.19.5", "@vibe-validate/git": "0.19.5", "@vibe-validate/utils": "0.19.5", "strip-ansi": "^7.1.2", "yaml": "^2.8.2", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-zYMhul1LKSemi27E56+EgYrR9AlFH7QWsAfAKxIIqUjSR9EdjTQ9wuyUDN0E+zRkY5HjasaX5Fx6h6EzI6gXZg=="],
 
-    "@vibe-validate/extractors": ["@vibe-validate/extractors@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/config": "0.19.5-rc.1", "@vibe-validate/utils": "0.19.5-rc.1", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-krLkhXUeNu3QPhrpnv5OHCC+VlNNhnixnpJb9J+xFcbjx+5zJvf4NP8zKF4TcYjnqOB8htOUwQkkMn0wvHiPzA=="],
+    "@vibe-validate/extractors": ["@vibe-validate/extractors@0.19.5", "", { "dependencies": { "@vibe-validate/config": "0.19.5", "@vibe-validate/utils": "0.19.5", "zod": "^3.25.76", "zod-to-json-schema": "^3.25.0" } }, "sha512-aXVk2Lb3lFBfHemrAhqKFZvIBbULlTLGMrWNNuXqseNMn++tlyaf9JmHZ0c/pK6Dwk8LnCygy7ouPlCSgT53Hg=="],
 
-    "@vibe-validate/git": ["@vibe-validate/git@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/utils": "0.19.5-rc.1", "yaml": "^2.8.2" } }, "sha512-qnbCe87TlMCr42OIKpLjmzdae4I4q5NmfgC8nP9sTB30qhvBkq1nvX4VEZdf0VxiYRmG+PMugYPwp1N2u1UD6Q=="],
+    "@vibe-validate/git": ["@vibe-validate/git@0.19.5", "", { "dependencies": { "@vibe-validate/utils": "0.19.5", "yaml": "^2.8.2" } }, "sha512-uHqVaAqYdXAr53UKYlD0TB4xfolRx/cu8V1drS4BK88A+/GwNNgaCwO8ZfWGNGUPQ0eXYG/CM/5eEQF4lvAlNg=="],
 
-    "@vibe-validate/history": ["@vibe-validate/history@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/core": "0.19.5-rc.1", "@vibe-validate/git": "0.19.5-rc.1", "yaml": "^2.8.2", "zod": "^3.25.76" } }, "sha512-H0UPJNJ5WFcqfdxL4vd9GSrqB7KffJIWZmyRtI90ysZbeECSe4G+O01PcvX7cc/mIJbC7F7UgJ2pXuGPcJ5xfw=="],
+    "@vibe-validate/history": ["@vibe-validate/history@0.19.5", "", { "dependencies": { "@vibe-validate/core": "0.19.5", "@vibe-validate/git": "0.19.5", "yaml": "^2.8.2", "zod": "^3.25.76" } }, "sha512-G/GAS0VJUUbiARWEL5xaUMu81Q6dTyUKMOoJRELdNvo9d3I9GDf003h3lnwEvDcbjMDuvPtRgOjqr/34+no/3Q=="],
 
-    "@vibe-validate/utils": ["@vibe-validate/utils@0.19.5-rc.1", "", { "dependencies": { "which": "^5.0.0" } }, "sha512-zlLD1cCH6c8Fiha1VDp/oSDxlV9cfUpt9TuLDxsql4HxU/V7ExPJ5Xj5KWIC57NA+aJng9U/fQ/YSDG4qWd55Q=="],
+    "@vibe-validate/utils": ["@vibe-validate/utils@0.19.5", "", { "dependencies": { "which": "^5.0.0" } }, "sha512-A7fD4vL3+sQSw33ZFUJSR+vFpbJb5zy0oFnbqv/8WYPutvaPQHZ0W3q9yFA+k0yiYxwCU0PaBm3k+R8MZ0mFNA=="],
 
     "@vitest/coverage-v8": ["@vitest/coverage-v8@3.2.4", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^1.0.2", "ast-v8-to-istanbul": "^0.3.3", "debug": "^4.4.1", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.17", "magicast": "^0.3.5", "std-env": "^3.9.0", "test-exclude": "^7.0.1", "tinyrainbow": "^2.0.0" }, "peerDependencies": { "@vitest/browser": "3.2.4", "vitest": "3.2.4" }, "optionalPeers": ["@vitest/browser"] }, "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ=="],
 
@@ -2376,7 +2376,7 @@
 
     "vibe-agent-toolkit": ["vibe-agent-toolkit@workspace:packages/vibe-agent-toolkit"],
 
-    "vibe-validate": ["vibe-validate@0.19.5-rc.1", "", { "dependencies": { "@vibe-validate/cli": "0.19.5-rc.1", "@vibe-validate/utils": "0.19.5-rc.1", "vibe-agent-toolkit": "^0.1.33" }, "bin": { "vibe-validate": "bin/vibe-validate", "vv": "bin/vv" } }, "sha512-/4ZO3ZwnId5kVClaFwPiq57YhCHCf/gCW+Eu+PMPpu9ERfgVb00zOZaLX9ZOyEgjn7Kip/qpNJTyevjqqBsOOg=="],
+    "vibe-validate": ["vibe-validate@0.19.5", "", { "dependencies": { "@vibe-validate/cli": "0.19.5", "@vibe-validate/utils": "0.19.5", "vibe-agent-toolkit": "^0.1.33" }, "bin": { "vv": "bin/vv", "vibe-validate": "bin/vibe-validate" } }, "sha512-DPWtbQoFfhbsIbGN9kxIqp6QCgEGkJCbE/wM1tmoaL/cVBsV1lDoViy2pN14nT6NzpLlUQUfrdNVKWqfKTsBLw=="],
 
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
@@ -2697,8 +2697,6 @@
     "test-exclude/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "ts-patch/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "vibe-validate/vibe-agent-toolkit": ["vibe-agent-toolkit@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/cli": "0.1.33", "@vibe-agent-toolkit/vat-development-agents": "0.1.33" }, "bin": { "vat": "bin/vat" } }, "sha512-lZAiYw+eszG2MGPsMbYT16gl0cdRHV+0qjah04YmQ6iYFNE7lHehq90tvpk8Qqix/c7ryoURxbAUgTUmpf1D8g=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -3090,10 +3088,6 @@
 
     "ts-patch/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli": ["@vibe-agent-toolkit/cli@0.1.33", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.2", "@vibe-agent-toolkit/agent-config": "0.1.33", "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/agent-skills": "0.1.33", "@vibe-agent-toolkit/claude-marketplace": "0.1.33", "@vibe-agent-toolkit/discovery": "0.1.33", "@vibe-agent-toolkit/gateway-mcp": "0.1.33", "@vibe-agent-toolkit/rag": "0.1.33", "@vibe-agent-toolkit/rag-lancedb": "0.1.33", "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "adm-zip": "^0.5.16", "commander": "^12.1.0", "js-yaml": "^4.1.0", "picomatch": "^4.0.3", "semver": "^7.7.3", "tar": "^7.5.7", "zod": "^3.24.1" }, "bin": { "vat": "dist/bin/vat.js" } }, "sha512-0RQukKa5LhJKqqIMW+aC3YsIH6TOzZV2q3O1nPO8xCDjT6fGm0yCvPiaIIuSUgOiJtkh9b9U4/of4q0Mv9NRwg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/vat-development-agents": ["@vibe-agent-toolkit/vat-development-agents@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/cli": "0.1.33", "yaml": "^2.8.2" } }, "sha512-xw/TlyrYYHJnCG2XXDEODua0ZTpFdb4Sk5vpUMzu5AVU/D2gjxlBd+IDP9Aw3GGLIJVt8MV/bmBlUFu4dd/phw=="],
-
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
@@ -3179,28 +3173,6 @@
     "gray-matter/js-yaml/argparse/sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@11.2.5", "", {}, "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-config": ["@vibe-agent-toolkit/agent-config@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "yaml": "^2.3.4" } }, "sha512-ZHgWsft4J3mDuw0yC7AhfmuaX9skXK+hoNqn+b+TF6yZTs5glgnwdCEn4hXoMp0FhgbEU42PBVY7Tn8go+Ejjg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-schema": ["@vibe-agent-toolkit/agent-schema@0.1.33", "", { "dependencies": { "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5" } }, "sha512-24pInktOPgbiji6g5j00iUuenFlcz5L9taCcQ4aGNQILkOmcvVFz7y93swEMxi87KuGUiGz4sJ6LBrwiecqFWg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/agent-skills": ["@vibe-agent-toolkit/agent-skills@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-config": "0.1.33", "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "adm-zip": "^0.5.16", "picomatch": "^4.0.3", "yaml": "^2.6.1", "zod": "^3.24.1", "zod-to-json-schema": "^3.23.5" } }, "sha512-oBHVEVtyRZ8nKR3mvrtbXSn29aWlvwDnN5yLXjdkUUbuNtcCMFi2IV19t5A24pjO6/Fum0uZV83KKh6vFml4Bw=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/claude-marketplace": ["@vibe-agent-toolkit/claude-marketplace@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-skills": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "ignore": "^6.0.0", "zod": "^3.24.1" } }, "sha512-UqtWfOOFF+zBoIKTjl4Nv6Koe7067bEzlghk6UKJa8gdMyt8HzpZxriQxZZgrKYWfBculPnGOp2ntvljXOOXVw=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/discovery": ["@vibe-agent-toolkit/discovery@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/utils": "0.1.33", "picomatch": "^4.0.2" } }, "sha512-xvkYl3tDxD/ShXiHGf+9lG4n6Tho+ToUQm0FLCcMSiTpn8tldgMbhwbnyQqw9ZZI4tKx5n9KbF5D6vU0nh+5+g=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/gateway-mcp": ["@vibe-agent-toolkit/gateway-mcp@0.1.33", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.4", "@vibe-agent-toolkit/agent-schema": "0.1.33", "zod": "^3.24.1" } }, "sha512-XuY8nZakA1m/A7283zmBKHLG/p8E9Yu+XKO4hm1/cJRF8JVJirj4YDV0GseKCT4Cb51dCtxjlRRXEIiZBkI/Hw=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag": ["@vibe-agent-toolkit/rag@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "gpt-tokenizer": "^2.6.0", "zod": "^3.22.0", "zod-to-json-schema": "^3.22.0" }, "optionalDependencies": { "@xenova/transformers": "^2.17.0", "onnxruntime-node": "^1.24.0", "openai": "^6.16.0" } }, "sha512-oSqwT+vz+Wprgp2O1stan/ABX2mCkpC7vfxCToLoBUEfyiIunJkW9ydW8XTEcA8LX0slzNn4X7fp5sG1LVbw8w=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb": ["@vibe-agent-toolkit/rag-lancedb@0.1.33", "", { "dependencies": { "@lancedb/lancedb": "^0.23.0", "@vibe-agent-toolkit/rag": "0.1.33", "@vibe-agent-toolkit/resources": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "apache-arrow": "^18.1.0", "zod": "^3.24.1" } }, "sha512-VvB0tLJm0Yw/Vr/yLNsqOTZ7aD0uBL5+d5kUZhbg7MpBzfhc7HAXidAnUpQGqz5w1ALVwSJt5wN37yvCVCaecQ=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/resources": ["@vibe-agent-toolkit/resources@0.1.33", "", { "dependencies": { "@vibe-agent-toolkit/agent-schema": "0.1.33", "@vibe-agent-toolkit/utils": "0.1.33", "ajv": "^8.17.1", "github-slugger": "^2.0.0", "js-yaml": "^4.1.1", "markdown-link-check": "^3.14.2", "picomatch": "^4.0.3", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.0", "remark-parse": "^11.0.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "zod": "^3.24.1" } }, "sha512-yHI79/0Yg0dRZqQgJkz2/4niT8GqZW9UTMnIBlEWcUgkDVAhwd26gL5h1IcnU2apLQvMDt1Ib/WGAn2Bu5cDIA=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/utils": ["@vibe-agent-toolkit/utils@0.1.33", "", { "dependencies": { "handlebars": "^4.7.8", "ignore": "^7.0.5", "picomatch": "^4.0.3", "which": "^5.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-ce9vwqQ96wSTz3UM9TV0fTmG8xucV3+Lz1qwUrcobGuv8aZAs/BPI6Cv3FmvzQ2Gaw8n7RktFDvX6b3qeyNCqw=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/vat-development-agents/@vibe-agent-toolkit/agent-schema": ["@vibe-agent-toolkit/agent-schema@0.1.33", "", { "dependencies": { "zod": "^3.23.8", "zod-to-json-schema": "^3.23.5" } }, "sha512-24pInktOPgbiji6g5j00iUuenFlcz5L9taCcQ4aGNQILkOmcvVFz7y93swEMxi87KuGUiGz4sJ6LBrwiecqFWg=="],
 
     "@vibe-agent-toolkit/cli/vitest/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -3664,32 +3636,6 @@
 
     "@vibe-agent-toolkit/vat-example-cat-agents/vitest/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
 
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb": ["@lancedb/lancedb@0.23.0", "", { "dependencies": { "reflect-metadata": "^0.2.2" }, "optionalDependencies": { "@lancedb/lancedb-darwin-arm64": "0.23.0", "@lancedb/lancedb-darwin-x64": "0.23.0", "@lancedb/lancedb-linux-arm64-gnu": "0.23.0", "@lancedb/lancedb-linux-arm64-musl": "0.23.0", "@lancedb/lancedb-linux-x64-gnu": "0.23.0", "@lancedb/lancedb-linux-x64-musl": "0.23.0", "@lancedb/lancedb-win32-arm64-msvc": "0.23.0", "@lancedb/lancedb-win32-x64-msvc": "0.23.0" }, "peerDependencies": { "apache-arrow": ">=15.0.0 <=18.1.0" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ] }, "sha512-aYrIoEG24AC+wILCL57Ius/Y4yU+xFHDPKLvmjzzN4byAjzeIGF0TC86S5RBt4Ji+dxS7yIWV5Q/gE5/fybIFQ=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/apache-arrow": ["apache-arrow@18.1.0", "", { "dependencies": { "@swc/helpers": "^0.5.11", "@types/command-line-args": "^5.2.3", "@types/command-line-usage": "^5.0.4", "@types/node": "^20.13.0", "command-line-args": "^5.2.1", "command-line-usage": "^7.0.1", "flatbuffers": "^24.3.25", "json-bignum": "^0.0.3", "tslib": "^2.6.2" }, "bin": { "arrow2csv": "bin/arrow2csv.js" } }, "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/utils/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
     "@vibe-agent-toolkit/resource-compiler/eslint/file-entry-cache/flat-cache/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-darwin-arm64": ["@lancedb/lancedb-darwin-arm64@0.23.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8w0sMCNMwBv2kv5+fczGeSVlNOL+BOKChSsO4usM0hMw3PmxasONPctQBsESDuPS8lQ6/AKAQc2HT/ddd5Mg5w=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-linux-arm64-gnu": ["@lancedb/lancedb-linux-arm64-gnu@0.23.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-+xse2IspO7hbuHT4H62q8Ct00fTojnuBxXp1X1I3/27dDvW8E+/itFiJuTZ0YMaJc7nNr9qh9YFXZ9hZdEmReg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-linux-arm64-musl": ["@lancedb/lancedb-linux-arm64-musl@0.23.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-c2UCtGoYjA3oDdw5y3RLK7J2th3rSjYBng+1I03vU9g092y8KATAJO/lV2AtyxSC+esSuyY1dMEaj8ADcXjZAA=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-linux-x64-gnu": ["@lancedb/lancedb-linux-x64-gnu@0.23.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OPL7tK3JCTx43ZxvbVs+CljfCer0KrojANQbcJ2V4VAp6XBhKx1sBAlIVGuCrd93pA8UOUP3iHsM7aglPo6rCg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-linux-x64-musl": ["@lancedb/lancedb-linux-x64-musl@0.23.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1ZEoQDwOrKvwPyAG+95/r1NYqX8Ca5bRek8Vr62CzWCEmHd/pFeEGWZ5STrkh+Bt3GLdi2JOivFtRbmuBAJypQ=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-win32-arm64-msvc": ["@lancedb/lancedb-win32-arm64-msvc@0.23.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-OuD1mkrgXvijRlXdbx3LvfuorO04FD5qHegnTOWGXh1sIwwrvvhcJAvXUGBNLY4n/lsWvA+xTjtMwRjUitvPKg=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/@lancedb/lancedb/@lancedb/lancedb-win32-x64-msvc": ["@lancedb/lancedb-win32-x64-msvc@0.23.0", "", { "os": "win32", "cpu": "x64" }, "sha512-5ve1hvVtp8zWxSE9A+MOQaicXl2Rn0ZG/NUaMTjTD3/CQHPKFmtrqDnM5khoPICTj2O2b10F6mn4cUzl5PASgA=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/apache-arrow/@types/node": ["@types/node@20.19.33", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/apache-arrow/flatbuffers": ["flatbuffers@24.12.23", "", {}, "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA=="],
-
-    "vibe-validate/vibe-agent-toolkit/@vibe-agent-toolkit/cli/@vibe-agent-toolkit/rag-lancedb/apache-arrow/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.50.1",
     "@typescript-eslint/parser": "^8.50.1",
-    "@vibe-validate/cli": "0.19.5-rc.1",
+    "@vibe-validate/cli": "0.19.5",
     "@vitest/coverage-v8": "^3.2.4",
     "adm-zip": "^0.5.16",
     "eslint": "^9.39.2",
@@ -96,7 +96,7 @@
     "tsx": "^4.21.0",
     "turbo": "^2.8.3",
     "typescript": "^5.9.3",
-    "vibe-validate": "0.19.5-rc.1",
+    "vibe-validate": "0.19.5",
     "vitest": "^3.2.4",
     "yaml": "^2.8.2"
   },


### PR DESCRIPTION
## Summary

Bumps both `vibe-validate` and `@vibe-validate/cli` from `0.19.5-rc.1` to `0.19.5` stable.

The 0.19.5 stable release fixes a git worktree corruption issue. No other behavior change.

## Test plan

- [x] `bun install` clean (lockfile updated, both packages resolve at 0.19.5)
- [x] `bun run validate` green at the new version (~3 min, 14/14 phases)
- [x] CHANGELOG entry under `[Unreleased]`
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)