### PR TITLE
fix(cli): post-install hint should reference /reload-plugins, not /re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`vat claude plugin install` post-install hints now point to the correct Claude Code slash command.** Both the standard and `--dev` install paths previously suggested `/reload-skills`, which is not a registered Claude Code CLI command — the real one is `/reload-plugins`. Docs (`packages/cli/docs/skills.md`, `docs/guides/distributing-vat-skills.md`, plugin READMEs, `vat-example-cat-agents` distribution doc) updated to match.
+
 ## [0.1.37] - 2026-05-16
 
 ### Fixed

--- a/docs/guides/distributing-vat-skills.md
+++ b/docs/guides/distributing-vat-skills.md
@@ -372,7 +372,7 @@ vat skills list --user
 ```
 
 > **Why symlinks?** After `vat skills build`, the built output in `dist/skills/` has rewritten links.
-> A symlink means rebuilds are immediately visible to Claude Code after `/reload-skills`.
+> A symlink means rebuilds are immediately visible to Claude Code after `/reload-plugins`.
 
 ### 3. Publish to npm
 
@@ -565,7 +565,7 @@ vat skills install npm:@vibe-agent-toolkit/vat-development-agents
 
 ### Skills Not Appearing in Claude Code
 
-**Solution:** Restart Claude Code or run `/reload-skills` command.
+**Solution:** Restart Claude Code or run `/reload-plugins` command.
 
 ### Build Fails with "Source not found"
 
@@ -704,7 +704,7 @@ To update a skill, rebuild and reinstall:
 ```bash
 # For dev installs (symlinks): just rebuild
 vat skills build
-# Then /reload-skills in Claude Code
+# Then /reload-plugins in Claude Code
 
 # For copied installs: rebuild and reinstall
 vat skills build
@@ -724,7 +724,7 @@ vat skills install --dev
 
 # 3. After changes, rebuild (symlinks reflect updates immediately)
 vat skills build
-# Then /reload-skills in Claude Code
+# Then /reload-plugins in Claude Code
 
 # 4. Clean up when done
 vat skills uninstall --all

--- a/packages/cli/docs/skills.md
+++ b/packages/cli/docs/skills.md
@@ -378,7 +378,7 @@ vat skills install ./dist/skills/my-skill --target claude --scope project
 **Post-Installation:**
 After installation, you need to:
 1. Restart Claude Code (or the target agent), or
-2. Run `/reload-skills` in Claude Code to load the new skill
+2. Run `/reload-plugins` in Claude Code to load the new skill
 
 ---
 
@@ -580,7 +580,7 @@ User: /my-skill
 - Use `--dry-run` to preview what will be installed before committing
 - Use `--force` flag carefully (overwrites existing skills)
 - Verify installation: `vat skills list --user`
-- Remember to restart the target agent or run `/reload-skills` in Claude Code
+- Remember to restart the target agent or run `/reload-plugins` in Claude Code
 
 ---
 
@@ -660,7 +660,7 @@ name: my-help  # Instead of "help"
 **Solution:**
 1. Verify installation: `vat skills list --user`
 2. Check location: Should be in `~/.claude/skills/` not `~/.claude/plugins/`
-3. Restart Claude Code or run `/reload-skills`
+3. Restart Claude Code or run `/reload-plugins`
 
 ### "Windows-style backslashes"
 **Problem:** Links use backslashes: `resources\SKILL.md`

--- a/packages/cli/src/commands/claude/plugin/install.ts
+++ b/packages/cli/src/commands/claude/plugin/install.ts
@@ -1057,7 +1057,7 @@ function outputDevSuccess(
     logger.info(`\n✅ Dry-run complete: ${installed.length} skill(s) would be symlinked`);
   } else {
     logger.info(`\n✅ Dev-installed ${installed.length} skill(s) via symlink`);
-    logger.info(`   After rebuilding, run /reload-skills in Claude Code`);
+    logger.info(`   After rebuilding, run /reload-plugins in Claude Code`);
   }
 }
 
@@ -1088,6 +1088,6 @@ function outputInstallSuccess(
   } else {
     logger.info(`\n✅ Installed ${skills.length} skill(s)`);
     logger.info(`\n💡 Run 'vat claude plugin list' to verify installation`);
-    logger.info(`   Restart Claude Code or run /reload-skills to use the new skill`);
+    logger.info(`   Restart Claude Code or run /reload-plugins to use the new skill`);
   }
 }

--- a/packages/vat-development-agents/README.md
+++ b/packages/vat-development-agents/README.md
@@ -71,7 +71,7 @@ vat skills install ./packages/vat-development-agents
 vat skills list --installed
 ```
 
-The `vibe-agent-toolkit` skill will be installed to `~/.claude/plugins/vibe-agent-toolkit/` and will appear in Claude Code after restarting or running `/reload-skills`.
+The `vibe-agent-toolkit` skill will be installed to `~/.claude/plugins/vibe-agent-toolkit/` and will appear in Claude Code after restarting or running `/reload-plugins`.
 
 **What the skill includes:**
 - VAT overview and use cases

--- a/packages/vat-example-cat-agents/README.md
+++ b/packages/vat-example-cat-agents/README.md
@@ -53,7 +53,7 @@ vat skills install ./packages/vat-example-cat-agents
 vat skills list --installed
 ```
 
-The `vat-cat-agents` skill will be installed to `~/.claude/plugins/vat-cat-agents/` and will appear in Claude Code after restarting or running `/reload-skills`.
+The `vat-cat-agents` skill will be installed to `~/.claude/plugins/vat-cat-agents/` and will appear in Claude Code after restarting or running `/reload-plugins`.
 
 **What the skill includes:**
 - SKILL.md with agent orchestration patterns

--- a/packages/vat-example-cat-agents/docs/distribution.md
+++ b/packages/vat-example-cat-agents/docs/distribution.md
@@ -490,9 +490,9 @@ Use this template in your README for user-facing documentation:
    unzip cat-agents-skill.zip -d ~/.claude/plugins/
    ```
 
-3. Restart Claude Code or reload skills:
+3. Restart Claude Code or reload plugins:
    ```
-   /reload-skills
+   /reload-plugins
    ```
 
 ### Option 2: Install from npm


### PR DESCRIPTION
…load-skills

The hints printed after `vat claude plugin install` (both standard and `--dev`) suggested running `/reload-skills` in Claude Code, but no such slash command exists — the real one is `/reload-plugins`. Updated the hint strings in install.ts and aligned the docs that mirrored the old phrasing.

Files updated:
- packages/cli/src/commands/claude/plugin/install.ts (two hint lines)
- packages/cli/docs/skills.md
- docs/guides/distributing-vat-skills.md
- packages/vat-development-agents/README.md
- packages/vat-example-cat-agents/README.md
- packages/vat-example-cat-agents/docs/distribution.md
- CHANGELOG.md (Unreleased / Fixed)

Note* during this PR I found that calling vv through bun would end up with vv loading bun's compat shims instead of Node modules, resulting in processes saying "module not found." Avoided the error by calling vv through node. May be worth looking into later