### PR TITLE
fix(link-auth): post-merge follow-ups — allowCommand env fix, sideEffects, subpath exports (issue #113)

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,8 @@
   "name": "@vibe-agent-toolkit/utils",
   "version": "0.1.40-rc.1",
   "type": "module",
-  "description": "Core utility functions with no external dependencies",
+  "description": "Core utility functions shared across the vibe-agent-toolkit packages",
+  "sideEffects": false,
   "keywords": [
     "typescript",
     "utilities",
@@ -16,6 +17,14 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./process": {
+      "types": "./dist/process.d.ts",
+      "import": "./dist/process.js"
+    },
+    "./fs": {
+      "types": "./dist/fs.d.ts",
+      "import": "./dist/fs.js"
     }
   },
   "files": [

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -1,3 +1,4 @@
+/* c8 ignore file — pure re-export barrel, no logic to cover */
 /**
  * @vibe-agent-toolkit/utils/fs
  *

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -1,0 +1,25 @@
+/**
+ * @vibe-agent-toolkit/utils/fs
+ *
+ * Narrow subpath export for filesystem and path primitives. Import this entry
+ * point when you need cross-platform path/fs helpers without pulling in the
+ * linkAuth, git, skill-testing, or macro-expansion machinery from the full
+ * `"."` barrel.
+ */
+
+export {
+  normalizePath,
+  normalizedTmpdir,
+  mkdirSyncReal,
+  isAbsolutePath,
+  isAbsoluteAnyPlatform,
+  hasParentTraversalSegment,
+  toAbsolutePath,
+  getRelativePath,
+  toForwardSlash,
+  safePath,
+  resolveFromImportMeta,
+  dynamicImportPath,
+} from './path-utils.js';
+
+export { copyDirectory, verifyCaseSensitiveFilename } from './fs-utils.js';

--- a/packages/utils/src/link-auth/expand-macro.ts
+++ b/packages/utils/src/link-auth/expand-macro.ts
@@ -19,8 +19,6 @@ import { fileURLToPath } from 'node:url';
 
 import { parse as parseYaml } from 'yaml';
 
-const macrosPath = fileURLToPath(new URL('./macros.yaml', import.meta.url));
-
 let macrosCache: Record<string, Record<string, unknown>> | undefined;
 
 /**
@@ -33,13 +31,16 @@ let macrosCache: Record<string, Record<string, unknown>> | undefined;
  * unconditionally, before the mock-setup intent reaches our file.
  *
  * Lazy load makes module import side-effect-free; only callers of
- * `expandMacro` pay the fs cost.
+ * `expandMacro` pay the fs cost. `macrosPath` is also computed here (not at
+ * module top level) so that merely importing this module leaves no `new URL()`
+ * reference for bundler static analysis to trip over.
  */
 function getMacros(): Record<string, Record<string, unknown>> {
   if (macrosCache !== undefined) return macrosCache;
 
   // Path is derived from `import.meta.url`, not user input — points at the
   // shipped macros.yaml asset next to this module in both src and dist trees.
+  const macrosPath = fileURLToPath(new URL('./macros.yaml', import.meta.url));
   // eslint-disable-next-line security/detect-non-literal-fs-filename
   const macrosFileContent = readFileSync(macrosPath, 'utf8');
   const parsed = parseYaml(macrosFileContent) as unknown;

--- a/packages/utils/src/link-auth/resolve-token.ts
+++ b/packages/utils/src/link-auth/resolve-token.ts
@@ -41,10 +41,12 @@ export interface TokenResolutionDeps {
   readonly runCommand: (argv: readonly string[]) => { success: boolean; stdout: string };
 
   /**
-   * Whether `{ command: ... }` sources are allowed. Defaults to
-   * `process.env['VAT_LINKAUTH_ALLOW_COMMAND'] !== '0'`. Set to `false` (or
-   * export `VAT_LINKAUTH_ALLOW_COMMAND=0`) to skip all command sources and rely
-   * solely on env-var sources — useful in locked-down CI or security reviews.
+   * Whether `{ command: ... }` sources are allowed. Defaults to reading
+   * `VAT_LINKAUTH_ALLOW_COMMAND` from the resolved `env` map (not ambient
+   * `process.env`), so a caller supplying a curated `deps.env` can control the
+   * flag without touching real process state. Set to `false` (or set
+   * `VAT_LINKAUTH_ALLOW_COMMAND=0` in the env) to skip all command sources and
+   * rely solely on env-var sources — useful in locked-down CI or security reviews.
    */
   readonly allowCommand: boolean;
 }
@@ -96,7 +98,7 @@ export function resolveToken(
 ): string | undefined {
   const env = deps?.env ?? process.env;
   const runCommand = deps?.runCommand ?? defaultRunCommand;
-  const allowCommand = deps?.allowCommand ?? (process.env['VAT_LINKAUTH_ALLOW_COMMAND'] !== '0');
+  const allowCommand = deps?.allowCommand ?? (env['VAT_LINKAUTH_ALLOW_COMMAND'] !== '0');
 
   for (const source of sources) {
     if (!allowCommand && 'command' in source) continue;

--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -1,0 +1,20 @@
+/**
+ * @vibe-agent-toolkit/utils/process
+ *
+ * Narrow subpath export for process/command-execution primitives. Import this
+ * entry point when you need cross-platform spawn helpers without pulling in
+ * the linkAuth, git, skill-testing, or macro-expansion machinery from the
+ * full `"."` barrel.
+ */
+
+export {
+  type SafeExecOptions,
+  type SafeExecResult,
+  CommandExecutionError,
+  safeExecSync,
+  safeExecResult,
+  isToolAvailable,
+  getToolVersion,
+  hasShellSyntax,
+  safeExecFromString,
+} from './safe-exec.js';

--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -1,3 +1,4 @@
+/* c8 ignore file — pure re-export barrel, no logic to cover */
 /**
  * @vibe-agent-toolkit/utils/process
  *

--- a/packages/utils/test/link-auth/resolve-token.test.ts
+++ b/packages/utils/test/link-auth/resolve-token.test.ts
@@ -234,10 +234,25 @@ describe('resolveToken — allowCommand opt-out', () => {
     expect(runCommand).not.toHaveBeenCalled();
   });
 
-  // Note: the `VAT_LINKAUTH_ALLOW_COMMAND` env-var-at-call-time behaviour is
-  // covered by the system test (link-auth-token-dispatch.system.test.ts), where
-  // real process.env interaction is safe. Unit tests here inject `allowCommand`
-  // directly to avoid ambient-state pollution.
+  it('reads VAT_LINKAUTH_ALLOW_COMMAND from deps.env, not ambient process.env', () => {
+    // Bug fix: the opt-out flag must come from the resolved env map so callers
+    // that supply a curated deps.env (e.g. a sandboxed env) can control it
+    // without touching real process.env. Pass deps as a Partial so allowCommand
+    // is absent and resolveToken must derive it from the env map.
+    const runCommand = vi.fn(() => ({ success: true, stdout: 'should-not-run' }));
+    const partialDeps: Partial<TokenResolutionDeps> = {
+      env: { VAT_LINKAUTH_ALLOW_COMMAND: '0' },
+      runCommand,
+      // allowCommand intentionally omitted — resolveToken derives it from env
+    };
+    expect(resolveToken([{ command: ['gh', 'auth', 'token'] }], partialDeps)).toBeUndefined();
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+
+  // Note: the `VAT_LINKAUTH_ALLOW_COMMAND` env-var-at-call-time behaviour via
+  // real process.env is covered by the system test
+  // (link-auth-token-dispatch.system.test.ts). Unit tests here inject via
+  // deps.env to avoid ambient-state pollution.
 });
 
 describe('scrubGitEnv', () => {
@@ -271,6 +286,16 @@ describe('scrubGitEnv', () => {
 
   it('returns an empty object for empty input', () => {
     expect(scrubGitEnv({})).toEqual({});
+  });
+
+  it('GITHUB_TOKEN and GH_TOKEN survive the scrub — gh auth token depends on them', () => {
+    // Neither name starts with "GIT_", so both must pass through untouched.
+    // Explicit assertion guards against a future refactor of the prefix-match
+    // logic accidentally over-scrubbing the exact vars `gh auth token` needs.
+    expect(scrubGitEnv({ GITHUB_TOKEN: 'ghp_abc', GH_TOKEN: 'gho_xyz', GIT_DIR: 'strip' })).toEqual({
+      GITHUB_TOKEN: 'ghp_abc',
+      GH_TOKEN: 'gho_xyz',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up fixes from the post-merge independent review of PR #138. All items from the review comment on that PR.

- **[Bug, Med]** `allowCommand` now reads `VAT_LINKAUTH_ALLOW_COMMAND` from the resolved `deps.env` map instead of ambient `process.env`. A caller supplying a curated env via `deps.env` (e.g. sandboxed testing or embedded use) and setting the flag there would have been silently ignored before — commands would still run. Fails closed now.
- **[Packaging]** Add `"sideEffects": false` to `packages/utils/package.json` so bundlers can tree-shake unused modules. Directly resolves the downstream dangling `macros.yaml` asset-reference report for consumers that never call `expandMacro`.
- **[Hygiene]** Move `macrosPath` computation inside `getMacros()` so importing `expand-macro.ts` leaves no top-level `new URL()` for bundler static analysis.
- **[Subpath exports]** Add `@vibe-agent-toolkit/utils/process` and `@vibe-agent-toolkit/utils/fs` entry points — narrow slices for consumers who only need spawn helpers or path/fs utils without pulling in linkAuth machinery.
- **[Nit]** Fix stale package description (`"no external dependencies"` was false since before this PR).
- **[Tests]** Add `GITHUB_TOKEN`/`GH_TOKEN` scrub-survival assertion; add unit test covering the `allowCommand` bug fix (reads from `deps.env`, not `process.env`).

## Test plan

- [ ] All 34 unit tests pass (includes 2 new tests)
- [ ] Integration tests pass
- [ ] System tests pass (real git/gh binary dispatch, GIT_* scrub)
- [ ] TypeScript typecheck clean (new barrel files included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)