### PR TITLE
fix(coverage): exclude utils re-export barrels from patch coverage

### DIFF
--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -1,4 +1,3 @@
-/* c8 ignore file — pure re-export barrel, no logic to cover */
 /**
  * @vibe-agent-toolkit/utils/fs
  *

--- a/packages/utils/src/process.ts
+++ b/packages/utils/src/process.ts
@@ -1,4 +1,3 @@
-/* c8 ignore file — pure re-export barrel, no logic to cover */
 /**
  * @vibe-agent-toolkit/utils/process
  *

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,6 +34,8 @@ export default defineConfig({
         '**/*.test.ts',
         '**/*.spec.ts',
         '**/index.ts', // Re-exports
+        'packages/utils/src/fs.ts', // Re-export barrel (no logic)
+        'packages/utils/src/process.ts', // Re-export barrel (no logic)
         '**/types.ts', // Type definitions
         '**/schemas/**', // Zod schema definitions (type definitions, not logic)
         'packages/dev-tools/**', // Exclude dev-tools (infrastructure)


### PR DESCRIPTION
## Summary

- `packages/utils/src/fs.ts` and `packages/utils/src/process.ts` are pure re-export barrel files (no executable logic), identical in nature to the existing `**/index.ts` exclusion in vitest coverage config.
- Without exclusion, codecov patch flags them as uncovered since no unit tests import via the subpath entry points directly.
- Also removes the `/* c8 ignore file */` comments added in the previous commit — not a real c8 directive, doesn't actually work.

## Test plan

- [ ] codecov/patch passes (barrel files excluded from diff coverage measurement)
- [ ] All other checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)