### PR TITLE
fix(skill-test): hardened Windows .cmd spawn for claude sessions (v0.1.41-rc.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Tool checks no longer silently pass.** If an eval declared `toolExpectations` but the grader returned no tool verdict, it used to count as a pass; now it's a hard error (exit **1**). Same for a grader tool verdict whose `passed` disagrees with its own sub-checks.
 - **No more orphaned `claude` processes on failure.** When one parallel eval failed, in-flight grader/executor children were left running and billing tokens; they're now killed before the harness exits.
+- **`vat skill test run` no longer crashes on Windows with `spawn EINVAL`.** On Windows, `claude` resolves to an npm `claude.cmd` shim, and since the Node CVE-2024-27980 fix a bare `child_process.spawn` of a `.cmd` throws `EINVAL` synchronously — so the harness died the instant it tried to launch the headless session (reported by an adopter across cmd.exe, PowerShell, and Git Bash). The `claude` spawn now routes through a new hardened `spawnHardened` helper (exported from `@vibe-agent-toolkit/utils`) that detects `.cmd`/`.bat`/`.ps1` shims and launches them through the shell with per-arg quoting (no injection), reusing the Windows handling `safeExecSync` already had. A Windows-only integration test spawns a real `.cmd` shim (`npm`) to guard against regression. The same latent defect in the internal compat-empirical harness is fixed too.
+- **`spawnHeadlessClaude` reaps the child on a spawn `'error'` event.** The `'error'` handler unregistered the child from the orphan-reap set without killing it; it now kills the process tree first, closing a narrow orphan-leak window (no-ops when the child never spawned).
 
 ### Security
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "picomatch": "^4.0.3",
         "zod": "^3.23.8",
@@ -88,7 +88,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
@@ -132,7 +132,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -170,7 +170,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
         "@vibe-agent-toolkit/claude-marketplace": "workspace:*",
@@ -193,7 +193,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -204,7 +204,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -220,7 +220,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -241,7 +241,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -258,7 +258,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -279,7 +279,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -310,7 +310,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -329,7 +329,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -347,7 +347,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -365,7 +365,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -386,7 +386,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -399,7 +399,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -413,7 +413,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -435,7 +435,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -450,7 +450,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -476,7 +476,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.41-rc.1",
+      "version": "0.1.41-rc.2",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/dev-tools/src/compat-empirical/runtimes/shared/claude-cli.ts
+++ b/packages/dev-tools/src/compat-empirical/runtimes/shared/claude-cli.ts
@@ -7,9 +7,10 @@
  * back to API billing regardless of its internal auth-precedence order.
  */
 
-import { spawn } from 'node:child_process';
+import { type ChildProcessByStdio } from 'node:child_process';
+import { type Readable } from 'node:stream';
 
-import { safePath } from '@vibe-agent-toolkit/utils';
+import { safePath, spawnHardened } from '@vibe-agent-toolkit/utils';
 
 import { promptUser } from '../../cli/prompt-user.js';
 
@@ -92,8 +93,12 @@ export function runClaudeSubscription(
   });
 
   return new Promise((resolve) => {
-    // eslint-disable-next-line sonarjs/no-os-command-from-path -- claude is the runtime we are explicitly testing; PATH is the standard install location
-    const child = spawn('claude', args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    // spawnHardened (not a bare spawn) so a Windows `claude.cmd` shim launches
+    // instead of throwing EINVAL. stdio ['ignore','pipe','pipe'] → non-null out/err.
+    const child = spawnHardened('claude', args, {
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }) as ChildProcessByStdio<null, Readable, Readable>;
 
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "type": "module",
   "description": "Core utility functions shared across the vibe-agent-toolkit packages",
   "sideEffects": false,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -8,6 +8,12 @@
 // Safe command execution (cross-platform, no shell injection)
 export * from './safe-exec.js';
 
+// Windows shell-invocation helpers (.cmd/.bat/.ps1 handling), shared by every spawn wrapper
+export * from './windows-shell.js';
+
+// Hardened async spawn (streaming stdio + correct Windows .cmd/.bat launching)
+export * from './spawn-hardened.js';
+
 // Cross-platform path utilities
 export * from './path-utils.js';
 

--- a/packages/utils/src/safe-exec.ts
+++ b/packages/utils/src/safe-exec.ts
@@ -2,6 +2,8 @@ import { spawnSync, type SpawnSyncOptions } from 'node:child_process';
 
 import which from 'which';
 
+import { buildWindowsShellLine, shouldUseShell } from './windows-shell.js';
+
 /**
  * Options for safe command execution
  */
@@ -59,84 +61,6 @@ export class CommandExecutionError extends Error {
 }
 
 /**
- * Determine if shell should be used for command execution on Windows
- *
- * ## Security Context
- *
- * This package's primary security model is `shell: false` to prevent command injection.
- * Windows requires `shell: true` only for shell scripts (.cmd/.bat/.ps1) which require
- * a shell interpreter by design (not executable binaries).
- *
- * ## Node.js on Windows - NO SHELL REQUIRED
- *
- * **Previous behavior (REMOVED):** Used shell:true for 'node' command
- * **Problem discovered:** Node.js DEP0190 deprecation warning - passing args array with
- * shell:true leads to incorrect command execution. Exit codes are ignored (always returns 0).
- *
- * **Testing shows:**
- * - ✅ `shell: false` + absolute path from `which.sync('node')` → Works correctly
- * - ❌ `shell: true` + args array → Exit codes ignored, security warning
- *
- * **Root Cause of Previous ENOENT Issues:** Likely resolved in newer Node.js versions.
- * Current testing (Node 20+) shows shell:false works correctly with absolute path.
- *
- * ## Why This Is Secure
- *
- * 1. **Minimal Shell Usage:** Shell only used for .cmd/.bat/.ps1 files (required)
- * 2. **Path Validation:** Command paths resolved via `which.sync()` before execution
- * 3. **Array-Based Arguments:** Arguments passed as array, preventing injection
- * 4. **Controlled Environment:** Commands from trusted configuration, not user input
- * 5. **No String Interpolation:** Never concatenate user input into command strings
- *
- * ## References
- *
- * - Node.js deprecation: https://nodejs.org/api/deprecations.html#DEP0190
- * - Security tests: `packages/utils/test/safe-exec.test.ts`
- * - Windows fix: PR #94 (fix/windows-shell-independence-v2)
- *
- * @param commandPath - Resolved absolute path to command
- * @returns true if shell should be used, false otherwise
- */
-function shouldUseShell(commandPath: string): boolean {
-  if (process.platform !== 'win32') {
-    return false;
-  }
-
-  // Node.js deprecation warning (DEP0190): Passing args with shell:true leads to incorrect
-  // command execution and security vulnerabilities. Testing shows shell:false works correctly
-  // with absolute path from which.sync('node') on Windows.
-  // Previous ENOENT issues may have been resolved in newer Node.js versions.
-  //
-  // REMOVED: if (command === 'node') return true;
-  // Reason: shell:true causes exit codes to be ignored (always returns 0)
-  // Fix: Use shell:false with absolute path - works correctly
-
-  // Windows shell scripts require shell by design (case-insensitive check)
-  const lowerPath = commandPath.toLowerCase();
-  return lowerPath.endsWith('.cmd') || lowerPath.endsWith('.bat') || lowerPath.endsWith('.ps1');
-}
-
-/**
- * Quote a single argument for a Windows `cmd.exe` command line.
- *
- * Rules:
- *   - An arg that's empty, or contains whitespace, quotes, or any of `& | < > ^ ( ) % !`,
- *     gets wrapped in double quotes.
- *   - Embedded double quotes become `""` (cmd.exe's escape form inside quoted strings).
- *
- * This is narrow on purpose: it's only used when we're forced to assemble a shell string
- * for `.cmd` / `.bat` wrappers on Windows (DEP0190 path). Callers still control what's
- * in `args`, but this keeps a stray space, glob metachar, or paren from getting
- * re-interpreted by the shell.
- */
-function windowsShellQuote(arg: string): string {
-  if (arg === '' || /["\s&|<>^()%!]/.test(arg)) {
-    return `"${arg.replaceAll('"', '""')}"`;
-  }
-  return arg;
-}
-
-/**
  * Resolve command, build spawn options, and execute via spawnSync.
  *
  * Handles Windows shell requirements: `.cmd`/`.bat`/`.ps1` files need `shell:true`.
@@ -168,7 +92,7 @@ function resolveAndSpawn(
     return spawnSync(execCommand, args, spawnOptions);
   }
 
-  const shellLine = `${execCommand} ${args.map(windowsShellQuote).join(' ')}`;
+  const shellLine = buildWindowsShellLine(execCommand, args);
   // eslint-disable-next-line sonarjs/os-command -- Windows DEP0190 workaround: command resolved via which.sync(); args are per-arg shell-quoted via windowsShellQuote()
   return spawnSync(shellLine, { ...spawnOptions, shell: true });
 }

--- a/packages/utils/src/skill-test/spawn-claude.ts
+++ b/packages/utils/src/skill-test/spawn-claude.ts
@@ -1,7 +1,7 @@
-import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { Readable } from 'node:stream';
+import { spawnSync, type ChildProcess, type ChildProcessByStdio } from 'node:child_process';
+import { Readable, type Writable } from 'node:stream';
 
-import which from 'which';
+import { spawnHardened } from '../spawn-hardened.js';
 
 export interface ClaudeSpawnArgs {
   pluginDirs: string[];
@@ -105,7 +105,7 @@ export function killAllActiveClaudeChildren(): void {
 
 export interface SpawnHeadlessOptions extends ClaudeSpawnArgs {
   /**
-   * The experimenter prompt, held IN MEMORY and streamed to the child's stdin
+   * The executor prompt, held IN MEMORY and streamed to the child's stdin
    * (claude 2.x reads the `-p` prompt from stdin; there is no `--prompt-file`
    * flag). Kept off argv so the prompt is never inlined (Windows cmd-quoting
    * safety) AND, deliberately, off disk: the harness stamps a per-run integrity
@@ -140,12 +140,17 @@ export interface SpawnHeadlessOptions extends ClaudeSpawnArgs {
  */
 export async function spawnHeadlessClaude(opts: SpawnHeadlessOptions): Promise<SpawnResult> {
   // opts.binPath is an internal test seam (see SpawnHeadlessOptions); production
-  // callers leave it unset and `claude` is resolved on PATH.
-  const bin = opts.binPath ?? which.sync('claude');
+  // callers leave it unset and the bare `claude` name is resolved on PATH by
+  // spawnHardened. spawnHardened is REQUIRED here (not a bare spawn): on Windows
+  // `claude` resolves to a `claude.cmd` shim, and since CVE-2024-27980 a bare
+  // spawn of a `.cmd` throws EINVAL — spawnHardened routes it through the shell.
   const args = assembleClaudeArgs(opts);
 
   return await new Promise<SpawnResult>((resolve, reject) => {
-    const child = spawn(bin, args, {
+    // `stdio: ['pipe','pipe','pipe']` guarantees all three streams are non-null;
+    // spawnHardened is typed to return the generic (nullable-stream) ChildProcess,
+    // so narrow to the piped shape here (mirrors Node's own stdio-tuple overload).
+    const child = spawnHardened(opts.binPath ?? 'claude', args, {
       cwd: opts.cwd,
       env: opts.env,
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -153,7 +158,7 @@ export async function spawnHeadlessClaude(opts: SpawnHeadlessOptions): Promise<S
       // group (backgrounded grandchildren + MCP subprocesses), not just the
       // direct child. Windows has no process groups (taskkill handles the tree).
       detached: process.platform !== 'win32',
-    });
+    }) as ChildProcessByStdio<Writable, Readable, Readable>;
     // Register immediately after spawn so the child is reapable by
     // killAllActiveClaudeChildren() for the entire time it can be in flight.
     activeClaudeChildren.add(child);
@@ -214,7 +219,11 @@ export async function spawnHeadlessClaude(opts: SpawnHeadlessOptions): Promise<S
     promptStream.pipe(child.stdin);
     child.stdout.on('data', (d: Buffer) => { opts.onStdout?.(d.toString()); });
     child.stderr.on('data', (d: Buffer) => { opts.onStderr?.(d.toString()); });
-    child.on('error', err => { clearAllTimers(); reject(err); });
+    // Reap on 'error' too: clearAllTimers() unregisters the child, so if 'error'
+    // ever fires while the process is actually alive we would otherwise drop it
+    // from the reap set without killing it (the exact orphan this file guards
+    // against). killProcessTree no-ops on an undefined pid (never-spawned case).
+    child.on('error', err => { clearAllTimers(); killProcessTree(child); reject(err); });
     child.on('close', code => { clearAllTimers(); resolve({ status: code ?? -1, timedOut, stalled }); });
   });
 }

--- a/packages/utils/src/spawn-hardened.ts
+++ b/packages/utils/src/spawn-hardened.ts
@@ -1,0 +1,56 @@
+import { spawn, type ChildProcess, type SpawnOptions } from 'node:child_process';
+
+import which from 'which';
+
+import { isAbsoluteAnyPlatform } from './path-utils.js';
+import { buildWindowsShellLine, shouldUseShell, windowsShellQuote } from './windows-shell.js';
+
+/**
+ * A `command` is treated as an explicit path (used verbatim, never PATH-resolved)
+ * when it is absolute or contains a path separator. A bare name (`claude`, `npm`,
+ * `git`) is resolved on PATH via `which.sync`. This mirrors — and preserves — the
+ * behaviour callers relied on before hardening: an explicit `binPath` is spawned
+ * as-given (so a nonexistent path still surfaces as an async `'error'` event, not a
+ * synchronous `which` throw), while a bare command is looked up.
+ */
+function isPathLike(command: string): boolean {
+  return isAbsoluteAnyPlatform(command) || command.includes('/') || command.includes('\\');
+}
+
+/**
+ * Cross-platform hardened async `spawn`, returning a live {@link ChildProcess} with
+ * streaming stdio intact (unlike the sync, buffered {@link ./safe-exec.ts} path).
+ *
+ * The one thing it does that a bare `child_process.spawn` does not: correctly launch
+ * Windows `.cmd`/`.bat`/`.ps1` wrappers. Since the CVE-2024-27980 fix, `spawn` throws
+ * `EINVAL` on such a wrapper unless `shell: true` — and npm-installed CLIs (`claude`,
+ * `npm`, …) resolve to exactly that on Windows. When shell mode is required we join the
+ * command + args into a SINGLE string with per-arg {@link windowsShellQuote} (Node's
+ * DEP0190 rejects `shell: true` with a separate args array); everywhere else we spawn
+ * `shell: false` with the resolved absolute path, keeping the no-injection guarantee.
+ *
+ * POSIX is a pure passthrough to `child_process.spawn` (`shouldUseShell` is always
+ * false off-Windows), so process-group / `detached` semantics are unchanged there.
+ *
+ * @param command - Bare command name (PATH-resolved) or an explicit path (used as-is).
+ * @param args - Arguments, passed as an array (never string-concatenated on POSIX).
+ * @param options - Standard `SpawnOptions` (cwd, env, stdio, detached, …), passed through.
+ */
+export function spawnHardened(
+  command: string,
+  args: string[],
+  options: SpawnOptions = {},
+): ChildProcess {
+  const resolved = isPathLike(command) ? command : which.sync(command);
+
+  if (!shouldUseShell(resolved)) {
+    return spawn(resolved, args, { ...options, shell: false });
+  }
+
+  // Windows shell path (.cmd/.bat/.ps1). Use the bare command for a PATH lookup (cmd.exe
+  // re-resolves it via PATHEXT); use the quoted resolved path when given an explicit path.
+  const shellCommand = isPathLike(command) ? windowsShellQuote(resolved) : command;
+  const shellLine = buildWindowsShellLine(shellCommand, args);
+  // eslint-disable-next-line sonarjs/os-command -- Windows DEP0190 workaround: command is a PATH-resolved bare name or an explicit path; args are per-arg shell-quoted via windowsShellQuote()
+  return spawn(shellLine, { ...options, shell: true });
+}

--- a/packages/utils/src/windows-shell.ts
+++ b/packages/utils/src/windows-shell.ts
@@ -1,0 +1,101 @@
+/**
+ * Windows shell-invocation helpers, shared by every spawn wrapper in this package
+ * ({@link ./safe-exec.ts} for the sync `spawnSync` path, {@link ./spawn-hardened.ts}
+ * for the async streaming `spawn` path). Extracted so there is exactly ONE Windows
+ * `.cmd`/`.bat`/`.ps1` convention across the toolkit — never two subtly-different
+ * copies.
+ *
+ * Background: since the CVE-2024-27980 fix, Node's `child_process.spawn`/`spawnSync`
+ * throw `EINVAL` when asked to launch a `.cmd`/`.bat` wrapper without `shell: true`.
+ * npm-installed CLIs (`claude`, `npm`, `git` shims, …) resolve to exactly such a
+ * wrapper on Windows, so any spawn that omits this handling crashes on Windows only.
+ */
+
+/**
+ * Determine if shell should be used for command execution on Windows.
+ *
+ * ## Security Context
+ *
+ * This package's primary security model is `shell: false` to prevent command injection.
+ * Windows requires `shell: true` only for shell scripts (.cmd/.bat/.ps1) which require
+ * a shell interpreter by design (not executable binaries).
+ *
+ * ## Node.js on Windows - NO SHELL REQUIRED
+ *
+ * **Previous behavior (REMOVED):** Used shell:true for 'node' command
+ * **Problem discovered:** Node.js DEP0190 deprecation warning - passing args array with
+ * shell:true leads to incorrect command execution. Exit codes are ignored (always returns 0).
+ *
+ * **Testing shows:**
+ * - ✅ `shell: false` + absolute path from `which.sync('node')` → Works correctly
+ * - ❌ `shell: true` + args array → Exit codes ignored, security warning
+ *
+ * **Root Cause of Previous ENOENT Issues:** Likely resolved in newer Node.js versions.
+ * Current testing (Node 20+) shows shell:false works correctly with absolute path.
+ *
+ * ## Why This Is Secure
+ *
+ * 1. **Minimal Shell Usage:** Shell only used for .cmd/.bat/.ps1 files (required)
+ * 2. **Path Validation:** Command paths resolved via `which.sync()` before execution
+ * 3. **Array-Based Arguments:** Arguments passed as array, preventing injection
+ * 4. **Controlled Environment:** Commands from trusted configuration, not user input
+ * 5. **No String Interpolation:** Never concatenate user input into command strings
+ *
+ * ## References
+ *
+ * - Node.js deprecation: https://nodejs.org/api/deprecations.html#DEP0190
+ * - Security tests: `packages/utils/test/safe-exec.test.ts`
+ * - Windows fix: PR #94 (fix/windows-shell-independence-v2)
+ *
+ * @param commandPath - Resolved absolute path to command
+ * @returns true if shell should be used, false otherwise
+ */
+export function shouldUseShell(commandPath: string): boolean {
+  if (process.platform !== 'win32') {
+    return false;
+  }
+
+  // Node.js deprecation warning (DEP0190): Passing args with shell:true leads to incorrect
+  // command execution and security vulnerabilities. Testing shows shell:false works correctly
+  // with absolute path from which.sync('node') on Windows.
+  // Previous ENOENT issues may have been resolved in newer Node.js versions.
+  //
+  // REMOVED: if (command === 'node') return true;
+  // Reason: shell:true causes exit codes to be ignored (always returns 0)
+  // Fix: Use shell:false with absolute path - works correctly
+
+  // Windows shell scripts require shell by design (case-insensitive check)
+  const lowerPath = commandPath.toLowerCase();
+  return lowerPath.endsWith('.cmd') || lowerPath.endsWith('.bat') || lowerPath.endsWith('.ps1');
+}
+
+/**
+ * Quote a single argument for a Windows `cmd.exe` command line.
+ *
+ * Rules:
+ *   - An arg that's empty, or contains whitespace, quotes, or any of `& | < > ^ ( ) % !`,
+ *     gets wrapped in double quotes.
+ *   - Embedded double quotes become `""` (cmd.exe's escape form inside quoted strings).
+ *
+ * This is narrow on purpose: it's only used when we're forced to assemble a shell string
+ * for `.cmd` / `.bat` wrappers on Windows (DEP0190 path). Callers still control what's
+ * in `args`, but this keeps a stray space, glob metachar, or paren from getting
+ * re-interpreted by the shell.
+ */
+export function windowsShellQuote(arg: string): string {
+  if (arg === '' || /["\s&|<>^()%!]/.test(arg)) {
+    return `"${arg.replaceAll('"', '""')}"`;
+  }
+  return arg;
+}
+
+/**
+ * Build the single `cmd.exe` command line used when a Windows shim forces shell mode
+ * (Node's DEP0190 rejects `shell: true` with a separate args array, so command + args
+ * must be one string). `commandToken` is the already-resolved command — a bare PATH
+ * name that `cmd.exe` re-resolves via PATHEXT, or a pre-quoted explicit path — and each
+ * arg is quoted via {@link windowsShellQuote} so shell metacharacters can't re-interpret.
+ */
+export function buildWindowsShellLine(commandToken: string, args: string[]): string {
+  return `${commandToken} ${args.map(windowsShellQuote).join(' ')}`;
+}

--- a/packages/utils/test/integration/spawn-hardened.integration.test.ts
+++ b/packages/utils/test/integration/spawn-hardened.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Integration coverage for {@link spawnHardened} against REAL child processes.
+ *
+ * The load-bearing case is Windows: `npm` resolves to `npm.cmd`, and since the
+ * CVE-2024-27980 fix a bare `child_process.spawn` of a `.cmd` throws `EINVAL`
+ * synchronously. This is the exact failure an adopter hit running `vat skill test`
+ * on Windows (claude → `claude.cmd`). The `npm --version` case below exercises the
+ * shell branch on Windows CI and would fail (throw / non-zero) against the old bare
+ * spawn — so it is a genuine regression guard, not a smoke test.
+ */
+import { describe, expect, it } from 'vitest';
+import which from 'which';
+
+import { spawnHardened } from '../../src/spawn-hardened.js';
+import { shouldUseShell } from '../../src/windows-shell.js';
+
+const onWindows = process.platform === 'win32';
+
+interface RunResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Spawn via the hardened wrapper and collect its output to completion. */
+async function run(command: string, args: string[]): Promise<RunResult> {
+  return await new Promise<RunResult>((resolve, reject) => {
+    const child = spawnHardened(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', reject);
+    child.on('close', code => { resolve({ code, stdout, stderr }); });
+  });
+}
+
+describe('spawnHardened (real processes)', () => {
+  it('runs a real .exe via an explicit path (non-shell branch)', async () => {
+    // process.execPath is an absolute path → used verbatim, spawned shell:false.
+    const result = await run(process.execPath, ['-e', 'process.stdout.write("HARDENED_OK")']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('HARDENED_OK');
+  });
+
+  it('resolves a bare command on PATH and runs it', async () => {
+    // `node` on PATH: resolves to node(.exe on Windows) → non-shell branch everywhere.
+    const result = await run('node', ['-e', 'process.stdout.write("PATH_OK")']);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain('PATH_OK');
+  });
+
+  it('runs an npm-shim command — the Windows .cmd regression guard', async () => {
+    // On Windows `npm` is `npm.cmd`; a bare spawn would throw EINVAL here. spawnHardened
+    // routes it through cmd.exe. On POSIX this simply exercises PATH resolution + run.
+    const result = await run('npm', ['--version']);
+    expect(result.code).toBe(0);
+    expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it.skipIf(!onWindows)('confirms npm really is a .cmd shim on this Windows runner', () => {
+    // Documents WHY the case above is a regression guard: without shell handling the
+    // preceding test would have thrown EINVAL on exactly this resolved path.
+    expect(shouldUseShell(which.sync('npm'))).toBe(true);
+  });
+});

--- a/packages/utils/test/windows-shell.test.ts
+++ b/packages/utils/test/windows-shell.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldUseShell, windowsShellQuote } from '../src/windows-shell.js';
+
+const onWindows = process.platform === 'win32';
+
+describe('windowsShellQuote', () => {
+  it('leaves a plain token untouched', () => {
+    expect(windowsShellQuote('claude')).toBe('claude');
+    expect(windowsShellQuote('--version')).toBe('--version');
+    expect(windowsShellQuote('C:/tools/x.txt')).toBe('C:/tools/x.txt');
+  });
+
+  it('quotes an empty argument (so it survives as a distinct arg)', () => {
+    expect(windowsShellQuote('')).toBe('""');
+  });
+
+  it('quotes whitespace', () => {
+    expect(windowsShellQuote('a b')).toBe('"a b"');
+    expect(windowsShellQuote('C:/Program Files/x')).toBe('"C:/Program Files/x"');
+  });
+
+  it('doubles embedded double-quotes inside the wrap (cmd.exe escape form)', () => {
+    expect(windowsShellQuote('a"b')).toBe('"a""b"');
+  });
+
+  it.each(['&', '|', '<', '>', '^', '(', ')', '%', '!'])(
+    'quotes the cmd.exe metacharacter %s',
+    metachar => {
+      expect(windowsShellQuote(`a${metachar}b`)).toBe(`"a${metachar}b"`);
+    },
+  );
+});
+
+describe('shouldUseShell', () => {
+  it.skipIf(onWindows)('is always false off Windows, even for a .cmd path', () => {
+    // Off Windows the platform fast-path returns false regardless of extension.
+    expect(shouldUseShell('/usr/local/bin/claude')).toBe(false);
+    expect(shouldUseShell('/usr/local/bin/anything.cmd')).toBe(false);
+    expect(shouldUseShell('/usr/local/bin/anything.bat')).toBe(false);
+  });
+
+  it('is false for real executables even on Windows', () => {
+    expect(shouldUseShell('C:/Program Files/nodejs/node.exe')).toBe(false);
+    expect(shouldUseShell('C:/tools/claude')).toBe(false);
+  });
+
+  it.skipIf(!onWindows)('is true for .cmd/.bat/.ps1 shims on Windows (case-insensitive)', () => {
+    expect(shouldUseShell('C:/npm/claude.cmd')).toBe(true);
+    expect(shouldUseShell('C:/npm/CLAUDE.CMD')).toBe(true);
+    expect(shouldUseShell('C:/tools/thing.bat')).toBe(true);
+    expect(shouldUseShell('C:/tools/thing.ps1')).toBe(true);
+  });
+});

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.41-rc.1",
+  "version": "0.1.41-rc.2",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Problem

An adopter running `vat skill test run` on **Windows** hit a hard crash:

```
Error: spawn EINVAL
```

Root cause: on Windows `claude` resolves to an npm `claude.cmd` shim, and since the Node **CVE-2024-27980** fix, a bare `child_process.spawn` of a `.cmd`/`.bat` throws `EINVAL` synchronously unless routed through the shell. `spawnHeadlessClaude` did a bare `spawn`, so the harness died the instant it tried to launch the headless session. Reproduced across cmd.exe, PowerShell, and Git Bash; blocked every eval suite on Windows. CI never caught it because the tests only ever spawned a fake node-script child, never a real `.cmd`.

## Fix (no new dependency)

- **New `spawnHardened`** in `@vibe-agent-toolkit/utils` — the async, streaming-stdio counterpart to the existing sync `safeExecSync`. It reuses the Windows handling `safeExecSync` already had (`.cmd`/`.bat`/`.ps1` → shell with per-arg quoting, no injection); POSIX is a pure passthrough to `child_process.spawn`, so process-group/`detached` semantics are unchanged.
- **One Windows-shell convention, zero duplication** — `shouldUseShell`, `windowsShellQuote`, and a new `buildWindowsShellLine` are extracted into `windows-shell.ts`; `safe-exec` now imports them instead of holding private copies.
- `spawnHeadlessClaude` and the internal compat-empirical harness (`claude-cli.ts`, same latent defect) both spawn through `spawnHardened`.

## Boy-scout fixes (in `spawn-claude.ts`)

- The child `'error'` handler unregistered the child from the orphan-reap set **without killing it** — a narrow orphan/token-leak against the file's own contract. It now kills the process tree first (no-ops when the child never spawned).
- Corrected the stale `"experimenter"` → `"executor"` doc comment (leftover from the #145 rename).

## Tests / regression guard

- `windows-shell.test.ts` — unit tests for shell-detection + quoting.
- `spawn-hardened.integration.test.ts` — spawns **real** `node` and `npm`. Since `npm` is `npm.cmd` on Windows, this exercises the exact `.cmd`→shell path that used to throw `EINVAL`, so **Windows CI now fails if this regresses**.

## Validation

Full `bun run validate` green locally (build, typecheck, ESLint, dependency check, duplication, unit, integration, and the 137s end-to-end system suite). No new runtime dependency. No public API signature changes — `spawnHardened`/`windows-shell` helpers are purely additive exports.

Version bumped to **v0.1.41-rc.2** (RC content stays under `[Unreleased]`; not tagged). Publishing the RC is a separate maintainer step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)