### PR TITLE
fix(eslint): remove the import binding the fixer orphaned; detect require()/dynamic namespaces — release 0.1.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.42] - 2026-08-08
+
 ### Breaking
 
 - **`@vibe-agent-toolkit/utils/fs` no longer re-exports the pure path-string helpers.** Seven
@@ -253,11 +255,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **15 advisories cleared from the dependency tree** by advancing the patched pins in the root
-  `overrides` block: `undici` 7.28.0 → 7.29.0 (5 advisories), `ip-address` 10.1.1 → 10.3.1 (3),
-  `hono` 4.12.27 → 4.12.34, `fast-uri` 3.1.4 → 3.1.5, `js-yaml` 4.3.0 → 4.3.1, and `postcss`
-  8.5.18 → 8.5.23. All are within-major bumps of transitive packages; no declared dependency
-  changed and no consumer-facing API is affected.
+- **16 advisories cleared from the dependency tree** via the root `overrides` block: `undici`
+  7.28.0 → 7.29.0 (5 advisories), `ip-address` 10.1.1 → 10.3.1 (3), `hono` 4.12.27 → 4.12.34,
+  `fast-uri` 3.1.4 → 3.1.5, `js-yaml` 4.3.0 → 4.3.1, and `postcss` 8.5.18 → 8.5.23, plus a new
+  `nanoid` 3.3.16 → 3.3.17 pin closing GHSA-2v37-7h3g-55p8 (CVSS 8.2). `nanoid` reaches the tree
+  only through `postcss`, whose `^3.3.16` range the patched version satisfies, so no other pin
+  moved. All are within-major bumps of transitive packages; no declared dependency changed and no
+  consumer-facing API is affected.
 
   One advisory is **accepted rather than fixed** and recorded in `osv-scanner.toml` with its
   reasoning: `brace-expansion` (GHSA-rgw5-rvv9-x895) resolves to 1.x, 2.x, and 5.x simultaneously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,15 +298,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cache of copies). Turborepo is common enough for this to matter: every package in this repo has a
   `.turbo/`.
 
-- **`buildWindowsShellLine('')` accepted an empty command token and promoted the caller's first
-  argument into the command position.** `isSingleShellToken` guards against a `commandToken` that
-  cmd.exe could split or partly re-execute, but `''` tripped neither of its branches — it does not
-  start with a quote, and the metacharacter regex cannot match a string with no characters — so
-  `buildWindowsShellLine('', ['calc', 'b'])` returned `" calc b"`, a line whose command is `calc`.
-  Not reachable from either of the current call sites (both resolve the command through
-  `which.sync` first, which throws on `''`), but that is a property of today's callers rather than
-  of the function, and this guard's whole purpose is to hold independently of them.
-
 - **`windowsShellQuote` produced command lines that `CommandLineToArgvW` mis-parses, corrupting
   arguments and silently merging them with the argument that follows.** The function knew none of
   Windows' backslash-escaping rules: a backslash run preceding a quote — or preceding the closing
@@ -327,29 +318,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chosen because it is understood identically by every known implementation, whereas `""` is absent
   from `CommandLineToArgvW`'s documented rules and CRT variants disagree about it. The residual cost
   is bounded and stated in the code: cmd's quote tracking desyncs only for an argument containing
-  both a quote *and* a shell metacharacter. Found by an adversarial review of the first, incomplete
-  attempt at this fix.
+  both a quote *and* a shell metacharacter.
 
-- **`buildWindowsShellLine`'s new command-token check failed open.** It accepted any string starting
-  and ending with a quote, so a whole crafted command line (`"a b" && calc "x"`) passed validation
-  while reading, in its own JSDoc, as a general assertion. It now requires a single shell token.
+  Two safety claims in the same module were also overstated and are now documented honestly rather
+  than changed. `%` and `!` trigger quoting but are **not neutralized** by it — `cmd.exe` still
+  expands `%VAR%` inside double quotes, which also corrupts a literal `%` in a filename (legal on
+  Windows). And `shouldUseShell`'s JSDoc asserted "arguments passed as array, preventing injection"
+  and "never concatenate user input into command strings" while the Windows shell branch does
+  exactly that concatenation. Both now name `shell: false` as the escape hatch.
 
-- **`shouldUseShell`'s documentation claimed safety properties this module does not have** —
-  "Arguments passed as array, preventing injection" and "Never concatenate user input into command
-  strings" — while the Windows shell branch does exactly that concatenation. Replaced with an honest
-  two-mode description and a named escape hatch.
+- **`buildWindowsShellLine` silently produced a broken command line when handed a command path it
+  could not safely place in the command position — it now throws instead.** Two shapes reached it:
+  an unquoted path containing spaces, which `cmd.exe` splits at the first space; and `''`, which
+  promoted the caller's *first argument* into the command position, so
+  `buildWindowsShellLine('', ['calc', 'b'])` returned `" calc b"` — a line whose command is `calc`.
+  It now requires a single shell token and throws with a message naming the offending token.
+  Separately, `safeExecSync`/`safeExecResult` now quote a path-like command the way `spawnHardened`
+  already did; the sibling paths previously disagreed and only one was correct.
 
-- **`buildWindowsShellLine` silently produced a broken command line when handed an unquoted command
-  path containing spaces**, because `cmd.exe` splits it at the first space. It now throws with a
-  message naming the offending token, and `safeExecSync`/`safeExecResult` now quote a path-like
-  command the same way `spawnHardened` already did — previously the two sibling paths disagreed, and
-  only one was correct.
-
-- **`windowsShellQuote`'s character class implied more safety than it delivered.** `%` and `!` were
-  in the set that triggers quoting, but wrapping in double quotes does not neutralize them —
-  `cmd.exe` still expands `%VAR%` inside quotes, which also corrupts literal `%` in filenames (legal
-  on Windows). Documented explicitly as *quoted, not neutralized*, with the `shell: false` escape
-  hatch named.
+  **What changes for you:** a call that used to return a subtly wrong command line now raises. If
+  you pass a command path through these helpers, resolve it first (both of VAT's own call sites go
+  through `which.sync`, which is why neither could reach the empty-token case).
 
 - **`@vibe-agent-toolkit/utils/package.json` was not exported**, so
   `require('@vibe-agent-toolkit/utils/package.json')` threw `ERR_PACKAGE_PATH_NOT_EXPORTED`. Version
@@ -361,6 +350,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subpath. A `../../docs/` link that resolved to nothing on npm is now absolute.
 
 - **`NON_PORTABLE_ASSET_REFERENCE` no longer advises an impossible fix for `CLAUDE_PROJECT_DIR`.** The family emitted one shared remediation — *"reference bundled files by a path relative to the skill directory"* — for every variant. That is right for `CLAUDE_PLUGIN_ROOT` and absolute script paths, and **wrong** for `CLAUDE_PROJECT_DIR`, which denotes the *user's repository* rather than a bundled asset: no skill-relative path can express it, and substituting one silently re-anchors user artifacts onto the plugin install directory. An adopter reported the rule advising them to revert a fix for exactly that bug. The `claude-project-dir` variant now carries its own remediation (take the location as an explicit parameter with `$CLAUDE_PROJECT_DIR` as fallback; make declared `targets` reflect the Claude Code coupling), and the shared headline no longer asserts the skill-relative advice.
+
 - **`NON_PORTABLE_ASSET_REFERENCE` over-captured a closing brace in nested shell expansion.** The variant patterns used `\$\{?NAME\}?`, whose optional trailing `\}?` consumed the closing brace of an **enclosing** expansion — `"${VAR:-$CLAUDE_PROJECT_DIR}"` was reported as `` "$CLAUDE_PROJECT_DIR}" ``. The malformed token reads exactly like the typo `$FOO}`, sending reviewers to source that was in fact valid shell. Matching is now brace-balanced via alternation. *(Adopter-reported; independently reproduced.)*
 
 ## [0.1.41] - 2026-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--fix` on the ESLint pack no longer leaves code that does not compile.** `no-path-join` and
+  `no-path-resolve` (and, latently, every other rule that rewrites a call *and* edits imports)
+  stripped the named specifier from the `node:path` import, inserted `safePath`, and left the
+  remaining call sites in the file as bare `join(...)` / `resolve(...)` — referencing an identifier
+  that was no longer imported. An adopter measured the blast radius on a real sweep of ~4,900 sites:
+  **146 files left with a dangling reference** (140 on `join`, 16 on `resolve`), worst single file
+  75 unrewritten call sites.
+
+  **It was silent and self-limiting**, which is what made it dangerous rather than merely wrong.
+  ESLint merges the fixes one `fix()` yields into a single range spanning `min..max` and applies only
+  non-overlapping ranges per pass, so a fix touching both the import and its own call site spanned
+  everything in between; N call sites produced N nested ranges and ESLint kept exactly one. Detection
+  then keyed on having seen the import specifier — the thing that had just been removed — so the rule
+  went quiet. `--fix` reached a stable fixpoint over broken source and exited clean, with no lint
+  output suggesting anything was wrong. You found out at `tsc`, after the sweep.
+
+  Two changes: the import edits are emitted once per file and every other call site gets a fix local
+  to its own callee, so one pass fixes the file; and a bare call to a banned path function is now
+  reported even with no import present, provided the name is unbound in scope — which keeps the worst
+  case at "run `--fix` again" instead of "ships broken code". One caveat survives by design: an
+  `eslint-disable` on the *first* reported call site in a file discards that file's import edits with
+  it, so prefer `exemptFiles` to opt a whole file out.
+
+  Guarded by two tests that both fail on the old code: multi-call-site RuleTester fixtures pinning
+  the single-pass output, and a suite that runs `--fix` to its fixpoint for **every** fixable rule in
+  the pack and asserts `no-undef` finds nothing in the result. A single-call-site fixture — which is
+  what every fixture was — structurally cannot reproduce this.
+
+- **`no-os-tmpdir --fix` produced `os.normalizedTmpdir()`, a method that does not exist.** The
+  member-expression branch of the shared rule factory rewrote only the property, so `os.tmpdir()`
+  became a call on the `node:os` namespace for a free function that lives in this package — imported
+  correctly at the top of the file and then reached for through the wrong object. Every fixed call
+  site throws `TypeError` at runtime. The whole callee is now replaced.
+
+  Found by probing rather than by review, and worth recording why the adopter's audit could not have
+  caught it: their check was for a dangling *reference*, and this is a dangling *member*. `no-undef`
+  sees a bound `os` and a property access and has nothing to say, and the rule itself goes quiet
+  because there is no `tmpdir` left to report. Green lint over code that cannot run. Only `tsc` sees
+  it. `no-os-tmpdir` is the only rule in the pack with `checkMemberExpression`, so it is the only one
+  that was affected.
+
+- **`prefer-startswith-over-regex` was narrower than the SonarCloud rule it exists to shift left.**
+  Two shapes went unreported: a regex held in a `const` and used via `RE.test(x)` (only *inline*
+  literals were examined), and any escape other than `\/` — so `/^\*prefix/`, an unambiguous literal
+  asterisk, was skipped. Both now fire; an escaped non-special character is treated as the literal
+  character it protects, and a single-assignment `const` initialised with a regex literal is resolved
+  to that literal. Escapes that mean something else (`\d`, `\b`, `\x41`, `\p{…}`, control and
+  whitespace escapes) still bail, as do unescaped metacharacters.
+
+  Newly caught in code that previously linted green: `/\.txt$/.test(s)` is `s.endsWith('.txt')` — the
+  `.` is escaped, so it was never the metacharacter the old rule's own fixture claimed it was.
+
+  **Worth stating as a general finding, not a per-rule one:** an adopter running this rule at `error`
+  reports zero findings *by construction* — lint cannot go green while a violation exists. A 0-vs-0
+  tie against another implementation is not agreement, it is two rules both failing to fire. For any
+  rule an adopter reports zero findings for, that rule is **unmeasured**, not agreed.
+
+- **The Windows shell branch is now exercised on every platform.** `shouldUseShell`'s only
+  `true`-returning case was gated behind `skipIf(!onWindows)`, so the branch every Windows spawn
+  depends on never executed off Windows — and an adopter's green Windows CI lane did not reach it
+  either. New tests force `process.platform` and assert both the extension check and the full
+  `shouldUseShell` → `resolveShellCommandToken` → `buildWindowsShellLine` composition, round-tripped
+  through the `CommandLineToArgvW` reference parser. No production behaviour change; verified-green
+  and never-run are no longer indistinguishable here.
+
 - **`isGitIgnored()` spawned a git subprocess per ancestor directory when the path was not in a git
   repository at all — `vat resources validate` on a 3,437-document tree outside any repository went
   from 196 s to 20.6 s, with a byte-identical report.** `git check-ignore` exits 128 for two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ValidateLinkOptions` in `@vibe-agent-toolkit/resources` gains a matching **required** `fsCache`
   field, so anything constructing that options object must supply the run's cache.
 
+- **The vestigial `zod` peerDependency is gone from `@vibe-agent-toolkit/utils`.** It was a
+  *required* peer, so anyone importing only `./path` was still told by their package manager to
+  install `zod`. The package imports `zod` nowhere: all six occurrences of `from 'zod'` in the
+  shipped `dist` are inside JSDoc `@example` blocks, and the version-introspection helpers
+  deliberately duck-type `_def.typeName` rather than importing the library — which is exactly what
+  makes them work across v3 and v4. The declared range (`^3.25.0 || ^4.0.0`) would additionally have
+  rejected a future major that the duck typing handles by design. `zod` remains a devDependency, so
+  the test that exercises the introspection against a real `zod` is unaffected.
+
+  **Listed as breaking, not merely removed**, because of who it breaks: not anyone importing from
+  `utils`, but a consumer that was relying on this package to pull `zod` into *their* tree and now
+  finds it absent. If you import `zod` yourself, declare it yourself. (Reported twice by an adopter
+  who went looking for this under Breaking and did not find it — it was filed under Added, beside
+  the subpath work that prompted it.)
+
 ### Added
 
 - **A `@vibe-agent-toolkit/utils/eslint` subpath — 21 ESLint rules that enforce the safety helpers
@@ -98,6 +113,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Requires ESLint 9+ (flat config) and Node >= 22. Full rule table
   in [the subpath's README](https://github.com/jdutton/vibe-agent-toolkit/blob/main/packages/utils/eslint/README.md).
 
+  `--fix` is safe to run across a whole migration: every rule that rewrites a call and edits
+  imports fixes all of a file's call sites without leaving a reference to something it just
+  un-imported, never deletes a `type`-only, aliased or re-exported specifier, and leaves a
+  suppressed call site working. Enforced by a suite that runs `--fix` to its fixpoint per rule and
+  checks the result with `no-undef`.
+
+  It also **finishes the job**, which matters in a repo gating at `--max-warnings=0`. Rewriting the
+  last `path.*` call in a file leaves `import path from 'node:path'` bound to nothing — not a
+  dangling reference, so a `no-undef` check cannot see it, and an adopter measured **536 such errors
+  surviving a converged `--fix` across 232 files**. The rules now report that orphaned binding
+  themselves, as a separate finding on the import line with its own fix, so it is visible and
+  suppressible rather than a rewrite quietly deleting a declaration. Deliberately narrow: a closed
+  list of Node builtins (`node:path`, `node:os`, `node:fs`, `node:fs/promises`,
+  `node:child_process`, and their bare spellings), only in a file where the safe symbol is already
+  bound, only whole declarations with no references left. Bare `import 'node:path'` side-effect
+  imports, `type` specifiers and partially-used declarations are left alone. This is not a general
+  unused-import rule and will not become one — the ecosystem's rules abstain here for good reason,
+  and in any case cannot help: `@typescript-eslint/no-unused-vars` declares `meta.fixable: 'code'`
+  yet emits only a *suggestion* for an unused import, which `--fix` never applies.
+
+  The member-call rules (`no-os-tmpdir` and friends) check the receiver rather than the method name,
+  and now recognise a namespace bound by `const os = require('node:os')` or
+  `const os = await import('node:os')` as well as by a static `import * as os`. An unrelated object
+  with a same-named method is still not a finding.
+
   **There is no separate plugin package to install**, and `eslint` is declared as an *optional* peer
   dependency, so nothing changes for consumers who take `utils` for `safePath.join()` alone: they
   get no unmet-peer warning and no new dependency. An ESLint plugin is data rather than code that
@@ -149,15 +189,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Node floor before this release, so an adopter installing on an older Node got no install-time
   signal from any of the other 20 — they simply failed later, at a syntax or API error, with nothing
   pointing at the Node version.
-
-- **The vestigial `zod` peerDependency is gone from `@vibe-agent-toolkit/utils`.** It was a
-  *required* peer, so anyone importing only `./path` was still told by their package manager to
-  install `zod`. The package imports `zod` nowhere: all six occurrences of `from 'zod'` in the
-  shipped `dist` are inside JSDoc `@example` blocks, and the version-introspection helpers
-  deliberately duck-type `_def.typeName` rather than importing the library — which is exactly what
-  makes them work across v3 and v4. The declared range (`^3.25.0 || ^4.0.0`) would additionally have
-  rejected a future major that the duck typing handles by design. `zod` remains a devDependency, so
-  the test that exercises the introspection against a real `zod` is unaffected.
 
 - **A `./crawl` subpath**, promoting `crawlDirectory`/`crawlDirectorySync` and the crawl-exclusion
   glob constants. It is deliberately kept out of `./glob`: it is the only subpath that
@@ -237,71 +268,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `minimatch` and `picomatch` entries.
 
 ### Fixed
-
-- **`--fix` on the ESLint pack no longer leaves code that does not compile.** `no-path-join` and
-  `no-path-resolve` (and, latently, every other rule that rewrites a call *and* edits imports)
-  stripped the named specifier from the `node:path` import, inserted `safePath`, and left the
-  remaining call sites in the file as bare `join(...)` / `resolve(...)` — referencing an identifier
-  that was no longer imported. An adopter measured the blast radius on a real sweep of ~4,900 sites:
-  **146 files left with a dangling reference** (140 on `join`, 16 on `resolve`), worst single file
-  75 unrewritten call sites.
-
-  **It was silent and self-limiting**, which is what made it dangerous rather than merely wrong.
-  ESLint merges the fixes one `fix()` yields into a single range spanning `min..max` and applies only
-  non-overlapping ranges per pass, so a fix touching both the import and its own call site spanned
-  everything in between; N call sites produced N nested ranges and ESLint kept exactly one. Detection
-  then keyed on having seen the import specifier — the thing that had just been removed — so the rule
-  went quiet. `--fix` reached a stable fixpoint over broken source and exited clean, with no lint
-  output suggesting anything was wrong. You found out at `tsc`, after the sweep.
-
-  Two changes: the import edits are emitted once per file and every other call site gets a fix local
-  to its own callee, so one pass fixes the file; and a bare call to a banned path function is now
-  reported even with no import present, provided the name is unbound in scope — which keeps the worst
-  case at "run `--fix` again" instead of "ships broken code". One caveat survives by design: an
-  `eslint-disable` on the *first* reported call site in a file discards that file's import edits with
-  it, so prefer `exemptFiles` to opt a whole file out.
-
-  Guarded by two tests that both fail on the old code: multi-call-site RuleTester fixtures pinning
-  the single-pass output, and a suite that runs `--fix` to its fixpoint for **every** fixable rule in
-  the pack and asserts `no-undef` finds nothing in the result. A single-call-site fixture — which is
-  what every fixture was — structurally cannot reproduce this.
-
-- **`no-os-tmpdir --fix` produced `os.normalizedTmpdir()`, a method that does not exist.** The
-  member-expression branch of the shared rule factory rewrote only the property, so `os.tmpdir()`
-  became a call on the `node:os` namespace for a free function that lives in this package — imported
-  correctly at the top of the file and then reached for through the wrong object. Every fixed call
-  site throws `TypeError` at runtime. The whole callee is now replaced.
-
-  Found by probing rather than by review, and worth recording why the adopter's audit could not have
-  caught it: their check was for a dangling *reference*, and this is a dangling *member*. `no-undef`
-  sees a bound `os` and a property access and has nothing to say, and the rule itself goes quiet
-  because there is no `tmpdir` left to report. Green lint over code that cannot run. Only `tsc` sees
-  it. `no-os-tmpdir` is the only rule in the pack with `checkMemberExpression`, so it is the only one
-  that was affected.
-
-- **`prefer-startswith-over-regex` was narrower than the SonarCloud rule it exists to shift left.**
-  Two shapes went unreported: a regex held in a `const` and used via `RE.test(x)` (only *inline*
-  literals were examined), and any escape other than `\/` — so `/^\*prefix/`, an unambiguous literal
-  asterisk, was skipped. Both now fire; an escaped non-special character is treated as the literal
-  character it protects, and a single-assignment `const` initialised with a regex literal is resolved
-  to that literal. Escapes that mean something else (`\d`, `\b`, `\x41`, `\p{…}`, control and
-  whitespace escapes) still bail, as do unescaped metacharacters.
-
-  Newly caught in code that previously linted green: `/\.txt$/.test(s)` is `s.endsWith('.txt')` — the
-  `.` is escaped, so it was never the metacharacter the old rule's own fixture claimed it was.
-
-  **Worth stating as a general finding, not a per-rule one:** an adopter running this rule at `error`
-  reports zero findings *by construction* — lint cannot go green while a violation exists. A 0-vs-0
-  tie against another implementation is not agreement, it is two rules both failing to fire. For any
-  rule an adopter reports zero findings for, that rule is **unmeasured**, not agreed.
-
-- **The Windows shell branch is now exercised on every platform.** `shouldUseShell`'s only
-  `true`-returning case was gated behind `skipIf(!onWindows)`, so the branch every Windows spawn
-  depends on never executed off Windows — and an adopter's green Windows CI lane did not reach it
-  either. New tests force `process.platform` and assert both the extension check and the full
-  `shouldUseShell` → `resolveShellCommandToken` → `buildWindowsShellLine` composition, round-tripped
-  through the `CommandLineToArgvW` reference parser. No production behaviour change; verified-green
-  and never-run are no longer indistinguishable here.
 
 - **`isGitIgnored()` spawned a git subprocess per ancestor directory when the path was not in a git
   repository at all — `vat resources validate` on a 3,437-document tree outside any repository went

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "picomatch": "^4.0.3",
         "zod": "^3.23.8",
@@ -88,7 +88,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
@@ -132,7 +132,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -170,7 +170,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
         "@vibe-agent-toolkit/claude-marketplace": "workspace:*",
@@ -192,7 +192,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -203,7 +203,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -219,7 +219,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -243,7 +243,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -260,7 +260,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -281,7 +281,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -313,7 +313,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -332,7 +332,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -350,7 +350,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -368,7 +368,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -389,7 +389,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -402,7 +402,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -416,7 +416,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -442,7 +442,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -458,7 +458,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -484,7 +484,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.42-rc.2",
+      "version": "0.1.42",
       "bin": {
         "vat": "./bin/vat",
       },
@@ -507,6 +507,7 @@
     "ip-address": "10.3.1",
     "js-yaml": "4.3.1",
     "lodash": "4.18.1",
+    "nanoid": "3.3.17",
     "path-to-regexp": "8.4.0",
     "postcss": "8.5.23",
     "qs": "6.15.2",
@@ -1873,7 +1874,7 @@
 
     "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
-    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/agent-config": {
       "name": "@vibe-agent-toolkit/agent-config",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -57,7 +57,7 @@
     },
     "packages/agent-runtime": {
       "name": "@vibe-agent-toolkit/agent-runtime",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -72,7 +72,7 @@
     },
     "packages/agent-schema": {
       "name": "@vibe-agent-toolkit/agent-schema",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "picomatch": "^4.0.3",
         "zod": "^3.23.8",
@@ -88,7 +88,7 @@
     },
     "packages/agent-skills": {
       "name": "@vibe-agent-toolkit/agent-skills",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-config": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -114,7 +114,7 @@
     },
     "packages/claude-marketplace": {
       "name": "@vibe-agent-toolkit/claude-marketplace",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
@@ -132,7 +132,7 @@
     },
     "packages/cli": {
       "name": "@vibe-agent-toolkit/cli",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "bin": {
         "vat": "./dist/bin/vat.js",
       },
@@ -170,7 +170,7 @@
     },
     "packages/dev-tools": {
       "name": "@vibe-agent-toolkit/dev-tools",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-skills": "workspace:*",
         "@vibe-agent-toolkit/claude-marketplace": "workspace:*",
@@ -192,7 +192,7 @@
     },
     "packages/discovery": {
       "name": "@vibe-agent-toolkit/discovery",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/utils": "workspace:*",
         "picomatch": "^4.0.2",
@@ -203,7 +203,7 @@
     },
     "packages/gateway-mcp": {
       "name": "@vibe-agent-toolkit/gateway-mcp",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -219,7 +219,7 @@
     },
     "packages/rag": {
       "name": "@vibe-agent-toolkit/rag",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/resources": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -243,7 +243,7 @@
     },
     "packages/rag-lancedb": {
       "name": "@vibe-agent-toolkit/rag-lancedb",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@lancedb/lancedb": "^0.23.0",
         "@vibe-agent-toolkit/rag": "workspace:*",
@@ -260,7 +260,7 @@
     },
     "packages/resource-compiler": {
       "name": "@vibe-agent-toolkit/resource-compiler",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "bin": {
         "vat-compile-resources": "./bin/vat-compile-resources",
       },
@@ -281,7 +281,7 @@
     },
     "packages/resources": {
       "name": "@vibe-agent-toolkit/resources",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/utils": "workspace:*",
@@ -313,7 +313,7 @@
     },
     "packages/runtime-claude-agent-sdk": {
       "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.5",
         "@anthropic-ai/sdk": "^0.37.0",
@@ -332,7 +332,7 @@
     },
     "packages/runtime-langchain": {
       "name": "@vibe-agent-toolkit/runtime-langchain",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@langchain/core": "^0.3.29",
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
@@ -350,7 +350,7 @@
     },
     "packages/runtime-openai": {
       "name": "@vibe-agent-toolkit/runtime-openai",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "openai": "^4.77.3",
@@ -368,7 +368,7 @@
     },
     "packages/runtime-vercel-ai-sdk": {
       "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.4",
         "@ai-sdk/provider-utils": "^4.0.8",
@@ -389,7 +389,7 @@
     },
     "packages/test-agents": {
       "name": "@vibe-agent-toolkit/test-agents",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "zod": "^3.24.1",
@@ -402,7 +402,7 @@
     },
     "packages/transports": {
       "name": "@vibe-agent-toolkit/transports",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "ws": "^8.18.0",
@@ -416,7 +416,7 @@
     },
     "packages/utils": {
       "name": "@vibe-agent-toolkit/utils",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "handlebars": "^4.7.8",
         "ignore": "^7.0.5",
@@ -442,7 +442,7 @@
     },
     "packages/vat-development-agents": {
       "name": "@vibe-agent-toolkit/vat-development-agents",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
         "@vibe-agent-toolkit/cli": "workspace:*",
@@ -458,7 +458,7 @@
     },
     "packages/vat-example-cat-agents": {
       "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "dependencies": {
         "@vibe-agent-toolkit/agent-runtime": "workspace:*",
         "@vibe-agent-toolkit/agent-schema": "workspace:*",
@@ -484,7 +484,7 @@
     },
     "packages/vibe-agent-toolkit": {
       "name": "vibe-agent-toolkit",
-      "version": "0.1.42-rc.1",
+      "version": "0.1.42-rc.2",
       "bin": {
         "vat": "./bin/vat",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "type": "module",
   "private": true,
   "description": "Toolkit for testing and packaging portable AI agents across various LLMs, frameworks, and deployment targets",
@@ -39,6 +39,7 @@
     "express-rate-limit": "8.2.2",
     "form-data": "4.0.6",
     "body-parser": "2.3.0",
+    "nanoid": "3.3.17",
     "postcss": "8.5.23",
     "smol-toml": "1.6.1",
     "yaml": "2.8.3",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-config",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Agent manifest loading and validation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-runtime",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "type": "module",
   "description": "Runtime framework for building and executing portable AI agents",
   "keywords": [

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-schema/package.json
+++ b/packages/agent-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-schema",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "JSON Schema definitions and TypeScript types for VAT agent manifest format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/agent-skills/package.json
+++ b/packages/agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/agent-skills",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Build, validate, and package agent skills in the Agent Skills format",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/claude-marketplace/package.json
+++ b/packages/claude-marketplace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/claude-marketplace",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Claude plugin marketplace tools: compatibility analysis, provenance tracking, enterprise config",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/cli",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Command-line interface for vibe-agent-toolkit",
   "type": "module",
   "bin": {

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/dev-tools",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "private": true,
   "type": "module",
   "description": "Development tools for the monorepo",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/discovery/package.json
+++ b/packages/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/discovery",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Intelligent file discovery for VAT agents and Agent Skills",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/gateway-mcp/package.json
+++ b/packages/gateway-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/gateway-mcp",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "MCP Gateway for exposing VAT agents through Model Context Protocol",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag-lancedb/package.json
+++ b/packages/rag-lancedb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag-lancedb",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "type": "module",
   "description": "LanceDB implementation of RAG interfaces for vibe-agent-toolkit",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/rag",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "type": "module",
   "description": "Abstract RAG (Retrieval-Augmented Generation) interfaces and shared implementations",
   "keywords": [

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resource-compiler/package.json
+++ b/packages/resource-compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resource-compiler",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Compile markdown resources to TypeScript with full IDE support",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/resources/package.json
+++ b/packages/resources/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/resources",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Markdown resource parsing, validation, and link integrity checking",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-claude-agent-sdk/package.json
+++ b/packages/runtime-claude-agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-claude-agent-sdk",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Claude Agent SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-langchain/package.json
+++ b/packages/runtime-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-langchain",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "LangChain.js runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-openai/package.json
+++ b/packages/runtime-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-openai",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "OpenAI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/runtime-vercel-ai-sdk/package.json
+++ b/packages/runtime-vercel-ai-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/runtime-vercel-ai-sdk",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Vercel AI SDK runtime adapter for VAT agents",
   "type": "module",
   "exports": {

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/test-agents/package.json
+++ b/packages/test-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/test-agents",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "private": true,
   "description": "Simple test agents for validating runtime adapters (internal use only)",
   "type": "module",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/transports",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Transport adapters for VAT conversational agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/utils/eslint/README.md
+++ b/packages/utils/eslint/README.md
@@ -112,6 +112,8 @@ Two ways your target can be wrong, which surface differently: `ERR_MODULE_NOT_FO
 | `no-child-process-execSync` | `child_process.execSync()` | `safeExecSync()` | `/process` | ✓ | `error` |
 | `no-unix-shell-commands` | `tar`, `grep`, `rm`, `echo`, … spawned directly | Node APIs, or a portable script fixture | — | | `error` |
 
+The member-call rules here check the **receiver**, not just the method name, so `env.tmpdir()` on some unrelated object is not a finding — and the namespace they check for can be bound by a static `import * as os`, by `const os = require('node:os')`, or by `const os = await import('node:os')`. The fix replaces the whole callee (`os.tmpdir()` → `normalizedTmpdir()`), which is correct however the binding was made. Matching the method name alone was the earlier behaviour and it produced `os.normalizedTmpdir()` — a method that does not exist, compiles, and throws.
+
 ### URLs and dynamic imports
 
 | Rule | Bans | Use instead | Subpath | Fix | `recommended` |
@@ -182,7 +184,23 @@ Every rule that rewrites a call *and* edits imports fixes **all** of a file's ca
 
 That test exists because the answer used to be no. ESLint merges the fixes one `fix()` yields into a **single range spanning `min..max`**, and applies only non-overlapping ranges per pass — so a fix touching both the import and its own call site spanned everything in between, N call sites produced N nested ranges, and ESLint kept one. The rule then went quiet, because the import specifier its detection keyed on was what had just been removed. `--fix` reached a stable fixpoint over source that no longer compiles and exited clean; you found out at `tsc`. An adopter measured **146 files left with a dangling reference** across one ~4,900-site sweep, worst single file 75 unrewritten calls.
 
-One caveat survives by design: only the **first** report's fix in a file is self-sufficient. Applying a later one on its own — an editor's "fix this problem", or an `eslint-disable` on the first call site — rewrites the call without adding the import. The next full `--fix` re-inserts it, and `exemptFiles` is the supported way to opt a whole file out. The shared edits cannot be hoisted onto their own report instead: removing `join` from the import while a *suppressed* `join(...)` call survives is the same broken output reached a different way.
+`eslint-disable` interacts with this in a way worth knowing about, because it is not obvious and it took an adversarial run to find. ESLint invokes a rule's `fix()` **before** the disable filter discards the problem, so a suppressed report still consumes any once-per-file edit its rule was holding. Where that edit is an import *insert*, the rules either re-emit it from every report or carry a repair leg that recognises the orphaned call and supplies the missing import on the next pass — so a disabled call site costs an extra pass, not a broken file. Where it is an import *removal*, the removal is latched and simply goes away with the discarded report, leaving an unused import for `no-unused-vars` to point at rather than a call with nothing behind it. `exemptFiles` remains the supported way to opt a whole file out.
+
+Two more things a fixer here will not do: delete a `type`-only, aliased, or re-exported specifier (removing a re-exported one produced output that did not parse), and insert an import *between* a leading `eslint-disable-next-line` and the statement it protects, which would silently revoke the suppression.
+
+#### The binding left behind
+
+`path.join(a, b)` becomes `safePath.join(a, b)`, and when that was the file's last `path.*` reference the `import path from 'node:path'` is left bound to nothing. That is not a dangling reference, so the `no-undef` fixpoint check above is blind to it — and the same adopter measured **536 errors surviving a converged `--fix` across 232 files** (289 `no-unused-vars`, 247 `sonarjs/unused-import`), every one of them this. In a repo gating at `--max-warnings=0`, `--fix` output that does not lint clean is not a finished migration.
+
+So the rules now report it themselves, as a separate `deadUnsafeImport` finding on the import line with its own fix. Being its own finding is the point: it shows up in lint output and you can `eslint-disable` it, rather than a call rewrite quietly taking a declaration with it.
+
+Deliberately narrow:
+
+- **A closed list of modules** — `node:path`, `node:os`, `node:fs`, `node:fs/promises`, `node:child_process` and their bare spellings. All Node builtins, all side-effect-free with certainty decided when the rule was written. This is *not* a general unused-import rule and will not become one; for blanket cleanup, `eslint-plugin-unused-imports` already exists and already autofixes.
+- **Only in a file these rules migrated** — the safe symbol must already be bound. A dead import in a file this pack never touched is somebody else's business.
+- **Only whole declarations, only with zero references left** — evaluated against the source as it stands on that pass, so the removal always lands *after* the rewrite that consumed the last reference, never speculatively beside it. A partially-dead declaration (`import path, { sep }` with `sep` still live) is left alone, as are bare `import 'node:path'` side-effect imports and anything carrying a `type` specifier.
+
+This cannot be delegated: `@typescript-eslint/no-unused-vars` declares `meta.fixable: 'code'` but emits only a **suggestion** for an unused import, and `--fix` never applies suggestions; `sonarjs/unused-import` declares no fixer at all. Verified with both enabled alongside these rules in one `verifyAndFix` — the import survived. Those rules abstain for a good reason, since removing an import can change behaviour; a rule that *created* the orphan knows it just consumed the last reference and knows the module, so it can act where a generic rule cannot.
 
 ## Why custom rules
 

--- a/packages/utils/eslint/README.md
+++ b/packages/utils/eslint/README.md
@@ -124,7 +124,7 @@ Two ways your target can be wrong, which surface differently: `ERR_MODULE_NOT_FO
 
 | Rule | Bans | Use instead | Subpath | Fix | `recommended` |
 |---|---|---|---|---|---|
-| `prefer-startswith-over-regex` | `/^foo/.test(s)` | `s.startsWith('foo')` | — | | `error` |
+| `prefer-startswith-over-regex` | `/^foo/.test(s)`, `` /^\*glob/.test(s) ``, `const RE = /^foo/; RE.test(s)` | `s.startsWith('foo')` | — | | `error` |
 | `no-test-scoped-functions` | helper functions declared inside `describe`/`it` | module scope | — | | — |
 | `require-justified-skip` | unannotated `it.skip`/`it.todo`, tautological assertions, empty test bodies | a `SKIP(#123): reason` annotation, or a real assertion | — | | — |
 
@@ -175,6 +175,14 @@ Within `recommended`, `error` is the default; three rules are `warn`:
 Raise all three to `error` once the backlog is clear. That is what this repo does.
 
 The criterion for `warn` is **migration volume**, not how real the finding is — a rule whose findings we doubted would be out of `recommended` entirely, not demoted. Everything at `error` either prevents a bug or moves a static-analysis finding left of a merge.
+
+### Running `--fix` over a large backlog
+
+Every rule that rewrites a call *and* edits imports fixes **all** of a file's call sites in a single pass, and `packages/utils/test/eslint/rules.test.ts` holds each of them to that: it runs `--fix` to its fixpoint and then asks `no-undef` whether the result still binds every identifier.
+
+That test exists because the answer used to be no. ESLint merges the fixes one `fix()` yields into a **single range spanning `min..max`**, and applies only non-overlapping ranges per pass — so a fix touching both the import and its own call site spanned everything in between, N call sites produced N nested ranges, and ESLint kept one. The rule then went quiet, because the import specifier its detection keyed on was what had just been removed. `--fix` reached a stable fixpoint over source that no longer compiles and exited clean; you found out at `tsc`. An adopter measured **146 files left with a dangling reference** across one ~4,900-site sweep, worst single file 75 unrewritten calls.
+
+One caveat survives by design: only the **first** report's fix in a file is self-sufficient. Applying a later one on its own — an editor's "fix this problem", or an `eslint-disable` on the first call site — rewrites the call without adding the import. The next full `--fix` re-inserts it, and `exemptFiles` is the supported way to opt a whole file out. The shared edits cannot be hoisted onto their own report instead: removing `join` from the import while a *suppressed* `join(...)` call survives is the same broken output reached a different way.
 
 ## Why custom rules
 

--- a/packages/utils/eslint/rules/dead-import.cjs
+++ b/packages/utils/eslint/rules/dead-import.cjs
@@ -1,0 +1,201 @@
+/**
+ * Removing the import binding THIS PACK's own fixers just orphaned.
+ *
+ * ## The gap this closes
+ *
+ * `path.join(a, b)` rewrites to `safePath.join(a, b)`, and when that was the
+ * file's last `path.*` reference the `import path from 'node:path'` is left
+ * bound to nothing. An adopter measured the consequence over ~5,100 sites:
+ * `--fix` converged, and **536 errors survived across 232 files** — 289
+ * `no-unused-vars` plus 247 `sonarjs/unused-import`, every one of them this same
+ * class. Their repo gates at `--max-warnings=0`, so the fixed output did not
+ * lint clean and the migration was not actually complete.
+ *
+ * The `no-undef` fixpoint check the rest of this pack leans on is structurally
+ * blind to it: a dead import leaves nothing DANGLING, it leaves something SPARE.
+ *
+ * ## Why this cannot be delegated to the ecosystem
+ *
+ * `@typescript-eslint/no-unused-vars` declares `meta.fixable: 'code'` — and for
+ * an unused import it emits only a SUGGESTION, which `--fix` never applies.
+ * `eslint-plugin-sonarjs/unused-import` declares no fixer at all. Measured on
+ * `@typescript-eslint/eslint-plugin@8.65.0`, with both rules enabled alongside
+ * ours in a single `verifyAndFix`: the import survived. `meta.fixable` is a
+ * capability flag about the RULE, not a promise about any given report.
+ *
+ * Those rules abstain for a real reason — removing an import can change
+ * behaviour (`import './polyfill'`, modules with top-level effects), and a
+ * generic rule cannot prove otherwise. A rule that CREATED the orphan is in a
+ * strictly better position: it knows it just consumed the binding's last
+ * reference, and it knows the module, because its own config named it.
+ *
+ * ## Why the module list is closed, and hardcoded
+ *
+ * Every entry is a Node builtin that this pack already targets, and every one is
+ * side-effect-free with certainty decided here, at authoring time. The only
+ * general signal available instead would be package.json `sideEffects` — author
+ * declared, unverified, absent by default (and absence means "assume side
+ * effects"), sometimes a glob array rather than a boolean, requiring filesystem
+ * resolution per import inside a linter expected to be pure and fast, and it
+ * **does not apply to `node:` builtins at all**, which is the only case here.
+ * So: no `sideEffects` lookup, no I/O, no new dependency, and deliberately NOT
+ * a general `unused-import-no-side-effects` rule. For blanket cleanup outside
+ * this list, `eslint-plugin-unused-imports` already exists and already autofixes.
+ *
+ * Bare aliases (`path`, `os`, …) are listed beside their `node:`-prefixed
+ * spellings because the rules themselves treat the two as one module. Detecting
+ * `path.join()` from `import path from 'path'` and then declining to clean up
+ * after it would leave exactly the adopter's blocker in place for whichever
+ * spelling a file happened to use.
+ */
+
+const REMOVABLE_MODULES = new Set([
+  'node:path',
+  'path',
+  'node:os',
+  'os',
+  'node:fs',
+  'fs',
+  'node:fs/promises',
+  'fs/promises',
+  'node:child_process',
+  'child_process',
+]);
+
+const DEAD_UNSAFE_IMPORT = 'deadUnsafeImport';
+const DEAD_UNSAFE_IMPORT_MESSAGE =
+  "'{{local}}' is no longer used — this rule's autofix rewrote the last call that " +
+  "referenced it. Remove the '{{module}}' import.";
+
+/**
+ * Does this declaration bring in anything the type checker alone can see?
+ *
+ * A `type` binding has zero references by construction — scope analysis does not
+ * record type positions as references — so "nothing uses it" is not evidence of
+ * anything. Deleting one silently breaks every `typeof join` and every
+ * annotation that named it, and NEITHER `no-undef` nor `no-unused-vars` can see
+ * the damage, because the reference it broke was a type reference. Round 2 of
+ * this work learned that by shipping the deletion first.
+ */
+function hasTypeOnlyBinding(node) {
+  return (
+    node.importKind === 'type' || node.specifiers.some((spec) => spec.importKind === 'type')
+  );
+}
+
+/**
+ * Is every binding this declaration introduces now unreferenced?
+ *
+ * Whole declarations only. A partially-dead declaration (`import path, { sep }`
+ * with `sep` still live) needs comma surgery, which is where removal bugs live,
+ * and it is not the shape the adopter measured — so it is left alone and stays a
+ * visible `no-unused-vars` finding rather than a risky edit.
+ *
+ * Re-exports need no special guard: `export { path }` and `export default path`
+ * both register as references under espree AND `@typescript-eslint/parser`
+ * (measured, both parsers), so such a declaration is never dead here. Round 2
+ * added an explicit `isReExported` check for the SPECIFIER-removal path, where
+ * the reference count is not consulted at all; this path reads the count, so a
+ * second check would be a guard that can never fire.
+ */
+function isDeadRemovableImport(sourceCode, node) {
+  if (!REMOVABLE_MODULES.has(node.source.value)) {
+    return false;
+  }
+  // A bare `import 'node:path';` declares no bindings, which would make "every
+  // binding is dead" vacuously true. Whether the module has side effects is
+  // beside the point — the author wrote a statement whose only possible purpose
+  // is its effect, and deleting it is an edit nobody asked for.
+  if (node.specifiers.length === 0 || hasTypeOnlyBinding(node)) {
+    return false;
+  }
+  // `every` over a non-empty list: the `specifiers.length === 0` bail above is
+  // what makes that safe, and it is the ONLY thing that does. A second
+  // `declared.length > 0` here would look like belt-and-braces and would in fact
+  // be a guard that can never fire — which mutation testing reports as an
+  // unguarded line, correctly, because deleting the real check leaves it green.
+  return sourceCode
+    .getDeclaredVariables(node)
+    .every((variable) => variable.references.length === 0);
+}
+
+/**
+ * Report — and remove — every import declaration this pass emptied out.
+ *
+ * Runs at `Program:exit`, over the SOURCE as it stands this pass. That ordering
+ * is the safety property, not an implementation detail: while a live reference
+ * survives in the text being linted, the binding is not dead and nothing is
+ * reported. The removal therefore lands on a later pass, after the rewrite that
+ * consumed the last reference — never speculatively alongside it.
+ *
+ * `migrated` gates the whole leg on the safe symbol being bound in the file, and
+ * is what keeps this a REPAIR leg rather than a general unused-import rule. It
+ * must be read from the SOURCE and never from a flag a `fix()` can flip: ESLint
+ * runs `fix()` for a suppressed problem before the `eslint-disable` filter
+ * discards it, so any mutable "did I add the import?" flag is already spent and
+ * lying by the time this runs.
+ *
+ * Its own report, with its own `fix`, deliberately — so the deletion appears in
+ * lint output and can be suppressed at the import line, rather than a rewrite
+ * quietly taking a declaration with it.
+ *
+ * Several rules in this pack can reach the same dead declaration in the same
+ * pass (a file using only `path.join` and `path.resolve` finishes owing nothing
+ * to `path`). They emit identical removals over an identical range, so ESLint
+ * applies one and drops the rest as overlapping. Measured with the three
+ * `safePath` rules enabled together over a file using all three: one
+ * `verifyAndFix`, output clean under `no-undef` and `no-unused-vars`, nothing
+ * left to report.
+ *
+ * In a check-only run that same file yields N identical messages, one per
+ * enabled rule. **Do not "fix" that by latching across rules.** These rule
+ * instances do share a module scope here, so a `WeakMap` keyed on `SourceCode`
+ * would dedupe them — and would reintroduce the exact trap round 2 was spent
+ * escaping. ESLint runs `fix()` for a suppressed problem BEFORE the
+ * `eslint-disable` filter discards it, so an `eslint-disable-next-line` naming
+ * whichever rule happened to win the latch would consume the file's only
+ * removal and then throw it away, leaving the import permanently undeletable and
+ * unreported. Duplicate messages on a file that is about to be fixed are the
+ * cheap failure; a silently stranded file is not.
+ *
+ * @param {object} context - ESLint rule context.
+ * @param {object} sourceCode - ESLint `SourceCode` for the file being linted.
+ * @param {object[]} importNodes - Unsafe-module `ImportDeclaration`s seen this pass.
+ * @param {boolean} migrated - Was the safe symbol already bound in the SOURCE?
+ */
+function reportDeadUnsafeImports(context, sourceCode, importNodes, migrated) {
+  if (!migrated) {
+    return;
+  }
+  for (const node of importNodes) {
+    if (!isDeadRemovableImport(sourceCode, node)) {
+      continue;
+    }
+    context.report({
+      node,
+      messageId: DEAD_UNSAFE_IMPORT,
+      data: {
+        local: sourceCode
+          .getDeclaredVariables(node)
+          .map((variable) => variable.name)
+          .join("', '"),
+        module: node.source.value,
+      },
+      // `fixer.remove(node)` takes the declaration and leaves its newline, so a
+      // blank line remains where the import was. That is exactly what the
+      // specifier-removal leg in `path-function-rule-factory.cjs` has always
+      // done — its fixtures pin the leading `\n` — and matching it keeps one
+      // behaviour rather than two. Extending the range through a trailing
+      // whitespace-only remainder would tidy both, and should be done to both at
+      // once, once an adopter has measured whether their formatter cares.
+      fix: (fixer) => fixer.remove(node),
+    });
+  }
+}
+
+module.exports = {
+  DEAD_UNSAFE_IMPORT,
+  DEAD_UNSAFE_IMPORT_MESSAGE,
+  REMOVABLE_MODULES,
+  reportDeadUnsafeImports,
+};

--- a/packages/utils/eslint/rules/eslint-rule-factory.cjs
+++ b/packages/utils/eslint/rules/eslint-rule-factory.cjs
@@ -36,6 +36,11 @@
  */
 
 const {
+  DEAD_UNSAFE_IMPORT,
+  DEAD_UNSAFE_IMPORT_MESSAGE,
+  reportDeadUnsafeImports,
+} = require('./dead-import.cjs');
+const {
   UNANCHORED_EXEMPT_FILE,
   UNANCHORED_EXEMPT_MESSAGE,
   createConfigurableExemptPathMatcher,
@@ -43,9 +48,67 @@ const {
 } = require('./exempt-path-matcher.cjs');
 const {
   EXEMPT_AND_SAFE_MODULE_SCHEMA,
+  insertAboveWithComments,
   isNameAlreadyBound,
   resolveSafeModule,
 } = require('./safe-import.cjs');
+
+/** Does this declaration bring in `name` as a named specifier? */
+function importsName(importNode, name) {
+  return importNode.specifiers.some(
+    (spec) => spec.type === 'ImportSpecifier' && spec.imported.name === name,
+  );
+}
+
+/**
+ * The local name of `import os from 'node:os'` / `import * as os from 'node:os'`.
+ *
+ * Without it the member-expression check has no receiver to compare against,
+ * and matching on the property name alone turns every `env.tmpdir()` into an
+ * `os.tmpdir()` finding.
+ */
+function namespaceLocalName(importNode) {
+  const spec = importNode.specifiers.find(
+    (candidate) =>
+      candidate.type === 'ImportDefaultSpecifier' || candidate.type === 'ImportNamespaceSpecifier',
+  );
+  return spec ? spec.local.name : null;
+}
+
+/**
+ * The module specifier of `require('x')`, `import('x')` or `await import('x')`.
+ *
+ * A static `import * as os` is not the only way to end up holding the `node:os`
+ * namespace, and the fix does not care which way it happened — the whole callee
+ * is replaced by a free function, so `os.tmpdir()` becomes `normalizedTmpdir()`
+ * whatever bound `os`.
+ *
+ * This is NOT a return to rc.1, which matched any receiver at all and so
+ * "detected" these shapes only as a side effect of the defect that also produced
+ * `os.normalizedTmpdir()`. The receiver check stays; this widens what counts as
+ * evidence that the receiver IS the module's namespace, and nothing else.
+ *
+ * @param {object} [init] - The initialiser of a variable declarator.
+ * @returns {string|null} The literal module name, or null.
+ */
+function namespaceModuleOf(init) {
+  const expr = init?.type === 'AwaitExpression' ? init.argument : init;
+  if (!expr) {
+    return null;
+  }
+  const isDynamicImport = expr.type === 'ImportExpression';
+  const isRequire =
+    expr.type === 'CallExpression' &&
+    expr.callee.type === 'Identifier' &&
+    expr.callee.name === 'require';
+  if (!isDynamicImport && !isRequire) {
+    return null;
+  }
+  // `ImportExpression.source` / the sole `require` argument. A computed
+  // specifier names no module we can check, so it binds nothing we may rewrite.
+  const source = isDynamicImport ? expr.source : expr.arguments[0];
+  return source?.type === 'Literal' && typeof source.value === 'string' ? source.value : null;
+}
 
 /**
  * Helper function to filter unsafe import specifiers
@@ -110,6 +173,7 @@ module.exports = function createNoUnsafeRule(config) {
       schema: [EXEMPT_AND_SAFE_MODULE_SCHEMA],
       messages: {
         noUnsafeOperation: message,
+        [DEAD_UNSAFE_IMPORT]: DEAD_UNSAFE_IMPORT_MESSAGE,
         [UNANCHORED_EXEMPT_FILE]: UNANCHORED_EXEMPT_MESSAGE,
       },
     },
@@ -138,9 +202,19 @@ module.exports = function createNoUnsafeRule(config) {
       // rewritten but must NOT gain a second binding of the same name — that is
       // a SyntaxError, not a redundant import. See `safe-import.cjs`.
       let hasSafeImport = isNameAlreadyBound(sourceCode, safeFn);
+      // The SAME question, answered once and never mutated. `hasSafeImport`
+      // flips the moment a fix inserts the import, and the dead-import leg must
+      // not be armed by a flag a suppressed report can spend — ESLint runs
+      // `fix()` before the `eslint-disable` filter discards the problem.
+      const safeBoundInSource = hasSafeImport;
       let unsafeImportNode = null;
+      const unsafeImportNodes = [];
       let safeImportNode = null;
-      // Guards the shared import edits against a second emission — see `fix()`.
+      // A SET, because a namespace can be bound by a static import, a
+      // `require()`, or a dynamic `import()` — see `namespaceModuleOf`.
+      const unsafeNamespaceNames = new Set();
+      // Latches the REMOVAL only — never the insert. See `fix()` for why the
+      // two shared edits must be treated differently.
       let unsafeImportRemoved = false;
 
       return {
@@ -148,25 +222,61 @@ module.exports = function createNoUnsafeRule(config) {
           reportUnanchoredExemptEntries(context, node);
         },
 
+        'Program:exit'() {
+          reportDeadUnsafeImports(context, sourceCode, unsafeImportNodes, safeBoundInSource);
+        },
+
         ImportDeclaration(node) {
-          // Track unsafe module imports
           if (moduleVariants.includes(node.source.value)) {
             unsafeImportNode = node;
-            for (const spec of node.specifiers) {
-              if (spec.type === 'ImportSpecifier' && spec.imported.name === unsafeFn) {
-                hasUnsafeImport = true;
-              }
+            unsafeImportNodes.push(node);
+            hasUnsafeImport = hasUnsafeImport || importsName(node, unsafeFn);
+            const local = namespaceLocalName(node);
+            if (local) {
+              unsafeNamespaceNames.add(local);
             }
           }
-
-          // Track safe module imports
           if (node.source.value === targetModule) {
             safeImportNode = node;
-            for (const spec of node.specifiers) {
-              if (spec.type === 'ImportSpecifier' && spec.imported.name === safeFn) {
-                hasSafeImport = true;
-              }
-            }
+            hasSafeImport = hasSafeImport || importsName(node, safeFn);
+          }
+        },
+
+        // `const os = require('node:os')` / `const os = await import('node:os')`.
+        //
+        // Recorded by NAME, matching how the static-import receiver has always
+        // been tracked, so a declaration must precede its use — which is the
+        // normal shape and the only one either form appears in. Resolving the
+        // receiver through scope instead would also reject a shadowing rebind,
+        // but it would change detection parity on a population an adopter has
+        // already measured across 4,963 files, so it is not worth trading here.
+        //
+        // KNOWN RESIDUAL, measured: `dead-import.cjs` only removes an
+        // `ImportDeclaration`, so after the rewrite `const os = require('node:os')`
+        // and `const os = await import('node:os')` are both left behind as
+        // `'os' is assigned a value but never used` (the dynamic form also draws
+        // `sonarjs/no-dead-store`). Removing a VariableDeclaration is a wider edit
+        // than removing an import (multiple declarators, destructuring, an `await`
+        // inside control flow), so it is deliberately not done here. A static
+        // `import * as os` — the shape that actually appears at scale — is cleaned
+        // up. An adopter confirmed the residual 2-for-2 and measured **zero** files
+        // using either dynamic shape across 4,963 tracked sources, so the
+        // population this would serve is currently empty.
+        //
+        // If it is ever extended that far, note what makes the dynamic case
+        // different in kind: the leftover `await import('node:os')` STILL RUNS.
+        // The module is loaded and the promise awaited, and only the binding is
+        // dead — so deleting the statement removes an execution, not just a name.
+        // For these builtins that is unobservable, which is precisely why the
+        // module list is closed; the same edit against an arbitrary module would
+        // not be safe, and no `sideEffects` metadata could tell you so.
+        VariableDeclarator(node) {
+          if (node.id.type !== 'Identifier') {
+            return;
+          }
+          const source = namespaceModuleOf(node.init);
+          if (source !== null && moduleVariants.includes(source)) {
+            unsafeNamespaceNames.add(node.id.name);
           }
         },
 
@@ -178,10 +288,23 @@ module.exports = function createNoUnsafeRule(config) {
             isUnsafeCall = true;
           }
 
-          // Check for member expression: obj.unsafeFn()
+          // Check for member expression: os.tmpdir()
+          //
+          // The RECEIVER must be the unsafe module's own namespace binding.
+          // Matching on the property name alone made `env.tmpdir()` — any
+          // object at all with a same-named method — an `os.tmpdir()` finding.
+          // That was survivable while the fixer rewrote only the property
+          // (`env.normalizedTmpdir()` fails to compile, so the false positive
+          // announced itself); once the whole callee is replaced it becomes
+          // `normalizedTmpdir()`, which compiles, type-checks, passes
+          // `no-undef`, and silently calls a different function with the
+          // receiver discarded. A false positive that produces WORKING code is
+          // strictly the more dangerous kind.
           if (
             checkMemberExpression &&
             node.callee.type === 'MemberExpression' &&
+            node.callee.object.type === 'Identifier' &&
+            unsafeNamespaceNames.has(node.callee.object.name) &&
             node.callee.property.name === unsafeFn
           ) {
             isUnsafeCall = true;
@@ -210,33 +333,61 @@ module.exports = function createNoUnsafeRule(config) {
               // identifier, so `no-undef` cannot see it either. `tsc` can.
               fixes.push(fixer.replaceText(node.callee, safeFn));
 
-              // Add import if needed.
+              // Add import if needed — on EVERY report, deliberately.
               //
-              // Emitted at most ONCE per file. ESLint merges one `fix()`'s
-              // yields into a single `min..max` range and applies only
-              // non-overlapping ranges per pass — so a report that edits both
-              // the import and its own call site spans everything between them,
-              // and N such reports leave N nested ranges of which ESLint keeps
-              // exactly one. Without these guards a file with N unsafe calls
-              // needed N+1 passes and, past ESLint's 10-pass cap, silently kept
-              // calls the import no longer backs. See the same guard (and an
-              // adopter's 146-file measurement of the failure) in
-              // `path-function-rule-factory.cjs`.
+              // The sister factory emits this once per file, because there a
+              // report that edits both the import and its own call site spans
+              // everything between them, N reports leave N nested ranges, and
+              // ESLint keeps one: the defect measured at 146 broken files.
+              //
+              // That guard does not belong here, and briefly having it was a
+              // mistake worth recording. These rules do NOT key detection on
+              // the import — `node.callee.name === unsafeFn` is true whether or
+              // not the specifier survives — and `hasSafeImport` is reseeded
+              // from scope each pass, so pass 2 always finished the job anyway.
+              // An adversarial run confirmed the guard changed no output at 4,
+              // 40 or 75 call sites. What it DID change was the failure mode:
+              // ESLint runs `fix()` for a suppressed problem before the
+              // `eslint-disable` filter discards it, so one disable comment on
+              // the first call site spent the once-per-file edit and stranded
+              // the file with calls the import no longer backs.
+              //
+              // Every report carrying its own import edit costs a pass and buys
+              // a fix that is correct on its own — including when applied alone
+              // from an editor's "fix this problem".
               if (!hasSafeImport) {
                 if (safeImportNode) {
                   // Add to existing safe module import
                   const lastSpecifier = safeImportNode.specifiers.at(-1);
                   fixes.push(fixer.insertTextAfter(lastSpecifier, `, ${safeFn}`));
                 } else {
-                  // Create new import after unsafe import or at the top
+                  // Land next to the imports, never after arbitrary code —
+                  // `insertTextAfter(body[0])` on a file whose first statement
+                  // is a `const` welds the declaration onto the end of it.
                   const targetNode = unsafeImportNode || sourceCode.ast.body[0];
-                  const newImport = `import { ${safeFn} } from '${targetModule}';\n`;
-                  fixes.push(fixer.insertTextAfter(targetNode, newImport));
+                  const declaration = `import { ${safeFn} } from '${targetModule}';`;
+                  fixes.push(
+                    targetNode.type === 'ImportDeclaration'
+                      ? fixer.insertTextAfter(targetNode, `\n${declaration}`)
+                      : insertAboveWithComments(fixer, sourceCode, targetNode, `${declaration}\n`),
+                  );
                 }
-                hasSafeImport = true;
               }
 
-              // Remove unsafe import if it's the only specifier
+              // Remove the unsafe import — LATCHED, unlike the insert above.
+              //
+              // The asymmetry is the whole design. An insert is safe to repeat
+              // (identical text, identical anchor, ESLint drops the duplicate)
+              // and repeating it is what keeps each report's fix correct on its
+              // own. A REMOVAL is not: if every report removes the specifier,
+              // one of those removals lands even when the report that would
+              // have rewritten the matching call was suppressed — and the
+              // suppressed call is left calling an identifier the import no
+              // longer provides. Measured: `tmpdir` undefined, permanently.
+              //
+              // Latched, the discarded first report simply takes the removal
+              // with it, and the worst case is an unused import that
+              // `no-unused-vars` will point at. A lint finding, not a crash.
               if (hasUnsafeImport && unsafeImportNode && !unsafeImportRemoved) {
                 const unsafeSpecs = filterUnsafeSpecifiers(unsafeImportNode, unsafeFn);
                 if (unsafeImportNode.specifiers.length === 1 && unsafeSpecs.length === 1) {

--- a/packages/utils/eslint/rules/eslint-rule-factory.cjs
+++ b/packages/utils/eslint/rules/eslint-rule-factory.cjs
@@ -59,7 +59,7 @@ function filterUnsafeSpecifiers(importNode, unsafeFn) {
  * Helper function to remove unsafe import specifiers
  * Extracted to reduce nesting depth for code quality
  */
-function removeUnsafeImportSpecifiers(fixer, sourceCode, unsafeImportNode, unsafeSpecs) {
+function removeUnsafeImportSpecifiers(fixer, sourceCode, unsafeSpecs) {
   const fixes = [];
   for (const spec of unsafeSpecs) {
     const comma = sourceCode.getTokenAfter(spec);
@@ -140,6 +140,8 @@ module.exports = function createNoUnsafeRule(config) {
       let hasSafeImport = isNameAlreadyBound(sourceCode, safeFn);
       let unsafeImportNode = null;
       let safeImportNode = null;
+      // Guards the shared import edits against a second emission — see `fix()`.
+      let unsafeImportRemoved = false;
 
       return {
         Program(node) {
@@ -196,16 +198,30 @@ module.exports = function createNoUnsafeRule(config) {
             fix(fixer) {
               const fixes = [];
 
-              // Replace unsafe call with safe call
-              if (node.callee.type === 'MemberExpression') {
-                // For obj.method(), replace just the method name
-                fixes.push(fixer.replaceText(node.callee.property, safeFn));
-              } else {
-                // For method(), replace the whole callee
-                fixes.push(fixer.replaceText(node.callee, safeFn));
-              }
+              // Replace the WHOLE callee, member expression or not.
+              //
+              // Rewriting only the property turned `os.tmpdir()` into
+              // `os.normalizedTmpdir()` — a method that does not exist on the
+              // `node:os` namespace. The replacement is a free function from
+              // OUR package, and the fixer imported it correctly; it just left
+              // the call reaching for it through the wrong object. Silent, like
+              // the overlap bug below: lint went green (the rule no longer sees
+              // `tmpdir`), and it is a dangling MEMBER rather than a dangling
+              // identifier, so `no-undef` cannot see it either. `tsc` can.
+              fixes.push(fixer.replaceText(node.callee, safeFn));
 
-              // Add import if needed
+              // Add import if needed.
+              //
+              // Emitted at most ONCE per file. ESLint merges one `fix()`'s
+              // yields into a single `min..max` range and applies only
+              // non-overlapping ranges per pass — so a report that edits both
+              // the import and its own call site spans everything between them,
+              // and N such reports leave N nested ranges of which ESLint keeps
+              // exactly one. Without these guards a file with N unsafe calls
+              // needed N+1 passes and, past ESLint's 10-pass cap, silently kept
+              // calls the import no longer backs. See the same guard (and an
+              // adopter's 146-file measurement of the failure) in
+              // `path-function-rule-factory.cjs`.
               if (!hasSafeImport) {
                 if (safeImportNode) {
                   // Add to existing safe module import
@@ -217,18 +233,20 @@ module.exports = function createNoUnsafeRule(config) {
                   const newImport = `import { ${safeFn} } from '${targetModule}';\n`;
                   fixes.push(fixer.insertTextAfter(targetNode, newImport));
                 }
+                hasSafeImport = true;
               }
 
               // Remove unsafe import if it's the only specifier
-              if (hasUnsafeImport && unsafeImportNode) {
+              if (hasUnsafeImport && unsafeImportNode && !unsafeImportRemoved) {
                 const unsafeSpecs = filterUnsafeSpecifiers(unsafeImportNode, unsafeFn);
                 if (unsafeImportNode.specifiers.length === 1 && unsafeSpecs.length === 1) {
                   // Remove entire import
                   fixes.push(fixer.remove(unsafeImportNode));
                 } else if (unsafeSpecs.length > 0) {
                   // Remove just the unsafe specifier
-                  fixes.push(...removeUnsafeImportSpecifiers(fixer, sourceCode, unsafeImportNode, unsafeSpecs));
+                  fixes.push(...removeUnsafeImportSpecifiers(fixer, sourceCode, unsafeSpecs));
                 }
+                unsafeImportRemoved = true;
               }
 
               return fixes;

--- a/packages/utils/eslint/rules/no-manual-path-normalize.cjs
+++ b/packages/utils/eslint/rules/no-manual-path-normalize.cjs
@@ -14,13 +14,20 @@
  */
 
 const {
+  DEAD_UNSAFE_IMPORT,
+  DEAD_UNSAFE_IMPORT_MESSAGE,
+  reportDeadUnsafeImports,
+} = require('./dead-import.cjs');
+const {
   SAFE_MODULE_ONLY_SCHEMA,
   SAFE_PATH_MODULE,
+  insertAboveWithComments,
   isNameAlreadyBound,
   resolveSafeModule,
 } = require('./safe-import.cjs');
 
 const SAFE_FN = 'toForwardSlash';
+const PATH_MODULES = new Set(['node:path', 'path']);
 
 module.exports = {
   meta: {
@@ -35,6 +42,7 @@ module.exports = {
       useToForwardSlash:
         'Use toForwardSlash() from {{safeModule}} instead of manual path normalization. ' +
         'Manual normalization is error-prone and less maintainable.',
+      [DEAD_UNSAFE_IMPORT]: DEAD_UNSAFE_IMPORT_MESSAGE,
     },
     schema: [SAFE_MODULE_ONLY_SCHEMA],
   },
@@ -46,10 +54,24 @@ module.exports = {
     // barrel must have the call rewritten WITHOUT gaining a second binding of
     // the same name — that is a SyntaxError. See `safe-import.cjs`.
     let hasToForwardSlashImport = isNameAlreadyBound(sourceCode, SAFE_FN);
+    // Never mutated — the dead-import leg must not be armed by a flag that a
+    // suppressed report's `fix()` can spend. See `dead-import.cjs`.
+    const safeBoundInSource = hasToForwardSlashImport;
     let utilsImportNode = null;
+    // `path.sep` is the last `path.*` reference in plenty of files, and
+    // `toForwardSlash(raw)` consumes it — leaving the same dead `node:path`
+    // binding the `safePath` rules used to leave.
+    const pathImportNodes = [];
 
     return {
+      'Program:exit'() {
+        reportDeadUnsafeImports(context, sourceCode, pathImportNodes, safeBoundInSource);
+      },
+
       ImportDeclaration(node) {
+        if (PATH_MODULES.has(node.source.value)) {
+          pathImportNodes.push(node);
+        }
         if (node.source.value === targetModule) {
           utilsImportNode = node;
           for (const spec of node.specifiers) {
@@ -110,12 +132,21 @@ module.exports = {
                       // Create new import at the top
                       const firstNode = sourceCode.ast.body[0];
                       const newImport = `import { ${SAFE_FN} } from '${targetModule}';\n`;
-                      fixes.push(fixer.insertTextBefore(firstNode, newImport));
+                      fixes.push(insertAboveWithComments(fixer, sourceCode, firstNode, newImport));
                     }
-                    // Multiple reports in one pass share this closure; without
-                    // this, a second occurrence in the same file inserts the
-                    // import a second time.
-                    hasToForwardSlashImport = true;
+                    // NOT latched. The comment here used to claim that without a
+                    // `hasToForwardSlashImport = true` a second occurrence would
+                    // insert the import twice; an adversarial run could not
+                    // reproduce that at any occurrence count. It cannot happen:
+                    // both reports insert identical text at the identical anchor,
+                    // so the ranges coincide and ESLint applies one and drops the
+                    // other as overlapping.
+                    //
+                    // Latching it is not free, either. ESLint runs `fix()` for a
+                    // SUPPRESSED problem before the `eslint-disable` filter
+                    // discards it, so the first report could spend the flag and
+                    // then be thrown away — leaving later occurrences rewritten
+                    // to a `toForwardSlash` nothing imports.
                   }
 
                   return fixes;

--- a/packages/utils/eslint/rules/path-function-rule-factory.cjs
+++ b/packages/utils/eslint/rules/path-function-rule-factory.cjs
@@ -10,6 +10,11 @@
  */
 
 const {
+  DEAD_UNSAFE_IMPORT,
+  DEAD_UNSAFE_IMPORT_MESSAGE,
+  reportDeadUnsafeImports,
+} = require('./dead-import.cjs');
+const {
   UNANCHORED_EXEMPT_FILE,
   UNANCHORED_EXEMPT_MESSAGE,
   createConfigurableExemptPathMatcher,
@@ -18,6 +23,7 @@ const {
 const {
   EXEMPT_AND_SAFE_MODULE_SCHEMA,
   SAFE_PATH_MODULE,
+  insertAboveWithComments,
   isNameAlreadyBound,
   resolveSafeModule,
 } = require('./safe-import.cjs');
@@ -58,10 +64,31 @@ function removeSpecifier(fixer, sourceCode, importNode, spec) {
 
 /**
  * Track path module specifiers from an import declaration.
+ *
+ * Two specifier shapes are deliberately NOT tracked, because tracking them is
+ * what let the fixer delete them:
+ *
+ * - **Type-only** (`import { type join, … }` / `import type { join }`). The
+ *   binding exists only for the type checker; there is no call to rewrite, and
+ *   removing the specifier silently breaks every `typeof join` that referenced
+ *   it. `no-undef` cannot see the damage — it is a TYPE reference.
+ * - **Aliased** (`import { join as pathJoin }`). The rule never reported
+ *   `pathJoin(...)` in the first place — `classifyCall` matches on the callee's
+ *   name — so tracking the specifier bought nothing and cost the whole import:
+ *   an unrelated unbound `join(` elsewhere in the file made the fixer remove
+ *   the alias, breaking every working `pathJoin` call site.
  */
 function trackPathImport(node, unsafeFn, state) {
+  if (node.importKind === 'type') {
+    return;
+  }
   for (const spec of node.specifiers) {
-    if (spec.type === 'ImportSpecifier' && spec.imported.name === unsafeFn) {
+    if (
+      spec.type === 'ImportSpecifier' &&
+      spec.importKind !== 'type' &&
+      spec.imported.name === unsafeFn &&
+      spec.local.name === unsafeFn
+    ) {
       state.namedImportSpec = spec;
       state.namedImportNode = node;
     }
@@ -69,6 +96,24 @@ function trackPathImport(node, unsafeFn, state) {
       state.defaultImportName = spec.local.name;
     }
   }
+}
+
+/**
+ * Is `name` re-exported by a bare `export { name }` in this file?
+ *
+ * Removing the import specifier then leaves the export naming nothing, and the
+ * result does not PARSE — `Export 'join' is not defined`. An autofix whose
+ * output cannot be parsed is the worst outcome available, so the specifier
+ * stays and the call sites are still rewritten. Whatever is left is a lint
+ * finding a human can read, not a broken file.
+ */
+function isReExported(sourceCode, name) {
+  return sourceCode.ast.body.some(
+    (node) =>
+      node.type === 'ExportNamedDeclaration' &&
+      !node.source &&
+      node.specifiers.some((spec) => spec.local?.name === name),
+  );
 }
 
 /**
@@ -104,34 +149,67 @@ function isIdentifierBound(sourceCode, node, name) {
 
 /**
  * Check if a call expression is an unsafe path function call.
- * Returns { isNamed } or null if not a match.
+ *
+ * Returns `{ isNamed }` — or `{ importOnly: true }` for a call that is already
+ * correct and merely missing its import — or null if not a match.
  */
 function classifyCall(node, unsafeFn, state, sourceCode) {
-  // Direct call from named import: join(...)
+  const isMember = node.callee.type === 'MemberExpression' && node.callee.property.type === 'Identifier';
+
+  // Direct call: join(...)
   if (node.callee.type === 'Identifier' && node.callee.name === unsafeFn) {
     if (state.namedImportSpec) {
       return { isNamed: true };
     }
-    // Belt and braces. Keying detection on "did I see the import?" made this
-    // rule STOP REPORTING the moment a fix removed the specifier — so a partial
+    // REPAIR LEG. Keying detection on "did I see the import?" made this rule
+    // stop reporting the moment a fix removed the specifier, so a partial
     // `--fix` reached a stable fixpoint over source that no longer compiles and
-    // exited clean. Recognising the bare call keeps the worst case at "run
-    // --fix again" instead of "you find out at tsc".
-    if (!isIdentifierBound(sourceCode, node.callee, unsafeFn)) {
+    // exited clean.
+    //
+    // Gated on `safePath` already being bound, which is what makes it a repair
+    // rather than a second, sloppier detector. An unbound `join` is NOT reliably
+    // our `join`: ESLint scope analysis does not bind `declare global { function
+    // join() }`, and it cannot see an ambient global from a `globals.d.ts`, an
+    // `@types` package, or a bundler — `resolve` and `relative` are entirely
+    // plausible as those. Requiring `safePath` in scope narrows this to the
+    // half-migrated file it exists to finish, where the name really was ours.
+    if (state.safePathBoundInSource && !isIdentifierBound(sourceCode, node.callee, unsafeFn)) {
       return { isNamed: false };
     }
     return null;
   }
-  // Member expression: path.join(...)
+
+  // Namespace call: path.join(...)
   if (
-    node.callee.type === 'MemberExpression' &&
+    isMember &&
     node.callee.object.type === 'Identifier' &&
     node.callee.object.name === state.defaultImportName &&
-    node.callee.property.type === 'Identifier' &&
     node.callee.property.name === unsafeFn
   ) {
     return { isNamed: false };
   }
+
+  // REPAIR LEG, the other half: `safePath.join(...)` with no `safePath` in
+  // scope. This is what a partially-applied fix leaves — and without it, that
+  // state is PERMANENT rather than transient.
+  //
+  // ESLint runs `fix()` for a problem BEFORE the `eslint-disable` filter
+  // discards it, so a suppressed report on the first call site consumes the
+  // once-per-file import edit and then throws it away. Every other call is
+  // rewritten to `safePath.join`, nothing imports `safePath`, and no report
+  // survives to carry the import on any later pass. Recognising the orphaned
+  // call is what closes that loop; it costs one extra pass, and only in a file
+  // that is already broken.
+  if (
+    isMember &&
+    node.callee.object.type === 'Identifier' &&
+    node.callee.object.name === SAFE_OBJECT &&
+    node.callee.property.name === unsafeFn &&
+    !isIdentifierBound(sourceCode, node.callee.object, SAFE_OBJECT)
+  ) {
+    return { importOnly: true };
+  }
+
   return null;
 }
 
@@ -157,44 +235,74 @@ function classifyCall(node, unsafeFn, state, sourceCode) {
  * a fix LOCAL to its own callee. Nothing overlaps, and one pass fixes the file.
  * `no-manual-path-normalize.cjs` carries the same guard for the same reason.
  *
- * Caveat, deliberate and stated because it is the same defect class in
- * miniature: only the FIRST report's fix is self-sufficient. Applying a later
- * one ALONE — an editor's "fix this problem", or an `eslint-disable` on the
- * first call site — rewrites the call without adding the import. The state is
- * transient (the next full `--fix` re-inserts it, because `hasSafePathImport`
- * is seeded from scope) and it is the strictly smaller failure: the alternative
- * is the batch `--fix` everyone actually runs silently breaking 146 files.
+ * Only the FIRST report's fix is self-sufficient, and that is load-bearing:
+ * applying a later one ALONE — an editor's "fix this problem", or an
+ * `eslint-disable` on the first call site — rewrites the call without adding
+ * the import. ESLint runs `fix()` before the disable filter, so a suppressed
+ * report consumes the once-per-file edit and then discards it.
  *
- * It cannot be closed by hoisting the shared edits onto their own report,
- * either. Removing `join` from the import while a suppressed `join(...)` call
- * survives is the same broken output reached a different way. `exemptFiles` is
- * the supported way to opt a whole file out.
+ * That state is recoverable rather than permanent ONLY because `classifyCall`
+ * has a repair leg for an orphaned `safePath.join(...)`. Without it the file
+ * stays broken through every subsequent `--fix`, because no report is left to
+ * carry the import — measured, not reasoned about. An earlier draft of this
+ * comment asserted the recovery came free from `hasSafePathImport` being seeded
+ * from scope; that was wrong, and an adversarial run produced the stable broken
+ * fixpoint to prove it.
+ *
+ * The shared edits still cannot be hoisted onto their own report: removing
+ * `join` from the import while a suppressed `join(...)` call survives is the
+ * same broken output reached a different way. `exemptFiles` opts a whole file
+ * out.
  */
-function buildFix(fixer, node, unsafeFn, isNamed, sourceCode, state) {
+function importSafePath(fixer, sourceCode, state) {
+  if (state.safeImportNode) {
+    const lastSpec = state.safeImportNode.specifiers.at(-1);
+    return fixer.insertTextAfter(lastSpec, `, ${SAFE_OBJECT}`);
+  }
+  const targetNode = state.namedImportNode || sourceCode.ast.body[0];
+  const declaration = `import { ${SAFE_OBJECT} } from '${state.safeModule}';`;
+  // Land the new import next to the imports, not after arbitrary code. A file
+  // reported only through a repair leg may have no path import at all, and
+  // `insertTextAfter(body[0])` would push the declaration below the statement
+  // that needs it — legal, since imports hoist, but it reads as though the
+  // fixer lost track of the file.
+  return targetNode.type === 'ImportDeclaration'
+    ? fixer.insertTextAfter(targetNode, `\n${declaration}`)
+    : insertAboveWithComments(fixer, sourceCode, targetNode, `${declaration}\n`);
+}
+
+function buildFix(fixer, node, unsafeFn, classification, sourceCode, state) {
+  // REPAIR: an orphaned `safePath.join(...)` is already the call we want, and
+  // the only thing missing is the import that a discarded report was carrying.
+  //
+  // This deliberately ignores `state.hasSafePathImport`. That flag is mutated
+  // inside `fix()`, and ESLint runs `fix()` for a SUPPRESSED problem before the
+  // disable filter throws it away — so on every pass the suppressed report
+  // spends the flag first and the repair emits nothing. The file then never
+  // recovers, which is precisely the stable broken fixpoint this leg exists to
+  // break. The gate that makes ignoring the flag safe is immutable: this
+  // classification is only reached when `safePath` is unbound in the SOURCE.
+  //
+  // Several orphaned calls yield the identical insert at the identical anchor,
+  // so ESLint applies one and drops the rest as overlapping — which is the
+  // desired outcome, not a hazard.
+  if (classification.importOnly) {
+    return [importSafePath(fixer, sourceCode, state)];
+  }
+
   const fixes = [fixer.replaceText(node.callee, `${SAFE_OBJECT}.${unsafeFn}`)];
 
   if (!state.hasSafePathImport) {
-    if (state.safeImportNode) {
-      const lastSpec = state.safeImportNode.specifiers.at(-1);
-      fixes.push(fixer.insertTextAfter(lastSpec, `, ${SAFE_OBJECT}`));
-    } else {
-      const targetNode = state.namedImportNode || sourceCode.ast.body[0];
-      const declaration = `import { ${SAFE_OBJECT} } from '${state.safeModule}';`;
-      // Land the new import next to the imports, not after arbitrary code. A
-      // file reported only through `classifyCall`'s bare-call leg may have no
-      // import at all, and `insertTextAfter(body[0])` would push the
-      // declaration below the statement that needs it — legal, since imports
-      // hoist, but it reads as though the fixer lost track of the file.
-      fixes.push(
-        targetNode.type === 'ImportDeclaration'
-          ? fixer.insertTextAfter(targetNode, `\n${declaration}`)
-          : fixer.insertTextBefore(targetNode, `${declaration}\n`),
-      );
-    }
+    fixes.push(importSafePath(fixer, sourceCode, state));
     state.hasSafePathImport = true;
   }
 
-  if (isNamed && state.namedImportNode && !state.namedImportRemoved) {
+  if (
+    classification.isNamed &&
+    state.namedImportNode &&
+    !state.namedImportRemoved &&
+    !isReExported(sourceCode, unsafeFn)
+  ) {
     fixes.push(...removeSpecifier(fixer, sourceCode, state.namedImportNode, state.namedImportSpec));
     state.namedImportRemoved = true;
   }
@@ -217,6 +325,7 @@ module.exports = function createPathFunctionRule(config) {
       schema: [EXEMPT_AND_SAFE_MODULE_SCHEMA],
       messages: {
         noUnsafePathFn: message,
+        [DEAD_UNSAFE_IMPORT]: DEAD_UNSAFE_IMPORT_MESSAGE,
         [UNANCHORED_EXEMPT_FILE]: UNANCHORED_EXEMPT_MESSAGE,
       },
     },
@@ -247,7 +356,17 @@ module.exports = function createPathFunctionRule(config) {
         // A file already importing `safePath` from the barrel needs the call
         // rewritten but must NOT gain a second binding of the same name.
         hasSafePathImport: isNameAlreadyBound(sourceCode, SAFE_OBJECT),
+        // The SAME question, answered once and never mutated. `hasSafePathImport`
+        // flips to true the moment a fix inserts the import, and gating the
+        // repair leg on a flag that the first report can flip would arm it for
+        // the rest of THIS pass — re-admitting the ambient-global false positive
+        // in any file that also has a `path.join()` to fix.
+        safePathBoundInSource: isNameAlreadyBound(sourceCode, SAFE_OBJECT),
         safeImportNode: null,
+        // EVERY path-module declaration, not just the one carrying `unsafeFn`.
+        // A file's dead binding is `import path from 'node:path'`, which
+        // `trackPathImport` only ever recorded as a NAME. See `dead-import.cjs`.
+        pathImportNodes: [],
       };
 
       return {
@@ -255,8 +374,18 @@ module.exports = function createPathFunctionRule(config) {
           reportUnanchoredExemptEntries(context, node);
         },
 
+        'Program:exit'() {
+          reportDeadUnsafeImports(
+            context,
+            sourceCode,
+            state.pathImportNodes,
+            state.safePathBoundInSource,
+          );
+        },
+
         ImportDeclaration(node) {
           if (PATH_MODULES.has(node.source.value)) {
+            state.pathImportNodes.push(node);
             trackPathImport(node, unsafeFn, state);
           }
           if (node.source.value === state.safeModule) {
@@ -278,7 +407,7 @@ module.exports = function createPathFunctionRule(config) {
             // drift from where the fixer actually writes the import.
             data: { safeModule: state.safeModule },
             fix(fixer) {
-              return buildFix(fixer, node, unsafeFn, classification.isNamed, sourceCode, state);
+              return buildFix(fixer, node, unsafeFn, classification, sourceCode, state);
             },
           });
         },

--- a/packages/utils/eslint/rules/path-function-rule-factory.cjs
+++ b/packages/utils/eslint/rules/path-function-rule-factory.cjs
@@ -84,17 +84,43 @@ function trackSafeImport(node, state) {
 }
 
 /**
- * Check if a call expression is an unsafe path function call.
- * Returns { isUnsafe, isNamed } or null if not a match.
+ * Is `name` resolvable from `node`'s scope outward — a parameter, a local, an
+ * import, or a configured global?
+ *
+ * Used only to decide whether a bare `join(...)` with no `node:path` import is
+ * OUR `join` or somebody else's. `import { join } from 'lodash'` binds the name
+ * and is not our business; an unbound `join` is a ReferenceError waiting to
+ * happen, and — see `classifyCall` — is exactly what a half-applied autofix
+ * leaves behind.
  */
-function classifyCall(node, unsafeFn, state) {
+function isIdentifierBound(sourceCode, node, name) {
+  for (let scope = sourceCode.getScope(node); scope; scope = scope.upper) {
+    if (scope.variables.some((variable) => variable.name === name)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Check if a call expression is an unsafe path function call.
+ * Returns { isNamed } or null if not a match.
+ */
+function classifyCall(node, unsafeFn, state, sourceCode) {
   // Direct call from named import: join(...)
-  if (
-    node.callee.type === 'Identifier' &&
-    node.callee.name === unsafeFn &&
-    state.namedImportSpec
-  ) {
-    return { isNamed: true };
+  if (node.callee.type === 'Identifier' && node.callee.name === unsafeFn) {
+    if (state.namedImportSpec) {
+      return { isNamed: true };
+    }
+    // Belt and braces. Keying detection on "did I see the import?" made this
+    // rule STOP REPORTING the moment a fix removed the specifier — so a partial
+    // `--fix` reached a stable fixpoint over source that no longer compiles and
+    // exited clean. Recognising the bare call keeps the worst case at "run
+    // --fix again" instead of "you find out at tsc".
+    if (!isIdentifierBound(sourceCode, node.callee, unsafeFn)) {
+      return { isNamed: false };
+    }
+    return null;
   }
   // Member expression: path.join(...)
   if (
@@ -111,6 +137,38 @@ function classifyCall(node, unsafeFn, state) {
 
 /**
  * Build auto-fix for an unsafe path function call.
+ *
+ * ## Why the import edits are emitted at most ONCE per file
+ *
+ * ESLint merges the fixes one `fix()` yields into a SINGLE range spanning
+ * `min..max`, and applies only non-overlapping ranges per pass. A fix that
+ * touches both the import and its own call site therefore spans everything in
+ * between — so N such reports produce N nested ranges, ESLint keeps the
+ * shortest and DISCARDS THE REST.
+ *
+ * That is not an edge case, it is every file with more than one call site. The
+ * import edit landed, the other calls did not, and (before `classifyCall` grew
+ * its bare-call leg) the next pass could no longer see them because the
+ * specifier it keyed on was gone. `--fix` reached a stable fixpoint over source
+ * that does not compile and exited clean. An adopter measured 146 files left
+ * with a dangling reference across one sweep — worst single file, 75 call sites.
+ *
+ * So: the shared edits belong to the first report, and every later report emits
+ * a fix LOCAL to its own callee. Nothing overlaps, and one pass fixes the file.
+ * `no-manual-path-normalize.cjs` carries the same guard for the same reason.
+ *
+ * Caveat, deliberate and stated because it is the same defect class in
+ * miniature: only the FIRST report's fix is self-sufficient. Applying a later
+ * one ALONE — an editor's "fix this problem", or an `eslint-disable` on the
+ * first call site — rewrites the call without adding the import. The state is
+ * transient (the next full `--fix` re-inserts it, because `hasSafePathImport`
+ * is seeded from scope) and it is the strictly smaller failure: the alternative
+ * is the batch `--fix` everyone actually runs silently breaking 146 files.
+ *
+ * It cannot be closed by hoisting the shared edits onto their own report,
+ * either. Removing `join` from the import while a suppressed `join(...)` call
+ * survives is the same broken output reached a different way. `exemptFiles` is
+ * the supported way to opt a whole file out.
  */
 function buildFix(fixer, node, unsafeFn, isNamed, sourceCode, state) {
   const fixes = [fixer.replaceText(node.callee, `${SAFE_OBJECT}.${unsafeFn}`)];
@@ -121,13 +179,24 @@ function buildFix(fixer, node, unsafeFn, isNamed, sourceCode, state) {
       fixes.push(fixer.insertTextAfter(lastSpec, `, ${SAFE_OBJECT}`));
     } else {
       const targetNode = state.namedImportNode || sourceCode.ast.body[0];
-      fixes.push(fixer.insertTextAfter(targetNode, `\nimport { ${SAFE_OBJECT} } from '${state.safeModule}';`));
+      const declaration = `import { ${SAFE_OBJECT} } from '${state.safeModule}';`;
+      // Land the new import next to the imports, not after arbitrary code. A
+      // file reported only through `classifyCall`'s bare-call leg may have no
+      // import at all, and `insertTextAfter(body[0])` would push the
+      // declaration below the statement that needs it — legal, since imports
+      // hoist, but it reads as though the fixer lost track of the file.
+      fixes.push(
+        targetNode.type === 'ImportDeclaration'
+          ? fixer.insertTextAfter(targetNode, `\n${declaration}`)
+          : fixer.insertTextBefore(targetNode, `${declaration}\n`),
+      );
     }
     state.hasSafePathImport = true;
   }
 
-  if (isNamed && state.namedImportNode) {
+  if (isNamed && state.namedImportNode && !state.namedImportRemoved) {
     fixes.push(...removeSpecifier(fixer, sourceCode, state.namedImportNode, state.namedImportSpec));
+    state.namedImportRemoved = true;
   }
 
   return fixes;
@@ -170,6 +239,9 @@ module.exports = function createPathFunctionRule(config) {
         safeModule: resolveSafeModule(context, SAFE_PATH_MODULE),
         namedImportSpec: null,
         namedImportNode: null,
+        // Both of these guard a SHARED edit against being emitted by more than
+        // one report — see `buildFix` for what ESLint does with the overlap.
+        namedImportRemoved: false,
         defaultImportName: null,
         // Seeded from SCOPE, not from "did I see an import from SAFE_MODULE?".
         // A file already importing `safePath` from the barrel needs the call
@@ -193,7 +265,7 @@ module.exports = function createPathFunctionRule(config) {
         },
 
         CallExpression(node) {
-          const classification = classifyCall(node, unsafeFn, state);
+          const classification = classifyCall(node, unsafeFn, state, sourceCode);
           if (!classification) {
             return;
           }

--- a/packages/utils/eslint/rules/prefer-startswith-over-regex.cjs
+++ b/packages/utils/eslint/rules/prefer-startswith-over-regex.cjs
@@ -117,11 +117,14 @@ function findVariable(sourceCode, identifier) {
  * literal. A binding assigned more than once could hold anything by the time
  * `.test()` runs, and nothing here proves which value that is.
  *
- * @returns {{pattern: string, flags: string} | null}
+ * `indirect` is what lets the caller treat a hoisted regex differently from an
+ * inline one — see the `g`/`y` guard, which only a shared object can trip.
+ *
+ * @returns {{pattern: string, flags: string, indirect: boolean} | null}
  */
 function resolveRegex(sourceCode, node) {
   if (node.type === 'Literal' && node.regex) {
-    return node.regex;
+    return { ...node.regex, indirect: false };
   }
   if (node.type !== 'Identifier') {
     return null;
@@ -140,7 +143,27 @@ function resolveRegex(sourceCode, node) {
   }
 
   const { init } = definition.node;
-  return init.type === 'Literal' && init.regex ? init.regex : null;
+  return init.type === 'Literal' && init.regex ? { ...init.regex, indirect: true } : null;
+}
+
+/**
+ * Render the flattened literal as JS SOURCE, not as a bare character run.
+ *
+ * The literal is a string of characters; the message drops it into
+ * `startsWith(…)`, which a human reads as source. Those are different
+ * languages, and interpolating one into the other loses exactly the characters
+ * that matter. `/^C:\\Users/` flattens to `C:\Users` — one backslash — and
+ * emitting it raw produced the advice `startsWith('C:\Users')`, which JavaScript
+ * reads back as `"C:Users"`. Worse in the realistic case: a `/^\\\\/` UNC check
+ * became `startsWith('\\')`, i.e. ONE backslash, silently true for any
+ * single-backslash path. A literal containing `'` produced advice that is a
+ * `SyntaxError` outright.
+ *
+ * This rule has no fixer, so the message IS the deliverable — there is no
+ * autofixer downstream that would have escaped it correctly.
+ */
+function asSourceLiteral(literal) {
+  return JSON.stringify(literal);
 }
 
 module.exports = {
@@ -152,11 +175,14 @@ module.exports = {
       recommended: true,
     },
     messages: {
+      // `{{pattern}}` carries its FLAGS. Rendering `/^abc/` for a source
+      // `/^abc/g` hid the one character that decides whether the advice is
+      // right, from the one person positioned to notice.
       preferStartsWith:
-        "Prefer `<string>.startsWith('{{literal}}')` over `/{{pattern}}/.test(<string>)`. " +
+        'Prefer `<string>.startsWith({{literal}})` over `/{{pattern}}/{{flags}}.test(<string>)`. ' +
         String.raw`An escaped character such as \/ or \* is the literal character itself.`,
       preferEndsWith:
-        "Prefer `<string>.endsWith('{{literal}}')` over `/{{pattern}}/.test(<string>)`. " +
+        'Prefer `<string>.endsWith({{literal}})` over `/{{pattern}}/{{flags}}.test(<string>)`. ' +
         String.raw`An escaped character such as \/ or \* is the literal character itself.`,
     },
     schema: [],
@@ -174,37 +200,55 @@ module.exports = {
         ) {
           return;
         }
+        // `startsWith` needs a string receiver where `.test()` would have
+        // coerced one. Arity is the only part of that this rule can check
+        // without types — a zero-argument `.test()` coerces `undefined` to
+        // "undefined" and is nobody's prefix check. A non-string ARGUMENT
+        // (`/^\[object/.test(v)`) remains a known limitation: `.test` coerces,
+        // `startsWith` throws, and only a type checker can tell them apart.
+        if (node.arguments.length !== 1) {
+          return;
+        }
+
         const regex = resolveRegex(sourceCode, node.callee.object);
         if (!regex) {
           return;
         }
-        const { pattern, flags } = regex;
+        const { pattern, flags, indirect } = regex;
         if (flags.includes('i') || flags.includes('m')) {
           return;
         }
+        // `g` and `y` make `.test()` STATEFUL through `lastIndex`. A regex
+        // LITERAL is reconstructed on every evaluation, so its cursor is always
+        // 0 and the flags are inert; a hoisted `const` is one object that
+        // remembers. `const RE = /^abc/g` answers [true, false, true, false] to
+        // four calls on the same string where `startsWith` answers true four
+        // times — so resolving through a binding is precisely what makes this
+        // advice wrong, and precisely where it must not be given.
+        if (indirect && (flags.includes('g') || flags.includes('y'))) {
+          return;
+        }
+
+        const report = (messageId, literal) => {
+          context.report({
+            node,
+            messageId,
+            data: { literal: asSourceLiteral(literal), pattern, flags },
+          });
+        };
 
         if (pattern.startsWith('^')) {
-          const body = pattern.slice(1);
-          const literal = literalEquivalent(body);
+          const literal = literalEquivalent(pattern.slice(1));
           if (literal !== null && literal !== '') {
-            context.report({
-              node,
-              messageId: 'preferStartsWith',
-              data: { literal, pattern },
-            });
+            report('preferStartsWith', literal);
             return;
           }
         }
 
         if (pattern.endsWith('$') && !pattern.endsWith(String.raw`\$`)) {
-          const body = pattern.slice(0, -1);
-          const literal = literalEquivalent(body);
+          const literal = literalEquivalent(pattern.slice(0, -1));
           if (literal !== null && literal !== '') {
-            context.report({
-              node,
-              messageId: 'preferEndsWith',
-              data: { literal, pattern },
-            });
+            report('preferEndsWith', literal);
           }
         }
       },

--- a/packages/utils/eslint/rules/prefer-startswith-over-regex.cjs
+++ b/packages/utils/eslint/rules/prefer-startswith-over-regex.cjs
@@ -131,7 +131,7 @@ function resolveRegex(sourceCode, node) {
   }
 
   const variable = findVariable(sourceCode, node);
-  if (!variable || variable.defs.length !== 1) {
+  if (variable?.defs.length !== 1) {
     return null;
   }
   const [definition] = variable.defs;

--- a/packages/utils/eslint/rules/prefer-startswith-over-regex.cjs
+++ b/packages/utils/eslint/rules/prefer-startswith-over-regex.cjs
@@ -1,9 +1,9 @@
 /**
  * ESLint rule: prefer-startswith-over-regex
  *
- * Catches `/^literal/.test(s)` and `/literal$/.test(s)` patterns where the
- * literal portion contains only plain characters and `\/` escape sequences,
- * and recommends `s.startsWith('literal')` / `s.endsWith('literal')`.
+ * Catches `/^literal/.test(s)` and `/literal$/.test(s)` patterns whose body
+ * flattens to a plain string, and recommends `s.startsWith('literal')` /
+ * `s.endsWith('literal')`.
  *
  * Why a local rule?
  * `unicorn/prefer-string-starts-ends-with` already handles the simple case
@@ -11,11 +11,32 @@
  * common `\/` (escaped slash) sequence. SonarCloud's S6557 catches these,
  * but only post-merge. This rule shifts that detection left into ESLint.
  *
+ * ## Two shapes this rule deliberately does NOT limit itself to
+ *
+ * Both were narrowings in the first draft, and an adopter found each of them
+ * the same way: SonarCloud raised a MAJOR S6557 on code this rule had reported
+ * green.
+ *
+ * 1. **The regex need not be inline.** `const RE = /^x/; RE.test(s)` is the
+ *    same violation as `/^x/.test(s)` — see {@link resolveRegex}.
+ * 2. **An escaped non-special character is a literal character.** `\*` is an
+ *    unambiguous `*`; refusing every escape but `\/` skipped it — see
+ *    {@link literalEquivalent}.
+ *
+ * Neither could have been caught by scanning an adopter's tree. The rule runs
+ * at `error` there, so its finding count is zero BY CONSTRUCTION — lint cannot
+ * go green while a violation exists. A 0-vs-0 tie against another
+ * implementation is not agreement, it is two rules both failing to fire. For
+ * any rule an adopter reports zero findings for, that rule is *unmeasured*.
+ *
  * Examples:
  *   /^file:\/\//.test(s)   →  s.startsWith('file://')
+ *   /^\*glob/.test(s)      →  s.startsWith('*glob')
+ *   const R = /^a/; R.test(s) →  s.startsWith('a')
  *   /^https?:\/\//.test(s) →  NOT flagged (contains `?` quantifier)
  *   /^[a-z]+/.test(s)      →  NOT flagged (contains `[` character class)
- *   /\.txt$/.test(s)       →  NOT flagged (contains `.` metachar)
+ *   /\.txt$/.test(s)       →  NOT flagged (`.` is a metachar; `\.` would flag)
+ *   /^\d+/.test(s)         →  NOT flagged (`\d` is a character class)
  */
 
 'use strict';
@@ -23,24 +44,103 @@
 const METACHARS = new Set(['^', '$', '+', '[', '{', '(', '.', '?', '*', '|']);
 
 /**
- * Treat `\/` as a single literal `/` and check the remainder for any
- * regex metacharacter or other backslash-escape we don't understand.
- * Returns the literal string if safely convertible, otherwise null.
+ * Escape sequences whose meaning is NOT "the character that follows the
+ * backslash": character classes (`\d`, `\w`, `\s`, `\p`), assertions (`\b`),
+ * numeric escapes and backreferences (`\0`–`\9`, `\k`), and the code-point
+ * forms (`\x`, `\u`, `\c`). `\n`, `\r`, `\t`, `\v`, `\f` ARE single literal
+ * characters, but flattening them would put a raw control character into the
+ * suggested `startsWith('…')` string, so they are rejected too.
+ *
+ * Every other escape — `\/`, `\.`, `\*`, `\+`, `\(`, `\\`, `\-` … — is an
+ * identity escape, and the character it protects is exactly what a
+ * `startsWith` comparison would look for.
+ */
+const MEANINGFUL_ESCAPE = /[0-9BDPSWbcdfknprstuvwx]/;
+
+/**
+ * Flatten a regex body to the plain string it is equivalent to.
+ *
+ * Returns the literal string if safely convertible, otherwise null. Scans
+ * character by character rather than doing a `replaceAll` of the one escape we
+ * happen to like: `\/` was accepted and `\*` was not, though both denote a
+ * single literal character and neither is a metacharacter once escaped.
  */
 function literalEquivalent(patternBody) {
-  // Step 1: collapse `\/` (the only escape we accept) into a literal `/`.
-  const flattened = patternBody.replaceAll(String.raw`\/`, '/');
-  // Step 2: any remaining `\` is an escape we don't understand (\d, \w, \\, etc.).
-  if (flattened.includes('\\')) {
-    return null;
-  }
-  // Step 3: reject any regex metacharacter we'd be silently flattening.
-  for (const ch of flattened) {
-    if (METACHARS.has(ch)) {
+  let literal = '';
+
+  for (let index = 0; index < patternBody.length; index += 1) {
+    const char = patternBody[index];
+
+    if (char === '\\') {
+      const escaped = patternBody[index + 1];
+      // A trailing lone backslash is not a valid pattern; refuse to guess.
+      if (escaped === undefined || MEANINGFUL_ESCAPE.test(escaped)) {
+        return null;
+      }
+      literal += escaped;
+      index += 1;
+      continue;
+    }
+
+    // Unescaped metacharacter: flattening it would change what matches.
+    if (METACHARS.has(char)) {
       return null;
     }
+    literal += char;
   }
-  return flattened;
+
+  return literal;
+}
+
+/**
+ * Find the variable `identifier` resolves to, searching outward from its scope.
+ */
+function findVariable(sourceCode, identifier) {
+  for (let scope = sourceCode.getScope(identifier); scope; scope = scope.upper) {
+    const found = scope.variables.find((variable) => variable.name === identifier.name);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * The regex `node` denotes: itself when it is a regex literal, or the literal
+ * a single-assignment variable was initialised with.
+ *
+ * The indirection matters because hoisting a regex to a module-level `const` is
+ * the normal way to write one — and examining only inline literals meant the
+ * rule went quiet on exactly the code most likely to run hot.
+ *
+ * Conservative on purpose: one definition, one write, and that write is a regex
+ * literal. A binding assigned more than once could hold anything by the time
+ * `.test()` runs, and nothing here proves which value that is.
+ *
+ * @returns {{pattern: string, flags: string} | null}
+ */
+function resolveRegex(sourceCode, node) {
+  if (node.type === 'Literal' && node.regex) {
+    return node.regex;
+  }
+  if (node.type !== 'Identifier') {
+    return null;
+  }
+
+  const variable = findVariable(sourceCode, node);
+  if (!variable || variable.defs.length !== 1) {
+    return null;
+  }
+  const [definition] = variable.defs;
+  if (definition.type !== 'Variable' || !definition.node.init) {
+    return null;
+  }
+  if (variable.references.filter((reference) => reference.isWrite()).length !== 1) {
+    return null;
+  }
+
+  const { init } = definition.node;
+  return init.type === 'Literal' && init.regex ? init.regex : null;
 }
 
 module.exports = {
@@ -48,21 +148,23 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        String.raw`Prefer String#startsWith / String#endsWith over /^literal/.test() — even when the literal includes \/ escape sequences`,
+        String.raw`Prefer String#startsWith / String#endsWith over /^literal/.test() — including escaped literals such as \/ and \*, and regexes held in a const`,
       recommended: true,
     },
     messages: {
       preferStartsWith:
         "Prefer `<string>.startsWith('{{literal}}')` over `/{{pattern}}/.test(<string>)`. " +
-        String.raw`Treat \/ as the literal / character.`,
+        String.raw`An escaped character such as \/ or \* is the literal character itself.`,
       preferEndsWith:
         "Prefer `<string>.endsWith('{{literal}}')` over `/{{pattern}}/.test(<string>)`. " +
-        String.raw`Treat \/ as the literal / character.`,
+        String.raw`An escaped character such as \/ or \* is the literal character itself.`,
     },
     schema: [],
   },
 
   create(context) {
+    const sourceCode = context.getSourceCode();
+
     return {
       CallExpression(node) {
         if (
@@ -72,11 +174,11 @@ module.exports = {
         ) {
           return;
         }
-        const obj = node.callee.object;
-        if (obj.type !== 'Literal' || !obj.regex) {
+        const regex = resolveRegex(sourceCode, node.callee.object);
+        if (!regex) {
           return;
         }
-        const { pattern, flags } = obj.regex;
+        const { pattern, flags } = regex;
         if (flags.includes('i') || flags.includes('m')) {
           return;
         }

--- a/packages/utils/eslint/rules/safe-import.cjs
+++ b/packages/utils/eslint/rules/safe-import.cjs
@@ -69,6 +69,28 @@ function isNameAlreadyBound(sourceCode, name) {
 }
 
 /**
+ * Insert `text` above `node`, ABOVE its leading comments.
+ *
+ * `fixer.insertTextBefore(node)` uses the node's own start offset, which is
+ * after any comment attached to it — so inserting an import before the first
+ * statement dropped it BETWEEN an `eslint-disable-next-line` and the line that
+ * directive protects. The directive then applies to the inserted import, and
+ * the statement the developer had deliberately suppressed silently becomes
+ * fixable. A fixer that can revoke a suppression is a fixer that edits code
+ * nobody asked it to touch.
+ *
+ * @param {object} fixer - ESLint rule fixer.
+ * @param {object} sourceCode - ESLint `SourceCode` for the file being fixed.
+ * @param {object} node - The node to insert above.
+ * @param {string} text - Text to insert, including its own trailing newline.
+ */
+function insertAboveWithComments(fixer, sourceCode, node, text) {
+  const comments = sourceCode.getCommentsBefore(node);
+  const start = (comments[0] ?? node).range[0];
+  return fixer.insertTextBeforeRange([start, start], text);
+}
+
+/**
  * The `safeModule` rule option: point the fixer at YOUR re-export seam.
  *
  * The narrow-subpath defaults above are right for a consumer importing this
@@ -135,6 +157,7 @@ module.exports = {
   SAFE_MODULE_ONLY_SCHEMA,
   SAFE_PATH_MODULE,
   SAFE_PROCESS_MODULE,
+  insertAboveWithComments,
   isNameAlreadyBound,
   resolveSafeModule,
   withSafeModuleOption,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "type": "module",
   "description": "Core utility functions shared across the vibe-agent-toolkit packages",
   "sideEffects": false,

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/utils",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "type": "module",
   "description": "Core utility functions shared across the vibe-agent-toolkit packages",
   "sideEffects": false,

--- a/packages/utils/test/eslint/rules.test.ts
+++ b/packages/utils/test/eslint/rules.test.ts
@@ -6,6 +6,7 @@
  * scaffolding in exactly one place.
  */
 
+import * as tsParser from '@typescript-eslint/parser';
 import { Linter, type Rule } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
@@ -195,13 +196,54 @@ function pathFunctionRuleCases(fn: 'join' | 'relative' | 'resolve'): RuleCases {
         filename: LINTED_FILE,
         options,
       },
-      // A same-named function from somewhere else is not ours. The bare-call
-      // leg keys on the name being UNBOUND, so binding it — here, or as a
-      // parameter, or as a local — is what keeps that leg from becoming a
-      // rule that flags every `join()` in the ecosystem.
-      { code: `import { ${fn} } from 'lodash'; const p = ${fn}(a, b);`, filename: LINTED_FILE, options },
-      { code: `function ${fn}(x) { return x; } const p = ${fn}(a);`, filename: LINTED_FILE, options },
-      { code: `const run = (${fn}) => ${fn}(a, b);`, filename: LINTED_FILE, options },
+      // A same-named function from somewhere else is not ours. The repair leg
+      // keys on the name being UNBOUND, so binding it — by import, declaration,
+      // or parameter — is what keeps it from flagging every `join()` in the
+      // ecosystem.
+      //
+      // EVERY case below puts the call in a DIFFERENT scope from the binding,
+      // on purpose. The first draft of these fixtures called at the same level
+      // as the binding, which meant `isIdentifierBound`'s walk up `scope.upper`
+      // never executed — an adversarial run deleted the entire walk and this
+      // suite stayed green while the mutant rewrote lodash's `join` into
+      // `safePath.join`. A scope-aware rule needs a scope-crossing fixture.
+      {
+        code: `${SAFE_IMPORT}\nimport { ${fn} } from 'lodash';\nfunction f(a, b) { return ${fn}(a, b); }`,
+        filename: LINTED_FILE,
+        options,
+      },
+      {
+        code: `${SAFE_IMPORT}\nfunction ${fn}(x) { return x; }\nfunction f(a) { return ${fn}(a); }`,
+        filename: LINTED_FILE,
+        options,
+      },
+      {
+        code: `${SAFE_IMPORT}\nexport const run = (${fn}) => () => ${fn}(a, b);`,
+        filename: LINTED_FILE,
+        options,
+      },
+      // Without `safePath` in scope the repair leg must not fire AT ALL — this
+      // is the gate that keeps ambient globals safe. ESLint scope analysis
+      // cannot see a `globals.d.ts`, an `@types` package, or a bundler-injected
+      // global, and `resolve`/`relative` are entirely plausible as those.
+      { code: `const p = ${fn}(a, b);`, filename: LINTED_FILE, options },
+      // A TYPE-ONLY specifier is not a call site. Tracking it made the fixer
+      // DELETE it, and because `typeof join` is a TYPE reference, `no-undef` —
+      // and so the fixpoint suite below — cannot see the damage.
+      //
+      // The call has to be here for this fixture to mean anything: with no call
+      // there is no report either way, and the case passes under a rule that
+      // tracks type specifiers just as happily as one that skips them.
+      {
+        code: [
+          `import { type ${fn} } from 'node:path';`,
+          `export type T = typeof ${fn};`,
+          `export const p = ${fn}(a, b);`,
+        ].join('\n'),
+        filename: LINTED_FILE,
+        options,
+        languageOptions: { parser: tsParser },
+      },
       // Files the CONSUMING config declared exempt, by their repo-relative paths.
       { code: unsafeMemberCode, filename: PATH_CORE_IMPL, options },
       { code: unsafeMemberCode, filename: `/Users/dev/vat/${PATH_UTILS_IMPL}`, options },
@@ -265,13 +307,74 @@ function pathFunctionRuleCases(fn: 'join' | 'relative' | 'resolve'): RuleCases {
         ].join('\n'),
         errors: [errors[0], errors[0]],
       },
-      // BARE, UNBOUND call — what a half-applied fix leaves behind. Detection
-      // used to require having seen the `node:path` specifier, so once a fix
-      // removed it the rule fell silent and `--fix` declared victory over source
-      // that no longer compiles. Recognising this shape is what makes a second
-      // `--fix` finish the job.
+      // BARE, UNBOUND call in a file that ALREADY has `safePath` — what a
+      // half-applied fix leaves behind. Detection used to require having seen
+      // the `node:path` specifier, so once a fix removed it the rule fell
+      // silent and `--fix` declared victory over source that no longer
+      // compiles. Recognising this shape is what makes a second `--fix` finish
+      // the job.
+      //
+      // The `safePath`-in-scope precondition is the whole difference between a
+      // repair leg and a second, worse detector: see the `declare global` and
+      // ambient-global valid cases below for what firing without it costs.
       {
-        code: `const p = ${fn}(a, b);`,
+        code: `${SAFE_IMPORT}\nconst p = ${fn}(a, b);\nconst q = safePath.${fn}(c, d);`,
+        filename: LINTED_FILE,
+        options,
+        output: `${SAFE_IMPORT}\nconst p = safePath.${fn}(a, b);\nconst q = safePath.${fn}(c, d);`,
+        errors,
+      },
+      // ALIASED specifier: rewrite the unbound `join(`, and KEEP the alias.
+      //
+      // `pathJoin(...)` is never the callee this rule matches, so tracking the
+      // specifier bought nothing — and cost the whole import. An unrelated
+      // unbound `join(` elsewhere in the file classified as "named", and the
+      // fixer removed the ALIAS, breaking every working `pathJoin` call site.
+      // The pinned output below is the proof the alias survives.
+      {
+        code: [
+          SAFE_IMPORT,
+          `import { ${fn} as aliased } from 'node:path';`,
+          'export const p = aliased(a, b);',
+          `export const q = ${fn}(c, d);`,
+        ].join('\n'),
+        filename: LINTED_FILE,
+        options,
+        output: [
+          SAFE_IMPORT,
+          `import { ${fn} as aliased } from 'node:path';`,
+          'export const p = aliased(a, b);',
+          `export const q = safePath.${fn}(c, d);`,
+        ].join('\n'),
+        errors,
+      },
+      // RE-EXPORTED specifier: rewrite the call, but KEEP the import.
+      //
+      // Removing it left `export { join }` naming nothing, and the fixed file
+      // did not PARSE — `Export 'join' is not defined`. Output that cannot be
+      // parsed is the worst result an autofix can produce, strictly worse than
+      // leaving a finding on screen, so the specifier stays and the residual is
+      // a lint message a human can read.
+      {
+        code: `import { ${fn} } from 'node:path';\nexport { ${fn} };\nconst p = ${fn}(a, b);`,
+        filename: LINTED_FILE,
+        options,
+        output: `import { ${fn} } from 'node:path';\n${SAFE_IMPORT}\nexport { ${fn} };\nconst p = safePath.${fn}(a, b);`,
+        errors,
+      },
+      // ORPHANED `safePath.join(...)` — the OTHER half of the repair, and the
+      // reason the file above can ever recover.
+      //
+      // ESLint runs `fix()` before the `eslint-disable` filter, so a suppressed
+      // report on the first call site consumes the once-per-file import edit
+      // and then discards it. Every other call becomes `safePath.join`, nothing
+      // imports `safePath`, and no report is left to carry the import on any
+      // later pass. An adversarial run produced exactly that as a STABLE
+      // fixpoint — `--fix` twice more changed nothing — against a docstring
+      // that claimed the state was transient. This leg is what makes the claim
+      // true.
+      {
+        code: `const p = safePath.${fn}(a, b);`,
         filename: LINTED_FILE,
         options,
         output: `${SAFE_IMPORT}\nconst p = safePath.${fn}(a, b);`,
@@ -347,14 +450,55 @@ const SEAM = '@acme/dev-tools/path-utils';
  * `no-path-join` stands for `path-function-rule-factory`, `no-os-tmpdir` for
  * `eslint-rule-factory`.
  */
-const PATH_FACTORY_RULE = 'no-path-join';
-const CALL_FACTORY_RULE = 'no-os-tmpdir';
+/**
+ * Rule names, named once. Several tables below enumerate the same rules from
+ * different angles (fixpoint, suppression, `safeModule`), and a rule renamed in
+ * one table and not another is a silently skipped suite, not a failure.
+ */
+const RULE = {
+  join: 'no-path-join',
+  resolve: 'no-path-resolve',
+  relative: 'no-path-relative',
+  tmpdir: 'no-os-tmpdir',
+  mkdir: 'no-fs-mkdirSync',
+  realpath: 'no-fs-realpathSync',
+  execSync: 'no-child-process-execSync',
+  cp: 'no-fs-promises-cp',
+  normalize: 'no-manual-path-normalize',
+} as const;
 
-function safeModuleCases(unsafeCode: string, fixedCode: string, errors: object[]): RuleCases {
+const NODE_FS = 'node:fs';
+const NODE_CHILD_PROCESS = 'node:child_process';
+
+/** `import { name } from 'module';` — spelled once, so the tables stay readable. */
+function namedImport(name: string, module: string): string {
+  return `import { ${name} } from '${module}';`;
+}
+
+const PATH_FACTORY_RULE = RULE.join;
+const CALL_FACTORY_RULE = RULE.tmpdir;
+
+/**
+ * @param unsafeCode - The shape that must report.
+ * @param fixedCode - What ONE `--fix` pass produces from it.
+ * @param errors - The expected reports.
+ * @param settledCode - The shape that must NOT report, when it differs from
+ *   `fixedCode`. One pass rewrites the call and leaves the now-unused `node:*`
+ *   binding for the pass after — so for the rules that migrate a NAMESPACE
+ *   member, the one-pass output is a legitimate finding (`deadUnsafeImport`) and
+ *   cannot double as the valid fixture. Conflating the two is how a suite ends
+ *   up asserting that a half-finished fix is the finished state.
+ */
+function safeModuleCases(
+  unsafeCode: string,
+  fixedCode: string,
+  errors: object[],
+  settledCode: string = fixedCode,
+): RuleCases {
   return {
     valid: [
       // Already importing from the configured seam — nothing to add.
-      { code: fixedCode, filename: LINTED_FILE, options: [{ safeModule: SEAM }] },
+      { code: settledCode, filename: LINTED_FILE, options: [{ safeModule: SEAM }] },
     ],
     invalid: [
       {
@@ -572,7 +716,12 @@ function unsafeCallRuleCases(
   { unsafeFn, unsafeModule, safeFn, safeModule, exemptPath }: UnsafeCallRuleSpec,
 ): RuleCases {
   const unsafeCode = `import { ${unsafeFn} } from '${unsafeModule}';\nconst r = ${unsafeFn}(x);`;
-  const output = `import { ${safeFn} } from '${safeModule}';\n\nconst r = ${safeFn}(x);`;
+  // The new import takes the removed one's LINE. It used to be welded onto
+  // whatever followed, because the fixer inserted after `body[0]` with a
+  // trailing newline regardless of what `body[0]` was — visible here only as a
+  // moved `\n`, and visible in a file whose first statement is not an import as
+  // `const os = {…};import { normalizedTmpdir } from '…';` on one line.
+  const output = `\nimport { ${safeFn} } from '${safeModule}';\nconst r = ${safeFn}(x);`;
   const errors = [{ messageId: 'noUnsafeOperation' }];
   const options = [{ exemptFiles: [exemptPath] }];
   const decoy = (filename: string) => ({ code: unsafeCode, filename, options, output, errors });
@@ -587,6 +736,26 @@ function unsafeCallRuleCases(
       },
       { code: unsafeCode, filename: exemptPath, options },
       { code: unsafeCode, filename: `/Users/dev/vat/${exemptPath}`, options },
+      // A same-named method on an unrelated object is not this module's call.
+      // The member branch used to match on the property name ALONE, so any
+      // `env.tmpdir()` was an `os.tmpdir()` finding. That was survivable while
+      // the fixer rewrote only the property — `env.normalizedTmpdir()` does not
+      // compile, so the false positive announced itself. Replacing the whole
+      // callee turned it into `normalizedTmpdir()`, which compiles, type-checks
+      // and passes `no-undef` while silently calling a different function with
+      // the receiver thrown away. A false positive that produces WORKING code
+      // is the more dangerous kind, so the receiver is now checked.
+      {
+        code: `const env = { ${unsafeFn}: () => 'x' };\nexport const r = env.${unsafeFn}();`,
+        filename: LINTED_FILE,
+        options,
+      },
+      {
+        code: `interface Env { ${unsafeFn}(): string }\nexport function pick(env: Env) { return env.${unsafeFn}(); }`,
+        filename: LINTED_FILE,
+        options,
+        languageOptions: { parser: tsParser },
+      },
     ],
     invalid: [
       { code: unsafeCode, filename: LINTED_FILE, options, output, errors },
@@ -646,8 +815,8 @@ const SUITES: readonly RuleSuite[] = [
   { name: 'require-justified-skip', cases: REQUIRE_JUSTIFIED_SKIP_CASES },
   { name: 'no-unix-shell-commands', cases: NO_UNIX_SHELL_COMMANDS_CASES },
   { name: PATH_FACTORY_RULE, cases: pathFunctionRuleCases('join') },
-  { name: 'no-path-resolve', cases: pathFunctionRuleCases('resolve') },
-  { name: 'no-path-relative', cases: pathFunctionRuleCases('relative') },
+  { name: RULE.resolve, cases: pathFunctionRuleCases('resolve') },
+  { name: RULE.relative, cases: pathFunctionRuleCases('relative') },
   {
     name: CALL_FACTORY_RULE,
     cases: unsafeCallRuleCases({
@@ -673,7 +842,7 @@ const SUITES: readonly RuleSuite[] = [
     name: 'no-child-process-execSync',
     cases: unsafeCallRuleCases({
       unsafeFn: 'execSync',
-      unsafeModule: 'node:child_process',
+      unsafeModule: NODE_CHILD_PROCESS,
       safeFn: 'safeExecSync',
       safeModule: '@vibe-agent-toolkit/utils/process',
       exemptPath: 'packages/utils/src/safe-exec.ts',
@@ -687,13 +856,15 @@ const SUITES: readonly RuleSuite[] = [
       "import path from 'node:path';\nconst p = path.join(a, b);",
       `import path from 'node:path';\nimport { safePath } from '${SEAM}';\nconst p = safePath.join(a, b);`,
       [{ messageId: 'noUnsafePathFn' }],
+      // Pass 2 takes the orphaned `path` binding with it; THIS is settled.
+      `import { safePath } from '${SEAM}';\nconst p = safePath.join(a, b);`,
     ),
   },
   {
     name: CALL_FACTORY_RULE,
     cases: safeModuleCases(
       "import { tmpdir } from 'node:os';\nconst r = tmpdir();",
-      `import { normalizedTmpdir } from '${SEAM}';\n\nconst r = normalizedTmpdir();`,
+      `\nimport { normalizedTmpdir } from '${SEAM}';\nconst r = normalizedTmpdir();`,
       [{ messageId: 'noUnsafeOperation' }],
     ),
   },
@@ -820,7 +991,7 @@ const SAFE_MODULE_RULE_TRIGGERS: Record<string, string> = {
   'no-fs-mkdirSync': "import { mkdirSync } from 'node:fs';\nmkdirSync(d, { recursive: true });",
   'no-fs-realpathSync': "import { realpathSync } from 'node:fs';\nconst r = realpathSync(p);",
   'no-fs-promises-cp': "import { cp } from 'node:fs/promises';\nawait cp(a, b);",
-  'no-child-process-execSync': "import { execSync } from 'node:child_process';\nexecSync('ls');",
+  [RULE.execSync]: `${namedImport('execSync', NODE_CHILD_PROCESS)}\nexecSync('ls');`,
   'no-url-pathname-for-fs': "const p = new URL('../fixtures/x.yaml', import.meta.url).pathname;",
   'no-bare-dynamic-import-path': 'const m = await import(configPath);',
 };
@@ -898,16 +1069,16 @@ const REWRITE_SITES = 4;
 
 /** `[rule, importLine, callExpression]` — a source is synthesized per row. */
 const MULTI_SITE_REWRITES: Array<[string, string, string]> = [
-  ['no-path-join', "import { join } from 'node:path';", 'join(a, b)'],
-  ['no-path-resolve', "import { resolve } from 'node:path';", 'resolve(a, b)'],
-  ['no-path-relative', "import { relative } from 'node:path';", 'relative(a, b)'],
-  ['no-os-tmpdir', "import { tmpdir } from 'node:os';", 'tmpdir()'],
-  ['no-fs-mkdirSync', "import { mkdirSync } from 'node:fs';", 'mkdirSync(a)'],
-  ['no-fs-realpathSync', "import { realpathSync } from 'node:fs';", 'realpathSync(a)'],
-  ['no-child-process-execSync', "import { execSync } from 'node:child_process';", 'execSync(a)'],
-  ['no-fs-promises-cp', "import { cp } from 'node:fs/promises';", 'cp(a, b)'],
+  [RULE.join, namedImport('join', 'node:path'), 'join(a, b)'],
+  [RULE.resolve, namedImport('resolve', 'node:path'), 'resolve(a, b)'],
+  [RULE.relative, namedImport('relative', 'node:path'), 'relative(a, b)'],
+  [RULE.tmpdir, namedImport('tmpdir', 'node:os'), 'tmpdir()'],
+  [RULE.mkdir, namedImport('mkdirSync', NODE_FS), 'mkdirSync(a)'],
+  [RULE.realpath, namedImport('realpathSync', NODE_FS), 'realpathSync(a)'],
+  [RULE.execSync, namedImport('execSync', NODE_CHILD_PROCESS), 'execSync(a)'],
+  [RULE.cp, namedImport('cp', 'node:fs/promises'), 'cp(a, b)'],
   // No import to remove — the import INSERT alone spans the file.
-  ['no-manual-path-normalize', '', String.raw`a.split('\\').join('/')`],
+  [RULE.normalize, '', String.raw`a.split('\\').join('/')`],
 ];
 
 function multiSiteSource(importLine: string, call: string): string {
@@ -931,8 +1102,14 @@ describe('autofix leaves no dangling reference', () => {
     // Membership, not cardinality — a rule added to the pack without a row here
     // is a rule whose fixer nobody runs to a fixpoint.
     const byName = (a: string, b: string): number => a.localeCompare(b);
+    // `!= null`, NOT `=== 'code'`. ESLint accepts `fixable: 'whitespace'` for a
+    // rule that rewrites callees and inserts imports — verified by running one —
+    // so keying on `'code'` leaves a rule that is fully fixable, absent from
+    // this list, and absent from MULTI_SITE_REWRITES. `toStrictEqual` passes on
+    // two matching omissions, which is the shape of a gate that measures
+    // nothing. (Omitting `fixable` entirely is NOT a hole: ESLint throws.)
     const fixable = Object.entries(plugin.rules)
-      .filter(([, rule]) => rule.meta?.fixable === 'code')
+      .filter(([, rule]) => rule.meta?.fixable != null)
       .map(([name]) => name);
     expect(MULTI_SITE_REWRITES.map(([name]) => name).sort(byName)).toStrictEqual(
       [...fixable].sort(byName),
@@ -999,5 +1176,662 @@ describe('autofix leaves no dangling reference', () => {
     // the code it settled on references an identifier that is no longer bound.
     expect(unboundIn(output)).toStrictEqual([]);
     expect(new Linter().verify(output, config, { filename: LINTED_FILE })).toStrictEqual([]);
+  });
+});
+
+/**
+ * `prefer-startswith-over-regex` emits SOURCE, so its message IS the deliverable.
+ *
+ * The rule has no fixer: nothing downstream re-escapes what it prints, and a
+ * developer applies the advice by hand. So the literal it names must (a) parse
+ * as a JS string and (b) denote exactly the characters the regex matches.
+ * Neither held, and no fixture covered either.
+ */
+const PREFIX_ADVICE = /startsWith\((.*)\)` over/;
+const SUFFIX_ADVICE = /endsWith\((.*)\)` over/;
+
+/** The literal the message tells a developer to write, decoded as JS would. */
+function advisedLiteral(message: string | undefined): string {
+  const text = message ?? '';
+  const match = PREFIX_ADVICE.exec(text) ?? SUFFIX_ADVICE.exec(text);
+  if (!match?.[1]) {
+    throw new Error(`no advice found in: ${text}`);
+  }
+  // `JSON.parse` accepts exactly the escapes a JS string literal does for the
+  // shapes this rule emits — and THROWS on the un-escaped text it used to
+  // produce, which is the point.
+  return JSON.parse(match[1]) as string;
+}
+
+describe('prefer-startswith-over-regex advice is valid, faithful JavaScript', () => {
+  const rule = loadLocalRule('prefer-startswith-over-regex.cjs');
+  const lint = (code: string): string[] =>
+    new Linter()
+      .verify(
+        code,
+        [
+          {
+            files: ['**/*.ts'],
+            plugins: { local: { rules: { r: rule } } },
+            rules: { 'local/r': 'error' },
+            languageOptions: { ecmaVersion: 2024, sourceType: 'module' },
+          },
+        ],
+        { filename: LINTED_FILE },
+      )
+      .map(({ message }) => message);
+
+  /**
+   * `[source, the characters the regex actually matches]`.
+   *
+   * Every row turns on a backslash or a quote — the two things that mean one
+   * thing to a regex and another to a JS string literal. `/^C:\\Users/` matches
+   * `C:\Users`; the rule printed `startsWith('C:\Users')`, which JavaScript
+   * reads back as `"C:Users"`. The UNC row is the one that bites in production:
+   * `startsWith('\\')` is ONE backslash, so a `\\`-prefix check silently
+   * becomes true for every single-backslash path.
+   */
+  const FAITHFUL_ADVICE: Array<[string, string]> = [
+    [String.raw`/^C:\\Users/`, String.raw`C:\Users`],
+    [String.raw`/^\\\\/`, '\\\\'],
+    [String.raw`/^a\\nb/`, String.raw`a\nb`],
+    [String.raw`/^a\\x41/`, String.raw`a\x41`],
+    [String.raw`/\\nb$/`, String.raw`\nb`],
+    ["/^don't/", "don't"],
+    [String.raw`/^don\'t/`, "don't"],
+    [String.raw`/^\*glob/`, '*glob'],
+    [String.raw`/^file:\/\//`, 'file://'],
+  ];
+
+  it.each(FAITHFUL_ADVICE)('%s advises the exact characters it matches', (source, expected) => {
+    const messages = lint(`export const f = (s) => ${source}.test(s);`);
+    expect(messages).toHaveLength(1);
+    // Parses as JS…
+    const advised = advisedLiteral(messages[0]);
+    // …and denotes the same characters the regex does.
+    expect(advised).toBe(expected);
+  });
+
+  it.each(FAITHFUL_ADVICE)('%s advice agrees with the regex on real strings', (source, expected) => {
+    // `source` is a fixture literal declared in FAITHFUL_ADVICE above; rebuilding it here is what
+    // lets one row drive both the lint fixture and the semantics check, so the two cannot drift
+    // apart. (The directive must sit on the line immediately before the call — a run of `//`
+    // comments is a run of separate comments, so a directive above them targets only the next
+    // comment line and is silently unused.)
+    // eslint-disable-next-line security/detect-non-literal-regexp -- fixture literal, never input
+    const regex = new RegExp(source.slice(1, source.lastIndexOf('/')));
+    const atStart = regex.source.startsWith('^');
+    const probes = [expected, `${expected}TAIL`, `HEAD${expected}`, expected.slice(1), '', 'unrelated'];
+    for (const probe of probes) {
+      const viaAdvice = atStart ? probe.startsWith(expected) : probe.endsWith(expected);
+      expect({ probe, matched: regex.test(probe) }).toStrictEqual({ probe, matched: viaAdvice });
+    }
+  });
+
+  /**
+   * `g`/`y` make `.test()` stateful through `lastIndex`. A regex LITERAL is
+   * rebuilt on every evaluation so its cursor is always 0; a hoisted `const` is
+   * one object that remembers. Resolving through a binding is therefore exactly
+   * what makes the advice wrong — and exactly what this rule newly does.
+   */
+  it.each(['g', 'y', 'gy'])('stays silent on a const-held regex with the %s flag', (flags) => {
+    expect(lint(`const RE = /^abc/${flags};\nexport const f = (s) => RE.test(s);`)).toStrictEqual([]);
+  });
+
+  it('demonstrates the divergence the g-flag guard prevents', () => {
+    const held = /^abc/g;
+    expect([1, 2, 3, 4].map(() => held.test('abcdef'))).toStrictEqual([true, false, true, false]);
+    expect([1, 2, 3, 4].map(() => 'abcdef'.startsWith('abc'))).toStrictEqual([true, true, true, true]);
+  });
+
+  it('still fires on an INLINE regex with g — the literal is rebuilt, so lastIndex is always 0', () => {
+    expect(lint('export const f = (s) => /^abc/g.test(s);')).toHaveLength(1);
+    // The regex literal below is the SUBJECT, not a style slip. `--fix` rewrote
+    // it to `'abcdef'.startsWith('abc')` — via this very rule and unicorn's —
+    // which left the assertion comparing `startsWith` to `startsWith` and
+    // passing vacuously. Exactly the class of defect this file exists to catch,
+    // committed against the file itself.
+    /* eslint-disable local/prefer-startswith-over-regex, unicorn/prefer-string-starts-ends-with -- the inline literal IS the assertion */
+    expect([1, 2, 3, 4].map(() => /^abc/g.test('abcdef'))).toStrictEqual([true, true, true, true]);
+    /* eslint-enable local/prefer-startswith-over-regex, unicorn/prefer-string-starts-ends-with */
+  });
+
+  it('renders the flags, so a reader can see what the advice rests on', () => {
+    expect(lint('export const f = (s) => /^abc/s.test(s);')[0]).toContain('/^abc/s.test(');
+  });
+
+  it('needs exactly one argument', () => {
+    expect(lint('export const f = () => /^abc/.test();')).toStrictEqual([]);
+    expect(lint('export const f = (s) => /^abc/.test(s, 1);')).toStrictEqual([]);
+  });
+
+  /**
+   * MEMBERSHIP of the bail class, pinned character by character.
+   *
+   * An adversarial run dropped 12 of the 22 characters and this suite stayed
+   * green — only 7 were named by any fixture. Under that mutant `/^\sfoo/`
+   * advised `startsWith('sfoo')`. Both directions are asserted here, so neither
+   * a narrowing nor a widening can pass unremarked.
+   */
+  const MEANINGFUL = [...'0123456789BDPSWbcdfknprstuvwx'];
+  const IDENTITY = [...'AaEeGgHhIiJjLlMmOoQqRrTtYyZz'].filter((char) => !MEANINGFUL.includes(char));
+
+  it.each(MEANINGFUL)(String.raw`\%s means something other than the character, so it bails`, (char) => {
+    expect(lint(`export const f = (s) => /^\\${char}tail/.test(s);`)).toStrictEqual([]);
+  });
+
+  it.each(IDENTITY)(String.raw`\%s is an identity escape, so it flattens`, (char) => {
+    const messages = lint(`export const f = (s) => /^\\${char}tail/.test(s);`);
+    expect(messages).toHaveLength(1);
+    expect(advisedLiteral(messages[0])).toBe(`${char}tail`);
+  });
+});
+
+/**
+ * A SUPPRESSED report still consumes the once-per-file import edit.
+ *
+ * ESLint runs a rule's `fix()` before the `eslint-disable` filter discards the
+ * problem, so `buildFix`'s "emit the shared edits once" guard is spent by a
+ * report that is then thrown away. Every other call site is rewritten to
+ * `safePath.join(...)`, nothing imports `safePath`, and — until the repair leg
+ * existed — no report survived to carry the import on any later pass.
+ *
+ * An adversarial run measured that as a STABLE fixpoint: `--fix` twice more
+ * changed nothing, lint reported zero problems, and the file did not compile.
+ * The docstring at the time claimed the state was transient. It was not. This
+ * test is the claim, executed rather than asserted.
+ */
+describe('a suppressed first report does not strand the file', () => {
+  const languageOptions = { ecmaVersion: 2024, sourceType: 'module' } as const;
+  const config = (name: string) => [
+    {
+      files: ['**/*.ts'],
+      plugins: {
+        local: {
+          rules: { [name]: loadLocalRule(`${name}.cjs`) },
+        },
+      },
+      rules: { [`local/${name}`]: 'error' as const },
+      languageOptions,
+    },
+  ];
+
+  /**
+   * The rule must still be DEFINED here even though it is switched off — an
+   * `eslint-disable` naming a rule the config does not know reports "Definition
+   * for rule … was not found", and that lands in the same message list as the
+   * `no-undef` findings this is reading. The first draft of this helper omitted
+   * it and produced a failure that looked exactly like a dangling identifier.
+   */
+  const unboundIn = (name: string, code: string): string[] =>
+    new Linter()
+      .verify(
+        code,
+        [
+          {
+            files: ['**/*.ts'],
+            plugins: { local: { rules: { [name]: loadLocalRule(`${name}.cjs`) } } },
+            rules: { 'no-undef': 'error', [`local/${name}`]: 'off' },
+            // With the rule switched off its disable directive becomes
+            // "unused", and ESLint 9 warns about that by default — into the
+            // same message list this is reading for dangling identifiers.
+            linterOptions: { reportUnusedDisableDirectives: 'off' },
+            languageOptions,
+          },
+        ],
+        { filename: LINTED_FILE },
+      )
+      .map(({ message }) => message);
+
+  it.each([
+    [RULE.join, 'join'],
+    [RULE.resolve, 'resolve'],
+    [RULE.relative, 'relative'],
+  ])('%s converges to compiling source with the first call site disabled', (name, fn) => {
+    const source = [
+      `import { ${fn} } from 'node:path';`,
+      `// eslint-disable-next-line local/${name}`,
+      `export const a = ${fn}('1', '2');`,
+      `export const b = ${fn}('3', '4');`,
+      `export const c = ${fn}('5', '6');`,
+    ].join('\n');
+    const cfg = config(name);
+
+    // Negative control: the disable really does suppress one of four reports.
+    expect(new Linter().verify(source, cfg, { filename: LINTED_FILE })).toHaveLength(2);
+    expect(unboundIn(name, source)).toStrictEqual([]);
+
+    const { output } = new Linter().verifyAndFix(source, cfg, { filename: LINTED_FILE });
+
+    // The whole point: no dangling `safePath`, and no dangling `join`.
+    expect(unboundIn(name, output)).toStrictEqual([]);
+    // The suppressed call is left ALONE — it still reads `join(...)`, which is
+    // why the `node:path` specifier must survive alongside it.
+    expect(output).toContain(`export const a = ${fn}('1', '2');`);
+    expect(output).toContain(`import { ${fn} } from 'node:path';`);
+    expect(output).toContain(`export const b = safePath.${fn}('3', '4');`);
+  });
+
+  it('recovers a file that a partial fix already stranded', () => {
+    // Exactly the broken output the old code produced and then declared clean.
+    const stranded = [
+      "import { join } from 'node:path';",
+      "export const a = join('1', '2');",
+      "export const b = safePath.join('3', '4');",
+    ].join('\n');
+    const cfg = config(RULE.join);
+
+    expect(unboundIn(RULE.join, stranded)).toStrictEqual(["'safePath' is not defined."]);
+
+    const { output } = new Linter().verifyAndFix(stranded, cfg, { filename: LINTED_FILE });
+    expect(unboundIn(RULE.join, output)).toStrictEqual([]);
+    expect(new Linter().verify(output, cfg, { filename: LINTED_FILE })).toStrictEqual([]);
+  });
+});
+
+/**
+ * The same suppression hazard, across every OTHER import-inserting rule.
+ *
+ * These rules do not key detection on the import, so they recover across passes
+ * on their own — but only because no `fix()` latches a once-per-file flag. This
+ * suite is what stops one being re-introduced: a latch here has no repair leg
+ * behind it, and the file would simply stay broken.
+ */
+const SUPPRESSION_CASES: Array<[string, string, string]> = [
+  [RULE.tmpdir, namedImport('tmpdir', 'node:os'), 'tmpdir()'],
+  [RULE.mkdir, namedImport('mkdirSync', NODE_FS), "mkdirSync('/d')"],
+  [RULE.realpath, namedImport('realpathSync', NODE_FS), "realpathSync('/p')"],
+  [RULE.execSync, namedImport('execSync', NODE_CHILD_PROCESS), "execSync('ls')"],
+  [RULE.cp, namedImport('cp', 'node:fs/promises'), "cp('a', 'b')"],
+  [RULE.normalize, '', String.raw`'x'.split('\\').join('/')`],
+];
+
+describe('a suppressed first report strands no other rule either', () => {
+  const languageOptions = { ecmaVersion: 2024, sourceType: 'module' } as const;
+
+  it.each(SUPPRESSION_CASES)('%s', (name, importLine, call) => {
+    const rule = loadLocalRule(`${name}.cjs`);
+    const source = [
+      importLine,
+      `// eslint-disable-next-line local/${name}`,
+      `export const a = ${call};`,
+      `export const b = ${call};`,
+      `export const c = ${call};`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const base = { files: ['**/*.ts'], plugins: { local: { rules: { [name]: rule } } }, languageOptions };
+    const cfg = [{ ...base, rules: { [`local/${name}`]: 'error' as const } }];
+    const undefCfg = [
+      {
+        ...base,
+        rules: { 'no-undef': 'error' as const, [`local/${name}`]: 'off' as const },
+        linterOptions: { reportUnusedDisableDirectives: 'off' as const },
+      },
+    ];
+    const unbound = (code: string): string[] =>
+      new Linter().verify(code, undefCfg, { filename: LINTED_FILE }).map(({ message }) => message);
+
+    // Negative control: one of three reports really is suppressed.
+    expect(new Linter().verify(source, cfg, { filename: LINTED_FILE })).toHaveLength(2);
+    expect(unbound(source)).toStrictEqual([]);
+
+    const { output } = new Linter().verifyAndFix(source, cfg, { filename: LINTED_FILE });
+    expect(unbound(output)).toStrictEqual([]);
+    // The suppressed call is untouched, so whatever it needs must survive.
+    expect(output).toContain(`export const a = ${call};`);
+  });
+});
+
+/**
+ * The binding the fixer itself orphaned, and the binding forms it can see.
+ *
+ * Both suites below close gaps an adopter measured on the rc.2 tarball, over
+ * 4,963 tracked source files. They share one config helper because the two are
+ * the same rule invocation seen from two ends: what the fixer LEAVES BEHIND, and
+ * what it can RECOGNISE in the first place.
+ */
+describe('bindings the fixer consumes and the bindings it can see', () => {
+  const languageOptions = { ecmaVersion: 2024, sourceType: 'module' } as const;
+
+  const configFor = (name: string, options?: object) => [
+    {
+      files: ['**/*.ts'],
+      plugins: { local: { rules: { [name]: loadLocalRule(`${name}.cjs`) } } },
+      rules: { [`local/${name}`]: (options ? ['error', options] : 'error') as 'error' },
+      languageOptions,
+    },
+  ];
+
+  const lint = (name: string, code: string): Linter.LintMessage[] =>
+    new Linter().verify(code, configFor(name), { filename: LINTED_FILE });
+
+  const fix = (name: string, code: string): string =>
+    new Linter().verifyAndFix(code, configFor(name), { filename: LINTED_FILE }).output;
+
+  /**
+   * The adopter's gate, restated as an assertion.
+   *
+   * Their repo lints at `--max-warnings=0`. After `--fix` converged over ~5,100
+   * sites, **536 errors survived across 232 files** — every one of them the same
+   * class, the now-unused `node:path` binding, split 289 `no-unused-vars` /
+   * 247 `sonarjs/unused-import`. So the fixed output did not lint clean, and the
+   * migration was not complete. Core `no-unused-vars` is the same question in
+   * one rule, and it is the only assertion here that would have caught it: the
+   * `no-undef` fixpoint check above is blind, because a dead import leaves
+   * nothing DANGLING — it leaves something SPARE.
+   *
+   * Neither ecosystem rule can fix this for us: `@typescript-eslint/no-unused-vars`
+   * declares `meta.fixable: 'code'` and yet emits only a SUGGESTION for an unused
+   * import, and `--fix` never applies suggestions. Verified with both rules
+   * enabled in a single `verifyAndFix`; the import survived.
+   */
+  const unusedIn = (code: string): string[] =>
+    new Linter()
+      .verify(code, [{ files: ['**/*.ts'], rules: { 'no-unused-vars': 'error' }, languageOptions }], {
+        filename: LINTED_FILE,
+      })
+      .map(({ message }) => message);
+
+  const DEFAULT_IMPORT = 'default import';
+  const NAMESPACE_IMPORT = 'namespace import';
+
+  describe('--fix removes the import binding it just orphaned', () => {
+    /** `[rule, label, source]` — every source is fully migrated by one pass. */
+    const DEAD_AFTER_FIX: Array<[string, string, string]> = [
+      [RULE.join, DEFAULT_IMPORT, `${PATH_NAMESPACE_IMPORT}\nexport const p = path.join('a', 'b');`],
+      [RULE.join, NAMESPACE_IMPORT, "import * as path from 'node:path';\nexport const p = path.join('a', 'b');"],
+      [RULE.resolve, DEFAULT_IMPORT, `${PATH_NAMESPACE_IMPORT}\nexport const p = path.resolve('a', 'b');`],
+      [RULE.relative, DEFAULT_IMPORT, `${PATH_NAMESPACE_IMPORT}\nexport const p = path.relative('a', 'b');`],
+      [RULE.tmpdir, DEFAULT_IMPORT, "import os from 'node:os';\nexport const t = os.tmpdir();"],
+      [RULE.tmpdir, NAMESPACE_IMPORT, "import * as os from 'node:os';\nexport const t = os.tmpdir();"],
+      // `path.sep` is a member reference like any other, and `toForwardSlash`
+      // consumes the last one. This rule never tracked the path import at all.
+      [
+        RULE.normalize,
+        'path.sep consumed by toForwardSlash',
+        `${PATH_NAMESPACE_IMPORT}\nconst raw = 'a\\\\b';\nexport const n = raw.split(path.sep).join('/');`,
+      ],
+    ];
+
+    it.each(DEAD_AFTER_FIX)('%s (%s)', (name, _label, source) => {
+      // Negative controls: the source must provoke the rule, and must not
+      // already be carrying the very finding this test looks for afterwards.
+      expect(lint(name, source).length).toBeGreaterThan(0);
+      expect(unusedIn(source)).toStrictEqual([]);
+
+      const output = fix(name, source);
+
+      expect(unusedIn(output)).toStrictEqual([]);
+      expect(output).not.toMatch(/from 'node:(path|os)'/);
+      // …and the fixpoint still holds: nothing left to report.
+      expect(lint(name, output)).toStrictEqual([]);
+    });
+
+    /**
+     * `[rule, label, source]` — every source ends the pass with a `node:*`
+     * import that must SURVIVE. Each row disables a different guard.
+     */
+    const IMPORT_MUST_SURVIVE: Array<[string, string, string]> = [
+      // Only the all-members-migrated case is dead. This is the case the
+      // adopter confirmed already worked, kept here so a wider "just delete it"
+      // cannot pass.
+      [
+        RULE.join,
+        'another member still uses the binding',
+        `${PATH_NAMESPACE_IMPORT}\nexport const p = path.join('a', 'b');\nexport const d = path.dirname(p);`,
+      ],
+      // A bare side-effect import declares no bindings, so "every binding is
+      // dead" is vacuously true. Deleting it is an edit nobody asked for, and
+      // `node:path`'s freedom from side effects is not the point — the author's
+      // intent is unreadable.
+      [RULE.join, 'bare side-effect import', `import 'node:path';\n${SAFE_IMPORT}\nexport const p = safePath.join('a', 'b');`],
+      // EVERY binding must be dead, not merely one of them. A single-specifier
+      // fixture cannot tell `every` from `some` — both answer the same for one
+      // variable — so the declaration here has to carry two.
+      [
+        RULE.join,
+        'a second specifier on the same declaration is still live',
+        "import path, { sep } from 'node:path';\nexport const p = path.join('a', 'b');\nexport const s = sep;",
+      ],
+      // The gate that keeps this a REPAIR leg rather than a general
+      // unused-import rule: with nothing from the safe module in scope, this
+      // fixer never ran here, so the dead import is somebody else's business.
+      [RULE.join, 'file was never migrated', `${PATH_NAMESPACE_IMPORT}\nexport const x = 1;`],
+    ];
+
+    it.each(IMPORT_MUST_SURVIVE)('%s keeps the import when %s', (name, _label, source) => {
+      const output = fix(name, source);
+      expect(output).toContain("'node:path'");
+      expect(lint(name, output)).toStrictEqual([]);
+    });
+
+    /**
+     * Type-only specifiers, which have no references by construction.
+     *
+     * A `type` binding exists only for the type checker, so scope analysis
+     * reports zero references for one that IS used — `no-undef` and
+     * `no-unused-vars` are equally blind to the damage, because the reference it
+     * breaks is a TYPE reference. Round 2 learned this by deleting them.
+     */
+    it.each([
+      ['declaration-level', "import type { PlatformPath } from 'node:path';"],
+      ['specifier-level', "import { type PlatformPath } from 'node:path';"],
+    ])('%s type-only imports are never removed', (_label, typeImport) => {
+      const source = [SAFE_IMPORT, typeImport, "export const p = safePath.join('a', 'b');"].join('\n');
+      const config = [
+        {
+          files: ['**/*.ts'],
+          plugins: { local: { rules: { [RULE.join]: loadLocalRule(`${RULE.join}.cjs`) } } },
+          rules: { [`local/${RULE.join}`]: 'error' as const },
+          languageOptions: { parser: tsParser },
+        },
+      ];
+      const { output } = new Linter().verifyAndFix(source, config, { filename: LINTED_FILE });
+      expect(output).toContain(typeImport);
+    });
+  });
+
+  /**
+   * How the unsafe namespace got bound.
+   *
+   * rc.1 matched ANY receiver, so it "detected" these shapes only as a side
+   * effect of the defect that also produced `os.normalizedTmpdir()` — and it
+   * reported `const os = { tmpdir(){} }` and `env.tmpdir()` as findings it would
+   * have rewritten into a call on the wrong function. rc.2 checks the receiver
+   * and correctly rejects both, but only recognised a static `import`. Whole-
+   * callee replacement is safe however the binding was made, so the two other
+   * binding forms belong in the same set — and the false positives must stay
+   * rejected, which is what the negative rows below pin.
+   */
+  describe('a namespace bound by require() or a dynamic import is still a namespace', () => {
+    const DYNAMIC = "export async function f() {\n  const os = await import('node:os');\n  return os.tmpdir();\n}";
+    const REQUIRED = "const os = require('node:os');\nexport function f() { return os.tmpdir(); }";
+
+    it.each([
+      ['await import()', DYNAMIC],
+      ['require()', REQUIRED],
+    ])('%s is reported and rewritten to a free call', (_label, source) => {
+      expect(lint(RULE.tmpdir, source)).toHaveLength(1);
+
+      const output = fix(RULE.tmpdir, source);
+      // The defect the receiver check exists to prevent: a member call on a
+      // namespace that has no such member. It compiles and it throws.
+      expect(output).not.toMatch(/\bos\s*\.\s*normalizedTmpdir\b/);
+      expect(output).toMatch(/(?<![.\w])normalizedTmpdir\(\)/);
+      expect(lint(RULE.tmpdir, output)).toStrictEqual([]);
+    });
+
+    it.each([
+      ['an unrelated object literal', "const os = { tmpdir: () => '/t' };\nexport function f() { return os.tmpdir(); }"],
+      ['the same method on another receiver', "const env = { tmpdir: () => '/t' };\nexport function f() { return env.tmpdir(); }"],
+      [
+        'a dynamic import of a different module',
+        "export async function f() {\n  const os = await import('node:util');\n  return os.tmpdir();\n}",
+      ],
+      ['a require() of a different module', "const os = require('node:util');\nexport function f() { return os.tmpdir(); }"],
+      // Not every one-argument call that is handed a module name IS `require`.
+      // Without the callee-name check this reports, and the fix would rewrite a
+      // call on somebody else's object into a free function.
+      ['a call that merely looks like require()', "const os = notRequire('node:os');\nexport function f() { return os.tmpdir(); }"],
+    ])('%s is not a finding', (_label, source) => {
+      expect(lint(RULE.tmpdir, source)).toStrictEqual([]);
+    });
+  });
+
+  /**
+   * The gate stays readable from the SOURCE, never from a flag `fix()` can flip.
+   *
+   * ESLint runs a rule's `fix()` for a suppressed problem BEFORE the
+   * `eslint-disable` filter discards it. So any mutable "have I added the safe
+   * import?" flag is already `true` — and lying — by the time `Program:exit`
+   * runs, and a dead-import leg reading it would delete an import in a file
+   * nothing was actually migrated in. Both factories therefore snapshot the
+   * answer at `create()` time; these are the fixtures that tell the two apart.
+   *
+   * Two imports of the same module, deliberately. The suppressed call keeps its
+   * OWN binding referenced, so a single-import file cannot express the state
+   * this guards — a live report whose `fix()` flips the flag, and a dead binding
+   * sitting beside it in the same pass. The second (unused) import supplies it.
+   */
+  it.each([
+    [
+      RULE.join,
+      [
+        "import legacy from 'path';",
+        PATH_NAMESPACE_IMPORT,
+        `// eslint-disable-next-line local/${RULE.join}`,
+        "export const a = path.join('1', '2');",
+      ].join('\n'),
+    ],
+    [
+      RULE.tmpdir,
+      [
+        "import legacy from 'os';",
+        "import os from 'node:os';",
+        `// eslint-disable-next-line local/${RULE.tmpdir}`,
+        'export const a = os.tmpdir();',
+      ].join('\n'),
+    ],
+  ])('%s: a suppressed report cannot arm the dead-import leg', (name, source) => {
+    // The rule's only report is suppressed, so nothing at all is left — in
+    // particular not a `deadUnsafeImport` that the discarded report enabled.
+    expect(lint(name, source)).toStrictEqual([]);
+    expect(fix(name, source)).toBe(source);
+  });
+
+  /**
+   * The configuration an adopter actually runs: the whole pack at once.
+   *
+   * Every rule above is tested in isolation, and isolation is precisely where
+   * this cannot go wrong. Three rules migrating three members of ONE import all
+   * reach the same dead declaration on the same pass and all emit a removal over
+   * the same range — so the question is whether ESLint's overlap handling
+   * converges or starves, and no single-rule fixture asks it.
+   */
+  it('the three safePath rules together converge on one import in a single pass', () => {
+    const source = [
+      PATH_NAMESPACE_IMPORT,
+      "export const a = path.join('a', 'b');",
+      "export const b = path.resolve('c');",
+      "export const c = path.relative('d', 'e');",
+    ].join('\n');
+    const names = [RULE.join, RULE.resolve, RULE.relative];
+    const config = [
+      {
+        files: ['**/*.ts'],
+        plugins: {
+          local: { rules: Object.fromEntries(names.map((name) => [name, loadLocalRule(`${name}.cjs`)])) },
+        },
+        rules: Object.fromEntries(names.map((name) => [`local/${name}`, 'error' as const])),
+        languageOptions,
+      },
+    ];
+
+    expect(new Linter().verify(source, config, { filename: LINTED_FILE })).toHaveLength(names.length);
+
+    const { output } = new Linter().verifyAndFix(source, config, { filename: LINTED_FILE });
+
+    expect(new Linter().verify(output, config, { filename: LINTED_FILE })).toStrictEqual([]);
+    expect(unusedIn(output)).toStrictEqual([]);
+    expect(output).not.toContain("'node:path'");
+    for (const fn of ['join', 'resolve', 'relative']) {
+      expect(output).toContain(`safePath.${fn}(`);
+    }
+  });
+});
+
+/**
+ * The shared dead-import helper, exercised directly on its own module list.
+ *
+ * Every rule wired to it today pre-filters to its own module before handing a
+ * declaration over, so the allow-list inside the helper is unreachable through
+ * any of them — and an untested unreachable guard is exactly the one a future
+ * rule discovers the hard way. This calls the helper with declarations the
+ * production callers never pass it.
+ */
+describe('reportDeadUnsafeImports only ever removes a listed module', () => {
+  const { reportDeadUnsafeImports } = loadLocalRuleModule<{
+    reportDeadUnsafeImports: (
+      context: unknown,
+      sourceCode: unknown,
+      importNodes: unknown[],
+      migrated: boolean,
+    ) => void;
+  }>('dead-import.cjs');
+
+  /** Hands the helper EVERY import declaration in the file, unfiltered. */
+  const unfilteredRule = {
+    meta: {
+      type: 'problem' as const,
+      fixable: 'code' as const,
+      schema: [],
+      messages: {
+        deadUnsafeImport: "'{{local}}' from '{{module}}'",
+      },
+    },
+    create(context: Rule.RuleContext): Rule.RuleListener {
+      const { sourceCode } = context;
+      return {
+        'Program:exit'() {
+          reportDeadUnsafeImports(
+            context,
+            sourceCode,
+            sourceCode.ast.body.filter((node) => node.type === 'ImportDeclaration'),
+            true,
+          );
+        },
+      };
+    },
+  };
+
+  const removedFrom = (code: string): string =>
+    new Linter().verifyAndFix(
+      code,
+      [
+        {
+          files: ['**/*.ts'],
+          plugins: { local: { rules: { r: unfilteredRule as Rule.RuleModule } } },
+          rules: { 'local/r': 'error' },
+          languageOptions: { ecmaVersion: 2024, sourceType: 'module' },
+        },
+      ],
+      { filename: LINTED_FILE },
+    ).output;
+
+  it.each([
+    ['node:path', true],
+    ['path', true],
+    ['node:child_process', true],
+    // Side-effect-free-ness is decided at authoring time for a CLOSED list, and
+    // these are not on it. A builtin nobody wired up is still not ours to delete,
+    // and a userland module may run anything at import time.
+    ['node:crypto', false],
+    ['react', false],
+    ['./local-module.js', false],
+  ])('%s removable=%s', (module, removable) => {
+    const source = `import dead from '${module}';\nexport const x = 1;`;
+    expect(removedFrom(source).includes(`'${module}'`)).toBe(!removable);
   });
 });

--- a/packages/utils/test/eslint/rules.test.ts
+++ b/packages/utils/test/eslint/rules.test.ts
@@ -76,16 +76,33 @@ const PREFER_STARTSWITH_OVER_REGEX_CASES: RuleCases = {
     // Patterns with regex metacharacters — must NOT flag (cannot safely flatten).
     { code: String.raw`const s = 'x'; if (/^https?:\/\//.test(s)) {}` },
     { code: "const s = 'x'; if (/^[a-z]+/.test(s)) {}" },
-    { code: String.raw`const s = 'x'; if (/\.txt$/.test(s)) {}` },
+    // Unescaped `.` is "any character" — flattening it would change what matches.
+    { code: "const s = 'x'; if (/.txt$/.test(s)) {}" },
     { code: "const s = 'x'; if (/^foo|bar/.test(s)) {}" },
     // Flags i/m make literal conversion unsafe — must not flag.
     { code: "const s = 'x'; if (/^foo/i.test(s)) {}" },
-    // Other escapes (\d, \w, \\) are not safely flattenable — must not flag.
+    // Escapes that MEAN something other than the next character — a class, an
+    // assertion, a code point — stay unflattenable.
     { code: String.raw`const s = 'x'; if (/^\d+/.test(s)) {}` },
+    { code: String.raw`const s = 'x'; if (/^\w/.test(s)) {}` },
+    { code: String.raw`const s = 'x'; if (/^\bword/.test(s)) {}` },
+    { code: String.raw`const s = 'x'; if (/^\cA/.test(s)) {}` },
+    { code: String.raw`const s = 'x'; if (/^\x41/.test(s)) {}` },
+    { code: String.raw`const s = 'x'; if (/^\p{Lu}/u.test(s)) {}` },
+    // A control character would go straight into the suggested startsWith('…').
+    { code: String.raw`const s = 'x'; if (/^\tab/.test(s)) {}` },
     // No anchor — not a prefix/suffix check.
     { code: "const s = 'x'; if (/foo/.test(s)) {}" },
     // Method calls that aren't .test() — must not flag.
     { code: "const s = 'x'; const m = /^foo/.exec(s);" },
+    // A const that does not hold a regex literal, and one reassigned after
+    // declaration: nothing here proves what `.test()` runs against.
+    { code: "const RE = makeRegex(); const s = 'x'; if (RE.test(s)) {}" },
+    { code: "let RE = /^a/; RE = /^[b]/; const s = 'x'; if (RE.test(s)) {}" },
+    { code: "const s = 'x'; if (someObject.pattern.test(s)) {}" },
+    // Resolution must respect the same metachar/flag limits as the inline form.
+    { code: String.raw`const RE = /^https?:\/\//; const s = 'x'; if (RE.test(s)) {}` },
+    { code: "const RE = /^foo/i; const s = 'x'; if (RE.test(s)) {}" },
   ],
   invalid: [
     { code: String.raw`const s = 'x'; if (/^file:\/\//.test(s)) {}`, errors: [{ messageId: 'preferStartsWith' }] },
@@ -93,6 +110,26 @@ const PREFER_STARTSWITH_OVER_REGEX_CASES: RuleCases = {
     { code: "const s = 'x'; if (/^foo/.test(s)) {}", errors: [{ messageId: 'preferStartsWith' }] },
     { code: "const s = 'x'; if (/bar$/.test(s)) {}", errors: [{ messageId: 'preferEndsWith' }] },
     { code: "const s = 'x'; if (/^abc-def/.test(s)) {}", errors: [{ messageId: 'preferStartsWith' }] },
+    // ESCAPED NON-SPECIAL CHARACTER. `\*` is an unambiguous literal asterisk,
+    // and accepting only `\/` skipped it — an adopter's SonarCloud raised the
+    // MAJOR S6557 this rule exists to shift left, on code the rule reported
+    // green. Every escape below denotes exactly the character it protects.
+    { code: String.raw`const s = 'x'; if (/^\*glob/.test(s)) {}`, errors: [{ messageId: 'preferStartsWith' }] },
+    { code: String.raw`const s = 'x'; if (/^\.hidden/.test(s)) {}`, errors: [{ messageId: 'preferStartsWith' }] },
+    // Was pinned as VALID with the note "contains `.` metachar". It does not —
+    // the `.` is escaped, and `/\.txt$/.test(s)` is `s.endsWith('.txt')` exactly.
+    { code: String.raw`const s = 'x'; if (/\.txt$/.test(s)) {}`, errors: [{ messageId: 'preferEndsWith' }] },
+    { code: String.raw`const s = 'x'; if (/^\$ref/.test(s)) {}`, errors: [{ messageId: 'preferStartsWith' }] },
+    { code: String.raw`const s = 'x'; if (/^\(paren/.test(s)) {}`, errors: [{ messageId: 'preferStartsWith' }] },
+    { code: String.raw`const s = 'x'; if (/\+plus$/.test(s)) {}`, errors: [{ messageId: 'preferEndsWith' }] },
+    // REGEX HELD IN A CONST — the normal way to hoist a hot regex, and the
+    // shape the rule was blind to because it examined only inline literals.
+    { code: "const RE = /^literal/; const s = 'x'; if (RE.test(s)) {}", errors: [{ messageId: 'preferStartsWith' }] },
+    { code: "const RE = /suffix$/; const s = 'x'; if (RE.test(s)) {}", errors: [{ messageId: 'preferEndsWith' }] },
+    {
+      code: String.raw`const RE = /^file:\/\//; function f(s) { return RE.test(s); }`,
+      errors: [{ messageId: 'preferStartsWith' }],
+    },
   ],
 };
 
@@ -128,6 +165,7 @@ const SAFE_PATH_MODULE = '@vibe-agent-toolkit/utils/path';
 const SAFE_FS_MODULE = '@vibe-agent-toolkit/utils/fs';
 const BARREL = '@vibe-agent-toolkit/utils';
 const SAFE_IMPORT = `import { safePath } from '${SAFE_PATH_MODULE}';`;
+const PATH_NAMESPACE_IMPORT = "import path from 'node:path';";
 const LINTED_FILE = 'packages/cli/src/example.ts';
 const PATH_CORE_IMPL = 'packages/utils/src/path-core.ts';
 const PATH_UTILS_IMPL = 'packages/utils/src/path-utils.ts';
@@ -157,6 +195,13 @@ function pathFunctionRuleCases(fn: 'join' | 'relative' | 'resolve'): RuleCases {
         filename: LINTED_FILE,
         options,
       },
+      // A same-named function from somewhere else is not ours. The bare-call
+      // leg keys on the name being UNBOUND, so binding it — here, or as a
+      // parameter, or as a local — is what keeps that leg from becoming a
+      // rule that flags every `join()` in the ecosystem.
+      { code: `import { ${fn} } from 'lodash'; const p = ${fn}(a, b);`, filename: LINTED_FILE, options },
+      { code: `function ${fn}(x) { return x; } const p = ${fn}(a);`, filename: LINTED_FILE, options },
+      { code: `const run = (${fn}) => ${fn}(a, b);`, filename: LINTED_FILE, options },
       // Files the CONSUMING config declared exempt, by their repo-relative paths.
       { code: unsafeMemberCode, filename: PATH_CORE_IMPL, options },
       { code: unsafeMemberCode, filename: `/Users/dev/vat/${PATH_UTILS_IMPL}`, options },
@@ -172,6 +217,64 @@ function pathFunctionRuleCases(fn: 'join' | 'relative' | 'resolve'): RuleCases {
         filename: LINTED_FILE,
         options,
         output: `\n${SAFE_IMPORT} const p = safePath.${fn}(a, b);`,
+        errors,
+      },
+      // THREE call sites, ONE pass. RuleTester applies exactly one round of
+      // fixes, so `output` here is the whole property: every call rewritten and
+      // the import surgery done, with nothing discarded for overlapping.
+      //
+      // Every fixture above has a single call site, and a single-call-site
+      // fixture CANNOT reproduce the defect this guards — the fix that edits
+      // both the import and its call spans the gap between them, so the second
+      // and third reports' ranges nested inside the first and ESLint dropped
+      // them. The specifier went away, the calls did not, and the next pass had
+      // nothing left to key on. See `buildFix` in the factory.
+      {
+        code: [
+          `import { ${fn} } from 'node:path';`,
+          `const a1 = ${fn}(a, b);`,
+          `const a2 = ${fn}(c, d);`,
+          `const a3 = ${fn}(e, f);`,
+        ].join('\n'),
+        filename: LINTED_FILE,
+        options,
+        output: [
+          '',
+          SAFE_IMPORT,
+          `const a1 = safePath.${fn}(a, b);`,
+          `const a2 = safePath.${fn}(c, d);`,
+          `const a3 = safePath.${fn}(e, f);`,
+        ].join('\n'),
+        errors: [errors[0], errors[0], errors[0]],
+      },
+      // Same shape through the namespace import, which removes no specifier —
+      // the import INSERT alone is enough to span the file and starve the rest.
+      {
+        code: [
+          PATH_NAMESPACE_IMPORT,
+          `const a1 = path.${fn}(a, b);`,
+          `const a2 = path.${fn}(c, d);`,
+        ].join('\n'),
+        filename: LINTED_FILE,
+        options,
+        output: [
+          PATH_NAMESPACE_IMPORT,
+          SAFE_IMPORT,
+          `const a1 = safePath.${fn}(a, b);`,
+          `const a2 = safePath.${fn}(c, d);`,
+        ].join('\n'),
+        errors: [errors[0], errors[0]],
+      },
+      // BARE, UNBOUND call — what a half-applied fix leaves behind. Detection
+      // used to require having seen the `node:path` specifier, so once a fix
+      // removed it the rule fell silent and `--fix` declared victory over source
+      // that no longer compiles. Recognising this shape is what makes a second
+      // `--fix` finish the job.
+      {
+        code: `const p = ${fn}(a, b);`,
+        filename: LINTED_FILE,
+        options,
+        output: `${SAFE_IMPORT}\nconst p = safePath.${fn}(a, b);`,
         errors,
       },
       // DECOY basenames — same file name, different directory. MUST still fire.
@@ -767,5 +870,134 @@ describe('every {{safeModule}} placeholder is backed by the option that fills it
       expect(message).not.toContain('{{');
       expect(message).toContain(SEAM);
     }
+  });
+});
+
+/**
+ * `--fix` must not leave behind a reference to something it just un-imported.
+ *
+ * This is the property an adopter measured on a real sweep, and it is not the
+ * property any fixture above asserts. RuleTester applies exactly ONE pass and
+ * compares a string; this runs `--fix` to its fixpoint and then asks the
+ * compiler's question — is every identifier in the result actually bound?
+ *
+ * Their numbers, over ~4,900 sites: **146 files left with a dangling
+ * reference** (140 on `join`, 16 on `resolve`), worst single file 75 unrewritten
+ * call sites. The mechanism was ESLint's fix merging — a `fix()` that edits both
+ * the import and its own call site yields ONE range spanning `min..max`, so with
+ * N call sites you get N nested ranges and ESLint keeps one. The rule then went
+ * quiet, because the specifier its detection keyed on was the thing that had
+ * just been removed. A stable fixpoint over source that does not compile, and a
+ * clean exit code. You find out at `tsc`, after the sweep.
+ *
+ * Every rule here rewrites a call AND edits imports, which is the whole
+ * population that can express the bug — including the ones that never showed it
+ * in the adopter's tree, where no file happened to call them twice.
+ */
+const REWRITE_SITES = 4;
+
+/** `[rule, importLine, callExpression]` — a source is synthesized per row. */
+const MULTI_SITE_REWRITES: Array<[string, string, string]> = [
+  ['no-path-join', "import { join } from 'node:path';", 'join(a, b)'],
+  ['no-path-resolve', "import { resolve } from 'node:path';", 'resolve(a, b)'],
+  ['no-path-relative', "import { relative } from 'node:path';", 'relative(a, b)'],
+  ['no-os-tmpdir', "import { tmpdir } from 'node:os';", 'tmpdir()'],
+  ['no-fs-mkdirSync', "import { mkdirSync } from 'node:fs';", 'mkdirSync(a)'],
+  ['no-fs-realpathSync', "import { realpathSync } from 'node:fs';", 'realpathSync(a)'],
+  ['no-child-process-execSync', "import { execSync } from 'node:child_process';", 'execSync(a)'],
+  ['no-fs-promises-cp', "import { cp } from 'node:fs/promises';", 'cp(a, b)'],
+  // No import to remove — the import INSERT alone spans the file.
+  ['no-manual-path-normalize', '', String.raw`a.split('\\').join('/')`],
+];
+
+function multiSiteSource(importLine: string, call: string): string {
+  const calls = Array.from({ length: REWRITE_SITES }, (_, i) => `const r${i} = ${call};`);
+  return [importLine, "const a = 'a';", "const b = 'b';", ...calls].filter(Boolean).join('\n');
+}
+
+describe('autofix leaves no dangling reference', () => {
+  const plugin = loadLocalRuleModule<{ rules: Record<string, Rule.RuleModule> }>('../index.cjs');
+  const languageOptions = { ecmaVersion: 2024, sourceType: 'module' } as const;
+
+  /** Bindings, not strings: `no-undef` answers the question `tsc` would. */
+  const unboundIn = (code: string): string[] =>
+    new Linter()
+      .verify(code, [{ files: ['**/*.ts'], rules: { 'no-undef': 'error' }, languageOptions }], {
+        filename: LINTED_FILE,
+      })
+      .map(({ message }) => message);
+
+  it('covers every fixable rule in the pack', () => {
+    // Membership, not cardinality — a rule added to the pack without a row here
+    // is a rule whose fixer nobody runs to a fixpoint.
+    const byName = (a: string, b: string): number => a.localeCompare(b);
+    const fixable = Object.entries(plugin.rules)
+      .filter(([, rule]) => rule.meta?.fixable === 'code')
+      .map(([name]) => name);
+    expect(MULTI_SITE_REWRITES.map(([name]) => name).sort(byName)).toStrictEqual(
+      [...fixable].sort(byName),
+    );
+  });
+
+  /**
+   * A dangling MEMBER, which the `no-undef` check above is blind to.
+   *
+   * `no-os-tmpdir` is the one rule with `checkMemberExpression`, and its fixer
+   * rewrote only the property — turning `os.tmpdir()` into
+   * `os.normalizedTmpdir()`, a method that does not exist on the `node:os`
+   * namespace. The replacement is a free function from this package, and the
+   * fixer imported it correctly; it just left the call reaching for it through
+   * the wrong object.
+   *
+   * Same silent shape as the overlap defect: the rule stops reporting (there is
+   * no `tmpdir` left to see), so lint goes green over code that throws
+   * `TypeError` at every fixed call site. `no-undef` sees a bound `os` and a
+   * property access and has nothing to say. Only `tsc` catches it — which is
+   * why an adopter's dangling-REFERENCE audit across all nine rewritable
+   * symbols came back clean on this rule.
+   */
+  it('no-os-tmpdir rewrites os.tmpdir() to a free call, not a method on the namespace', () => {
+    const config = [
+      {
+        files: ['**/*.ts'],
+        plugins: { local: { rules: { 'no-os-tmpdir': plugin.rules['no-os-tmpdir'] as Rule.RuleModule } } },
+        rules: { 'local/no-os-tmpdir': 'error' as const },
+        languageOptions,
+      },
+    ];
+    const source = "import os from 'node:os';\nconst t0 = os.tmpdir();\nconst t1 = os.tmpdir();";
+
+    expect(new Linter().verify(source, config, { filename: LINTED_FILE })).toHaveLength(2);
+
+    const { output } = new Linter().verifyAndFix(source, config, { filename: LINTED_FILE });
+    expect(output).not.toMatch(/\bos\s*\.\s*normalizedTmpdir\b/);
+    expect(output.match(/(?<![.\w])normalizedTmpdir\(\)/g)).toHaveLength(2);
+    expect(new Linter().verify(output, config, { filename: LINTED_FILE })).toStrictEqual([]);
+  });
+
+  it.each(MULTI_SITE_REWRITES)('%s', (name, importLine, call) => {
+    const source = multiSiteSource(importLine, call);
+    const config = [
+      {
+        files: ['**/*.ts'],
+        plugins: { local: { rules: { [name]: plugin.rules[name] as Rule.RuleModule } } },
+        rules: { [`local/${name}`]: 'error' as const },
+        languageOptions,
+      },
+    ];
+
+    // Negative control: a source that stopped provoking the rule would make
+    // every assertion below vacuously true.
+    const before = new Linter().verify(source, config, { filename: LINTED_FILE });
+    expect(before).toHaveLength(REWRITE_SITES);
+    expect(unboundIn(source)).toStrictEqual([]);
+
+    const { output, fixed } = new Linter().verifyAndFix(source, config, { filename: LINTED_FILE });
+    expect(fixed).toBe(true);
+
+    // The defect, stated exactly: `--fix` settles, reports nothing further, and
+    // the code it settled on references an identifier that is no longer bound.
+    expect(unboundIn(output)).toStrictEqual([]);
+    expect(new Linter().verify(output, config, { filename: LINTED_FILE })).toStrictEqual([]);
   });
 });

--- a/packages/utils/test/integration/eslint-recommended-config.integration.test.ts
+++ b/packages/utils/test/integration/eslint-recommended-config.integration.test.ts
@@ -291,12 +291,13 @@ describe('the ./eslint subpath ships', () => {
     expect(project.packedFiles).toContain('eslint/rules/no-os-tmpdir.cjs');
     // 21 registered rules + three shared factories (`eslint-rule-factory`,
     // `path-function-rule-factory`, `no-command-direct-factory`) + `exempt-path-matcher`
-    // + `safe-import` (the autofix target and the already-bound check).
+    // + `safe-import` (the autofix target and the already-bound check)
+    // + `dead-import` (removing the binding a fixer orphaned).
     // Exact, not a floor: a floor lets rules silently fall out of the tarball.
     // npm reports manifest paths POSIX-style; normalize anyway so the count cannot
     // quietly become zero on a platform that reports them otherwise.
     const rules = project.packedFiles.filter((file) => toForwardSlash(file).startsWith('eslint/rules/'));
-    expect(rules.length).toBe(26);
+    expect(rules.length).toBe(27);
   });
 
   it('ships the hand-written types alongside them', () => {

--- a/packages/utils/test/integration/eslint-recommended-config.integration.test.ts
+++ b/packages/utils/test/integration/eslint-recommended-config.integration.test.ts
@@ -297,7 +297,7 @@ describe('the ./eslint subpath ships', () => {
     // npm reports manifest paths POSIX-style; normalize anyway so the count cannot
     // quietly become zero on a platform that reports them otherwise.
     const rules = project.packedFiles.filter((file) => toForwardSlash(file).startsWith('eslint/rules/'));
-    expect(rules.length).toBe(27);
+    expect(rules).toHaveLength(27);
   });
 
   it('ships the hand-written types alongside them', () => {

--- a/packages/utils/test/windows-shell.test.ts
+++ b/packages/utils/test/windows-shell.test.ts
@@ -13,6 +13,43 @@ import {
 } from '../src/windows-shell.js';
 
 const onWindows = process.platform === 'win32';
+const REAL_PLATFORM = process.platform;
+const CMD_SHIM = 'C:/npm/claude.cmd';
+
+/**
+ * Run `body` with `process.platform` substituted, then put it back.
+ *
+ * Every case that makes `shouldUseShell` return true is otherwise gated behind
+ * `skipIf(!onWindows)` — so the branch every Windows spawn depends on never
+ * executes on the machine this is developed on, and a green run on macOS says
+ * nothing about it. An adopter put it exactly: verified-green and never-run are
+ * indistinguishable from the outside. Their Windows CI lane went green without
+ * reaching this branch either — of the sixteen `safeExecSync` call sites in
+ * their tree, the three most likely to spawn a `.cmd` live in a directory that
+ * belongs to no package, so `turbo run test` never invoked them.
+ *
+ * `process.platform` is a plain value property, so `defineProperty` is what
+ * substitutes it; `vi.spyOn` cannot — there is no getter to intercept. Restored
+ * in a `finally` with the real descriptor's shape, because a leaked `win32`
+ * would silently retarget every later test in this worker.
+ */
+function asPlatform<T>(platform: NodeJS.Platform, body: () => T): T {
+  const define = (value: NodeJS.Platform): void => {
+    Object.defineProperty(process, 'platform', {
+      value,
+      writable: false,
+      enumerable: true,
+      configurable: true,
+    });
+  };
+
+  define(platform);
+  try {
+    return body();
+  } finally {
+    define(REAL_PLATFORM);
+  }
+}
 
 // NOTE: `String.raw` cannot express a string ending in a backslash (the backslash escapes
 // the closing backtick), and that shape is central to everything below — so these tests use
@@ -450,5 +487,68 @@ describe('shouldUseShell', () => {
     expect(shouldUseShell('C:/npm/CLAUDE.CMD')).toBe(true);
     expect(shouldUseShell('C:/tools/thing.bat')).toBe(true);
     expect(shouldUseShell('C:/tools/thing.ps1')).toBe(true);
+  });
+
+  /**
+   * The same extension check, with the platform FORCED — so it runs everywhere.
+   *
+   * The suite above gates the only case that returns `true` behind
+   * `skipIf(!onWindows)`, which means the branch every Windows spawn depends on
+   * never executes on the machine this is developed on. An adopter put the
+   * problem precisely: verified-green and never-run are indistinguishable from
+   * the outside. Their Windows CI lane went green without reaching this branch
+   * either — of the sixteen `safeExecSync` call sites in their tree, the three
+   * most likely to spawn a `.cmd` live in a directory that belongs to no
+   * package, so `turbo run test` never invoked them.
+   *
+   * `process.platform` is a plain value property, so `defineProperty` is what
+   * substitutes it; `vi.spyOn` cannot (there is no getter to intercept).
+   */
+  describe('with the platform forced', () => {
+    it('is true for .cmd/.bat/.ps1 shims, case-insensitively', () => {
+      const shims = [CMD_SHIM, 'C:/npm/CLAUDE.CMD', 'C:/tools/thing.bat', 'C:/tools/thing.PS1'];
+      expect(asPlatform('win32', () => shims.map((p) => shouldUseShell(p)))).toStrictEqual([
+        true, true, true, true,
+      ]);
+    });
+
+    it('is false for a real executable even on win32', () => {
+      expect(asPlatform('win32', () => shouldUseShell('C:/Program Files/nodejs/node.exe'))).toBe(false);
+      expect(asPlatform('win32', () => shouldUseShell('C:/tools/claude'))).toBe(false);
+    });
+
+    it('is false for the very same shim off Windows — the platform gate, isolated', () => {
+      expect(asPlatform('darwin', () => shouldUseShell(CMD_SHIM))).toBe(false);
+      expect(asPlatform('linux', () => shouldUseShell('/usr/local/bin/anything.cmd'))).toBe(false);
+    });
+
+    it('restores the real platform afterwards', () => {
+      expect(process.platform).toBe(REAL_PLATFORM);
+    });
+  });
+});
+
+/**
+ * The Windows shell path, end to end, on any platform.
+ *
+ * `shouldUseShell` → `resolveShellCommandToken` → `buildWindowsShellLine` is the
+ * chain `safeExecSync` and `spawnHardened` take when they spawn a `.cmd`. Each
+ * link is tested above; this asserts they compose into a command line whose
+ * `CommandLineToArgvW` round trip is exactly `[command, ...args]` — which is the
+ * claim that matters and the one no macOS run was making.
+ */
+describe('the Windows shell branch composes end to end', () => {
+  it('routes a spacey .cmd path through the shell and survives the round trip', () => {
+    const command = `C:${BS}Program Files${BS}npm${BS}claude.cmd`;
+    const args = ['--flag', 'a b', `trailing${BS}`];
+
+    const argv = asPlatform('win32', () => {
+      expect(shouldUseShell(command)).toBe(true);
+      return commandLineToArgv(
+        buildWindowsShellLine(resolveShellCommandToken(command, command), args),
+      );
+    });
+
+    expect(argv).toStrictEqual([command, ...args]);
   });
 });

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-development-agents/package.json
+++ b/packages/vat-development-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-development-agents",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "VAT development agents - dogfooding the vibe-agent-toolkit",
   "type": "module",
   "keywords": [

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vat-example-cat-agents/package.json
+++ b/packages/vat-example-cat-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vibe-agent-toolkit/vat-example-cat-agents",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Example agents: 8 quirky cat agents demonstrating VAT patterns",
   "type": "module",
   "exports": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.42-rc.1",
+  "version": "0.1.42-rc.2",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {

--- a/packages/vibe-agent-toolkit/package.json
+++ b/packages/vibe-agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibe-agent-toolkit",
-  "version": "0.1.42-rc.2",
+  "version": "0.1.42",
   "description": "Modular toolkit for building, testing, and deploying portable AI agents",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Closes the two gaps an adopter left open after certifying round 2's headline fix
(146 dangling files → 0, 830 files, one pass, `tsc` 196/196).

**Ships as stable `0.1.42`** — all 21 manifests carry that version and the CHANGELOG
is stamped under `## [0.1.42]`. It publishes to `latest`. The two breaking changes
already sitting in `[Unreleased]` (the `./fs` → `./path` split and the required
`fsCache` parameter) ride along, and both were measured against a real adopter tree
before cutting rather than assumed: **zero** importers of any of the seven moved
symbols from `/fs` (all 190 usages go through the unaffected `.` barrel), and
**zero** hits for `verifyCaseSensitiveFilename` / `ValidateLinkOptions`, with
`@vibe-agent-toolkit/resources` not even a declared dependency there.

Also carries a security fix unrelated to the ESLint work: a new `nanoid` 3.3.17 pin
closing GHSA-2v37-7h3g-55p8 (CVSS 8.2). The advisory published after `0.1.41`
shipped — between main's last green Dependency Audit and the next PR run — so it was
inherited, not introduced, and it was failing OSV-Scanner on every open PR.

## 1. A dead `node:path` import survived a completed migration

Rewriting the last `path.*` call in a file leaves `import path from 'node:path'`
bound to nothing. That is not a dangling *reference*, so the `no-undef` fixpoint
suite is structurally blind to it — a dead import leaves something **spare**, not
something dangling. The adopter measured **536 such errors surviving a converged
`--fix` across 232 files** (289 `no-unused-vars` + 247 `sonarjs/unused-import`). At
`--max-warnings=0` that means the fixed output does not lint clean, so the migration
never completed and their pass 2 changed nothing.

**It cannot be delegated to the ecosystem**, which is the non-obvious part:
`@typescript-eslint/no-unused-vars` declares `meta.fixable: 'code'` and yet emits only
a *suggestion* for an unused import, and `--fix` never applies suggestions;
`sonarjs/unused-import` declares no fixer at all. Verified with both enabled alongside
ours in a single `verifyAndFix` — the import survived. Those rules abstain for a real
reason (removing an import can change behaviour), but a rule that *created* the orphan
knows it just consumed the last reference and knows the module, because its own config
named it.

New shared `packages/utils/eslint/rules/dead-import.cjs` reports it as its own
`deadUnsafeImport` finding with its own fixer — visible in lint output and suppressible
at the import line, never a call rewrite silently deleting a declaration. Wired into all
three import-inserting lanes, including `no-manual-path-normalize`, which consumes
`path.sep` exactly like the others and was not tracking the import at all.

Deliberately narrow, and **not** a general unused-import rule: a closed list of Node
builtins decided at authoring time (no `package.json` `sideEffects` lookup — that field
is author-declared, absent by default, and does not apply to `node:` builtins anyway);
only in a file where the safe symbol is already bound; only whole declarations with zero
references, judged against the source as it stands on that pass — so the removal always
lands *after* the rewrite that consumed the last reference, never speculatively beside
it. Bare `import 'node:path'` side-effect imports, `type` specifiers and partially-used
declarations are left alone. No re-export guard: `export { path }` and
`export default path` both register as references under espree **and**
`@typescript-eslint/parser` (measured on both), so such a declaration is never dead here
and a second check could not fire.

## 2. A namespace bound by `require()` or a dynamic import went undetected

`namespaceModuleOf()` now recognises `require('x')`, `import('x')` and
`await import('x')`; the receiver name became a `Set`. This is **not** a return to rc.1,
which matched *any* receiver — the same defect that produced `os.normalizedTmpdir()` and
that reported `const os = {tmpdir(){}}` and `env.tmpdir()` as findings it would have
rewritten into a call on the wrong function. The receiver check stays; what widened is
only what counts as evidence that the receiver **is** the module's namespace. Both
false-positive shapes remain pinned at 0, joined by two new controls (wrong module, and
a one-argument call that merely looks like `require`).

## Verification

`bun run validate` green end-to-end (build 20.5s / typecheck 6s / lint 30.3s /
duplication 6.4s / unit 40.1s / integration 68.8s / system 192.3s).

Tests 171 → **200**. Mutations 22 → **34, 33 RED**; the 34th is a labelled equivalent
mutant (the general factory never writes `hasSafeImport` inside `fix()`, and R16
independently forecloses adding such a latch). Five mutations survived the first run and
every one was a real hole in the **tests**: a redundant guard that made its partner
unfalsifiable (deleted the redundant one), a single-binding fixture that cannot tell
`every` from `some`, an allow-list unreachable because every caller pre-filters (now
unit-tested by calling the helper directly), a missing negative control of the right
shape, and a suppressed-report fixture that needed two imports of the same module to
express the state at all.

**Adopter re-certified** against their real repo lint pipeline (194 Turbo lint tasks,
cache bypassed) rather than a synthetic harness:

| | round 5 (rc.1) | this build |
|---|---|---|
| files rewritten | 830 (AST scan) | **733** (real per-package `eslint . --fix`) |
| passes to converge | 1 | **1** (diff hash byte-identical over two forced uncached runs) |
| dangling references | 146 → 0 | **0** |
| repo typecheck | 196/196 | **196/196, exit 0** |
| `no-unused-vars` + `sonarjs` residue | 536 across 232 files | **0** — after `--fix` *and* on a fresh check-only pass |

830 vs 733 is methodology, not regression (same commit; AST scan vs per-package lint
scope). All five Gap-B shapes behave as specified; both negative controls silent.

## Disclosures

**The published artifact will not be byte-identical to what the adopter certified.**
After sign-off, one shipped file gained a comment:
`packages/utils/eslint/rules/eslint-rule-factory.cjs` went `beff688e…` → `271e6cec…`.
Comment-only, no behaviour change. It records their finding that a leftover
`await import('node:os')` **still executes** — module loaded, promise awaited, only the
binding dead. (A stable `0.1.42` tarball could never be byte-identical to the rc.2 one
regardless, since the version string differs.)

**Known residual, population currently empty.** Only import *declarations* are removed,
so `const os = require('node:os')` and `const os = await import('node:os')` are left as
`'os' is assigned a value but never used`. The adopter confirmed this 2-for-2 and
measured **zero** files using either shape across 4,963 sources. Extending removal to
variable declarations would remove an *execution*, not just a name — unobservable for
these builtins, which is exactly why the module list is closed. Annotated at the code
site; deliberately not built.

**Check-mode reports multiply, on purpose.** One dead import yields one message per
enabled rule that reaches it (up to 3×), cleared by a single `--fix`. **Not** deduped
across rules: a `WeakMap` on `SourceCode` would do it, and an `eslint-disable` naming
whichever rule won the latch would then consume the file's only removal and throw the
file away — the exact stranding trap round 2 was spent escaping. Documented in
`dead-import.cjs`.

**Deferred, annotated rather than fixed:** `eslint-rule-factory`'s direct-call branch
still has no scope check (`function mkdirSync(){}` is reported), and `declare global`
remains a residual false positive for the repair leg in a mid-migration file. Narrowing
either changes the detection parity the adopter measured.

## Also in this branch

The `zod` peerDependency removal moves from **Added** to **Breaking** in the CHANGELOG.
It was correct — utils imports `zod` nowhere, all six occurrences of `from 'zod'` are
JSDoc `@example` blocks — but was filed where the people it affects would not look,
which is why the adopter reported it twice.

Round 1 (`259f8bd3`) is included: it stopped `--fix` emitting code that does not compile
and widened `prefer-startswith-over-regex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
